### PR TITLE
Introduce preflight checks and `acorn check` command

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn.md
+++ b/docs/docs/100-reference/01-command-line/acorn.md
@@ -28,6 +28,7 @@ acorn [flags]
 * [acorn all](acorn_all.md)	 - List (almost) all objects
 * [acorn app](acorn_app.md)	 - List or get apps
 * [acorn build](acorn_build.md)	 - Build an app from a Acornfile file
+* [acorn check](acorn_check.md)	 - Check if the cluster is ready for Acorn
 * [acorn container](acorn_container.md)	 - List or get running containers
 * [acorn credential](acorn_credential.md)	 - Manage registry credentials
 * [acorn exec](acorn_exec.md)	 - Run a command in a container

--- a/docs/docs/100-reference/01-command-line/acorn_check.md
+++ b/docs/docs/100-reference/01-command-line/acorn_check.md
@@ -1,0 +1,39 @@
+---
+title: "acorn check"
+---
+## acorn check
+
+Check if the cluster is ready for Acorn
+
+```
+acorn check [flags]
+```
+
+### Examples
+
+```
+
+acorn check
+```
+
+### Options
+
+```
+  -h, --help            help for check
+  -o, --output string   Output format (json, yaml, {{gotemplate}})
+  -q, --quiet           No Results. Success or Failure only.
+```
+
+### Options inherited from parent commands
+
+```
+  -A, --all-namespaces      Namespace to work in
+      --context string      Context to use in the kubeconfig file
+      --kubeconfig string   Location of a kubeconfig file
+      --namespace string    Namespace to work in (default "acorn")
+```
+
+### SEE ALSO
+
+* [acorn](acorn.md)	 - 
+

--- a/docs/docs/100-reference/01-command-line/acorn_check.md
+++ b/docs/docs/100-reference/01-command-line/acorn_check.md
@@ -20,6 +20,7 @@ acorn check
 
 ```
   -h, --help            help for check
+  -i, --image string    Override the image used for test deployments.
   -o, --output string   Output format (json, yaml, {{gotemplate}})
   -q, --quiet           No Results. Success or Failure only.
 ```

--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -22,6 +22,7 @@ acorn install
       --acorn-dns string                      enabled|disabled|auto. If enabled, containers created by Acorn will get public FQDNs. Auto functions as disabled if a custom clusterDomain has been supplied (default auto)
       --acorn-dns-endpoint string             The URL to access the Acorn DNS service
       --api-server-replicas int               acorn-api deployment replica count
+      --checks                                Disable preflight checks with --checks=false
       --cluster-domain strings                The externally addressable cluster domain (default .on-acorn.io)
       --controller-replicas int               acorn-controller deployment replica count
       --default-publish-mode string           If no publish mode is set default to this value (default user)

--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -21,6 +21,7 @@ func New() *cobra.Command {
 		NewApiServer(),
 		NewApp(),
 		NewBuild(),
+		NewCheck(),
 		NewContainer(),
 		NewController(),
 		NewCredential(),

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -29,9 +29,10 @@ type Check struct {
 
 func (a *Check) Run(cmd *cobra.Command, args []string) error {
 	checkresult := check.RunChecks(
-		check.CheckNodesReady,
 		check.CheckRBAC,
+		check.CheckNodesReady,
 		check.CheckDefaultStorageClass,
+		check.CheckIngressCapability,
 	)
 
 	failures := 0

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -33,6 +33,7 @@ func (a *Check) Run(cmd *cobra.Command, args []string) error {
 		check.CheckNodesReady,
 		check.CheckDefaultStorageClass,
 		check.CheckIngressCapability,
+		check.CheckExec,
 	)
 
 	failures := 0

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -28,7 +28,7 @@ type Check struct {
 }
 
 func (a *Check) Run(cmd *cobra.Command, args []string) error {
-	checkresult := check.RunChecks(
+	checkresult := check.RunChecks(cmd.Context(),
 		check.CheckRBAC,
 		check.CheckNodesReady,
 		check.CheckDefaultStorageClass,

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -8,6 +8,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/install/check"
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/acorn/pkg/tables"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
@@ -27,9 +28,10 @@ type Check struct {
 }
 
 func (a *Check) Run(cmd *cobra.Command, args []string) error {
-	checkresult := check.Check(
+	checkresult := check.RunChecks(
 		check.CheckNodesReady,
 		check.CheckRBAC,
+		check.CheckDefaultStorageClass,
 	)
 
 	failures := 0
@@ -50,10 +52,12 @@ func (a *Check) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if failures > 0 {
-		return fmt.Errorf("Preflight Check FAILED: %d issues", failures)
+		err := fmt.Errorf("%d checks failed", failures)
+		pterm.Error.Println(err)
+		return err
 	}
 
-	fmt.Println("Preflight Check PASSED")
+	pterm.Success.Println("Checks PASSED")
 
 	return nil
 }

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -5,7 +5,7 @@ import (
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/cli/builder/table"
-	"github.com/acorn-io/acorn/pkg/install/check"
+	"github.com/acorn-io/acorn/pkg/install"
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/acorn/pkg/tables"
 	"github.com/pterm/pterm"
@@ -25,15 +25,19 @@ acorn check`,
 type Check struct {
 	Quiet  bool   `usage:"No Results. Success or Failure only." short:"q"`
 	Output string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
+
+	Image string `usage:"Override the image used for test deployments." short:"i"`
 }
 
 func (a *Check) Run(cmd *cobra.Command, args []string) error {
-	checkresult := check.RunChecks(cmd.Context(),
-		check.CheckRBAC,
-		check.CheckNodesReady,
-		check.CheckDefaultStorageClass,
-		check.CheckIngressCapability,
-		check.CheckExec,
+
+	checkOpts := install.CheckOptions{RuntimeImage: a.Image}
+	checkresult := install.RunChecks(cmd.Context(), checkOpts,
+		install.CheckRBAC,
+		install.CheckNodesReady,
+		install.CheckDefaultStorageClass,
+		install.CheckIngressCapability,
+		install.CheckExec,
 	)
 
 	failures := 0

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+
+	cli "github.com/acorn-io/acorn/pkg/cli/builder"
+	"github.com/acorn-io/acorn/pkg/cli/builder/table"
+	"github.com/acorn-io/acorn/pkg/install/check"
+	"github.com/acorn-io/acorn/pkg/system"
+	"github.com/acorn-io/acorn/pkg/tables"
+	"github.com/spf13/cobra"
+)
+
+func NewCheck() *cobra.Command {
+	return cli.Command(&Check{}, cobra.Command{
+		Use: "check",
+		Example: `
+acorn check`,
+		SilenceUsage: true,
+		Short:        "Check if the cluster is ready for Acorn",
+	})
+}
+
+type Check struct {
+	Quiet  bool   `usage:"No Results. Success or Failure only." short:"q"`
+	Output string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
+}
+
+func (a *Check) Run(cmd *cobra.Command, args []string) error {
+	checkresult := check.Check(
+		check.CheckNodesReady,
+		check.CheckRBAC,
+	)
+
+	failures := 0
+	for _, r := range checkresult {
+		if !r.Passed {
+			failures++
+		}
+	}
+
+	if !a.Quiet {
+		out := table.NewWriter(tables.CheckResult, system.UserNamespace(), a.Quiet, a.Output)
+		for _, r := range checkresult {
+			out.Write(&r)
+		}
+		if err := out.Err(); err != nil {
+			fmt.Println(err)
+		}
+	}
+
+	if failures > 0 {
+		return fmt.Errorf("Preflight Check FAILED: %d issues", failures)
+	}
+
+	fmt.Println("Preflight Check PASSED")
+
+	return nil
+}

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -20,6 +20,8 @@ acorn install`,
 }
 
 type Install struct {
+	DisablePreflightChecks bool `usage:"Disable preflight checks"`
+
 	Image  string `usage:"Override the default image used for the deployment"`
 	Output string `usage:"Output manifests instead of applying them (json, yaml)" short:"o"`
 
@@ -38,9 +40,10 @@ func (i *Install) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return install.Install(cmd.Context(), image, &install.Options{
-		OutputFormat:       i.Output,
-		Config:             i.Config,
-		APIServerReplicas:  i.APIServerReplicas,
-		ControllerReplicas: i.ControllerReplicas,
+		DisablePreflightChecks: i.DisablePreflightChecks,
+		OutputFormat:           i.Output,
+		Config:                 i.Config,
+		APIServerReplicas:      i.APIServerReplicas,
+		ControllerReplicas:     i.ControllerReplicas,
 	})
 }

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -20,7 +20,7 @@ acorn install`,
 }
 
 type Install struct {
-	DisablePreflightChecks bool `usage:"Disable preflight checks"`
+	Checks *bool `usage:"Disable preflight checks with --checks=false"`
 
 	Image  string `usage:"Override the default image used for the deployment"`
 	Output string `usage:"Output manifests instead of applying them (json, yaml)" short:"o"`
@@ -40,10 +40,10 @@ func (i *Install) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return install.Install(cmd.Context(), image, &install.Options{
-		DisablePreflightChecks: i.DisablePreflightChecks,
-		OutputFormat:           i.Output,
-		Config:                 i.Config,
-		APIServerReplicas:      i.APIServerReplicas,
-		ControllerReplicas:     i.ControllerReplicas,
+		Checks:             i.Checks,
+		OutputFormat:       i.Output,
+		Config:             i.Config,
+		APIServerReplicas:  i.APIServerReplicas,
+		ControllerReplicas: i.ControllerReplicas,
 	})
 }

--- a/pkg/install/check/check.go
+++ b/pkg/install/check/check.go
@@ -205,7 +205,7 @@ func CheckExec(ctx context.Context) CheckResult {
 
 	cIO := conn.ToExecIO(false)
 
-	exitCode, err := term.Pipe(cIO, streams.Current())
+	exitCode, err := term.Pipe(cIO, &streams.Streams{Output: streams.Output{Out: io.Discard, Err: io.Discard}, In: os.Stdin})
 	if err != nil {
 		result.Passed = false
 		result.Message = fmt.Sprintf("Error piping execIO: %v", err)

--- a/pkg/install/check/check.go
+++ b/pkg/install/check/check.go
@@ -1,0 +1,140 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/acorn-io/acorn/pkg/k8sclient"
+	"github.com/acorn-io/baaah/pkg/restconfig"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
+	klogv2 "k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func PreflightChecks() []CheckResult {
+	return Check(CheckNodesReady, CheckRBAC)
+}
+
+func IsFailed(results []CheckResult) bool {
+	for _, r := range results {
+		if !r.Passed {
+			return true
+		}
+	}
+	return false
+}
+
+type CheckResult struct {
+	Message string `json:"message"`
+	Passed  bool   `json:"passed"`
+	Name    string `json:"name"`
+}
+
+func Check(checks ...func() CheckResult) []CheckResult {
+	var results []CheckResult
+	for _, check := range checks {
+		results = append(results, check())
+	}
+	return results
+}
+
+func CheckNodesReady() CheckResult {
+	result := CheckResult{
+		Name: "NodesReady",
+	}
+
+	silenceKlog()
+	cli, err := newClient()
+	if err != nil {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Error creating client: %v", err)
+		return result
+	}
+
+	// Try to list cluster nodes
+	var nds corev1.NodeList
+
+	if err := cli.List(context.Background(), &nds); err != nil {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Error listing nodes: %v", err)
+		return result
+	}
+
+	nrdy := 0
+	for _, nd := range nds.Items {
+		for _, c := range nd.Status.Conditions {
+			if c.Type == corev1.NodeReady && c.Status != corev1.ConditionTrue {
+				nrdy++
+				break
+			}
+		}
+	}
+
+	if nrdy > 0 {
+		result.Passed = false
+		result.Message = fmt.Sprintf("%d nodes are not ready", nrdy)
+	} else {
+		result.Passed = true
+		result.Message = "All nodes are ready"
+	}
+
+	return result
+}
+
+func silenceKlog() {
+	klog.SetOutput(io.Discard)
+	klogv2.SetOutput(io.Discard)
+	utilruntime.ErrorHandlers = nil
+}
+
+func newClient() (client.WithWatch, error) {
+	cfg, err := restconfig.Default()
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sclient.New(cfg)
+}
+
+func CheckRBAC() CheckResult {
+
+	result := CheckResult{
+		Name: "RBAC",
+	}
+
+	silenceKlog()
+	cli, err := newClient()
+	if err != nil {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Error creating client: %v", err)
+		return result
+	}
+
+	// Check if the cluster is authorized to create a namespace
+	av := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Verb:     "create",
+				Group:    "",
+				Resource: "namespace",
+			},
+		},
+	}
+	if err := cli.Create(context.TODO(), av); err != nil {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Error creating SelfSubjectAccessReview to verify AuthZ: %v", err)
+	} else {
+		result.Passed = av.Status.Allowed
+		if av.Status.Allowed {
+			result.Message = "User can create namespaces"
+		} else {
+			result.Message = "User cannot create namespaces"
+		}
+	}
+
+	return result
+}

--- a/pkg/install/check/check.go
+++ b/pkg/install/check/check.go
@@ -38,26 +38,21 @@ type CheckResult struct {
 // PreflightChecks is a list of all checks that are run before the installation.
 // They are crictial and will make the installation fail.
 func PreflightChecks(ctx context.Context) []CheckResult {
-	return RunChecks(ctx, CheckRBAC, CheckNodesReady)
+	return RunChecks(ctx,
+		CheckRBAC,
+		CheckNodesReady,
+	)
 }
 
 // InFlightChecks is a list of all checks that are run after the installation.
 // They are not critical and should not affect the installation process.
 func InFlightChecks(ctx context.Context) []CheckResult {
-	checks := []func(ctx context.Context) CheckResult{
+
+	return RunChecks(ctx,
 		CheckDefaultStorageClass,
 		CheckIngressCapability,
 		CheckExec,
-	}
-
-	// Some debugging test
-	if os.Getenv("ACORN_INSTALL_FAIL_CHECKS") == "true" {
-		checks = append(checks, func(ctx context.Context) CheckResult {
-			return CheckResult{Name: "FailTest", Passed: false, Message: "This is a test failure"}
-		})
-	}
-
-	return RunChecks(ctx, checks...)
+	)
 }
 
 // IsFailed is a simple helper function marking a list of check results

--- a/pkg/install/check/check.go
+++ b/pkg/install/check/check.go
@@ -4,21 +4,51 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/acorn-io/acorn/pkg/k8sclient"
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PreflightChecks() []CheckResult {
-	return Check(CheckNodesReady, CheckRBAC)
+// CheckResult describes the results of a check, making it human-readable
+type CheckResult struct {
+	Message string `json:"message"`
+	Passed  bool   `json:"passed"`
+	Name    string `json:"name"`
 }
 
+// PreflightChecks is a list of all checks that are run before the installation.
+// They are crictial and will make the installation fail.
+func PreflightChecks() []CheckResult {
+	return RunChecks(CheckNodesReady, CheckRBAC)
+}
+
+// InFlightChecks is a list of all checks that are run after the installation.
+// They are not critical and should not affect the installation process.
+func InFlightChecks() []CheckResult {
+	checks := []func() CheckResult{
+		CheckDefaultStorageClass,
+	}
+
+	// Some debugging test
+	if os.Getenv("ACORN_INSTALL_FAIL_CHECKS") == "true" {
+		checks = append(checks, func() CheckResult {
+			return CheckResult{Name: "FailTest", Passed: false, Message: "This is a test failure"}
+		})
+	}
+
+	return RunChecks(checks...)
+}
+
+// IsFailed is a simple helper function marking a list of check results
+// as failed if one or more results show failed status.
 func IsFailed(results []CheckResult) bool {
 	for _, r := range results {
 		if !r.Passed {
@@ -28,13 +58,8 @@ func IsFailed(results []CheckResult) bool {
 	return false
 }
 
-type CheckResult struct {
-	Message string `json:"message"`
-	Passed  bool   `json:"passed"`
-	Name    string `json:"name"`
-}
-
-func Check(checks ...func() CheckResult) []CheckResult {
+// RunChecks runs a list of checks and returns their results as a list.
+func RunChecks(checks ...func() CheckResult) []CheckResult {
 	var results []CheckResult
 	for _, check := range checks {
 		results = append(results, check())
@@ -42,6 +67,30 @@ func Check(checks ...func() CheckResult) []CheckResult {
 	return results
 }
 
+// silenceKlog is a helper function to silence klog output which could disturb
+// the clean installation logs.
+func silenceKlog() {
+	klog.SetOutput(io.Discard)
+	klogv2.SetOutput(io.Discard)
+	utilruntime.ErrorHandlers = nil
+}
+
+// newClient is a helper function to quickly create a new k8s client instance
+func newClient() (client.WithWatch, error) {
+	cfg, err := restconfig.Default()
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sclient.New(cfg)
+}
+
+/*
+ * CheckNodesReady checks if all nodes are ready.
+ * -> This is a critical check, which "could" affect the installation.
+ * TODO: We only need to check if the cluster is operational.
+ * -> A single malfunctiuning node should not prevent the installation.
+ */
 func CheckNodesReady() CheckResult {
 	result := CheckResult{
 		Name: "NodesReady",
@@ -85,21 +134,12 @@ func CheckNodesReady() CheckResult {
 	return result
 }
 
-func silenceKlog() {
-	klog.SetOutput(io.Discard)
-	klogv2.SetOutput(io.Discard)
-	utilruntime.ErrorHandlers = nil
-}
-
-func newClient() (client.WithWatch, error) {
-	cfg, err := restconfig.Default()
-	if err != nil {
-		return nil, err
-	}
-
-	return k8sclient.New(cfg)
-}
-
+/*
+ * CheckRBAC checks if the user has the necessary privileges allow
+ * Acorn to run. In this case, we check if the user has the rights
+ * to create a namespace, which is required for the installation.
+ * -> This is a critical check that must be passed for Acorn to be installed.
+ */
 func CheckRBAC() CheckResult {
 
 	result := CheckResult{
@@ -134,6 +174,60 @@ func CheckRBAC() CheckResult {
 		} else {
 			result.Message = "User cannot create namespaces"
 		}
+	}
+
+	return result
+}
+
+/*
+ * CheckDefaultStorageClass checks if a default storage class is defined.
+ * -> This is a non-critical check that "only" affects some features of Acorn.
+ */
+func CheckDefaultStorageClass() CheckResult {
+	result := CheckResult{
+		Name: "DefaultStorageClass",
+	}
+
+	silenceKlog()
+	cli, err := newClient()
+	if err != nil {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Error creating client: %v", err)
+		return result
+	}
+
+	// List registered storageClasses
+	var scs storagev1.StorageClassList
+
+	if err := cli.List(context.Background(), &scs); err != nil {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Error listing storage classes: %v", err)
+		return result
+	}
+
+	// Check if there is a default storageClass
+	defaultSc := ""
+	for _, sc := range scs.Items {
+		for k, v := range sc.Annotations {
+			if k == "storageclass.kubernetes.io/is-default-class" && v == "true" {
+				defaultSc = sc.Name
+				break
+			}
+		}
+		if defaultSc != "" {
+			break
+		}
+	}
+
+	if len(scs.Items) == 0 {
+		result.Passed = false
+		result.Message = "No storage classes found"
+	} else if defaultSc == "" {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Found %d storage classes, but none are marked as default", len(scs.Items))
+	} else {
+		result.Passed = true
+		result.Message = fmt.Sprintf("Found default storage class %s", defaultSc)
 	}
 
 	return result

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -114,7 +114,7 @@ func Install(ctx context.Context, image string, opts *Options) error {
 
 	if !opts.DisablePreflightChecks {
 		s := opts.Progress.New("Running Preflight Checks")
-		if check.IsFailed(check.PreflightChecks()) {
+		if check.IsFailed(check.PreflightChecks(ctx)) {
 			_ = s.Fail(errors.New("preflight checks failed, use `acorn check` to debug or `acorn install --disable-preflight-checks` to skip"))
 		} else {
 			s.Success()
@@ -173,7 +173,7 @@ func Install(ctx context.Context, image string, opts *Options) error {
 	}
 
 	s := opts.Progress.New("Running In-Flight Checks")
-	checkresults := check.InFlightChecks()
+	checkresults := check.InFlightChecks(ctx)
 	if check.IsFailed(checkresults) {
 		_ = s.Fail(fmt.Errorf("failed in-flight check(s) may break some features of Acorn"))
 	}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -55,13 +55,13 @@ var (
 type Mode string
 
 type Options struct {
-	DisablePreflightChecks bool
-	OutputFormat           string
-	APIServerReplicas      *int
-	ControllerReplicas     *int
-	Config                 apiv1.Config
-	Mode                   uiv1.InstallMode
-	Progress               progress.Builder
+	Checks             *bool
+	OutputFormat       string
+	APIServerReplicas  *int
+	ControllerReplicas *int
+	Config             apiv1.Config
+	Mode               uiv1.InstallMode
+	Progress           progress.Builder
 }
 
 func (o *Options) complete() *Options {
@@ -112,10 +112,10 @@ func Install(ctx context.Context, image string, opts *Options) error {
 		return printObject(image, opts)
 	}
 
-	if !opts.DisablePreflightChecks {
+	if opts.Checks == nil || *opts.Checks {
 		s := opts.Progress.New("Running Preflight Checks")
 		if check.IsFailed(check.PreflightChecks(ctx)) {
-			_ = s.Fail(errors.New("preflight checks failed, use `acorn check` to debug or `acorn install --disable-preflight-checks` to skip"))
+			_ = s.Fail(errors.New("preflight checks failed, use `acorn check` to debug or `acorn install --checks=false` to skip"))
 		} else {
 			s.Success()
 		}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -13,7 +13,6 @@ import (
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	uiv1 "github.com/acorn-io/acorn/pkg/apis/ui.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/config"
-	"github.com/acorn-io/acorn/pkg/install/check"
 	"github.com/acorn-io/acorn/pkg/install/progress"
 	k8sclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	labels2 "github.com/acorn-io/acorn/pkg/labels"
@@ -112,9 +111,10 @@ func Install(ctx context.Context, image string, opts *Options) error {
 		return printObject(image, opts)
 	}
 
+	checkOpts := CheckOptions{RuntimeImage: image}
 	if opts.Checks == nil || *opts.Checks {
 		s := opts.Progress.New("Running Preflight Checks")
-		if check.IsFailed(check.PreflightChecks(ctx)) {
+		if IsFailed(PreflightChecks(ctx, checkOpts)) {
 			_ = s.Fail(errors.New("preflight checks failed, use `acorn check` to debug or `acorn install --checks=false` to skip"))
 		} else {
 			s.Success()
@@ -173,8 +173,8 @@ func Install(ctx context.Context, image string, opts *Options) error {
 	}
 
 	s := opts.Progress.New("Running In-Flight Checks")
-	checkresults := check.InFlightChecks(ctx)
-	if check.IsFailed(checkresults) {
+	checkresults := InFlightChecks(ctx, checkOpts)
+	if IsFailed(checkresults) {
 		_ = s.Fail(fmt.Errorf("failed in-flight check(s) may break some features of Acorn"))
 	}
 

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -1,6 +1,14 @@
 package tables
 
 var (
+	CheckResult = [][]string{
+		{"Name", "Name"},
+		{"Passed", "Passed"},
+		{"Message", "Message"},
+	}
+
+	CheckResultConverter = MustConverter(CheckResult)
+
 	App = [][]string{
 		{"Name", "{{ . | name }}"},
 		{"Image", "{{ trunc .Spec.Image }}"},


### PR DESCRIPTION
References:

## Pre-Flight (critical) Checks

:exclamation: Those (could) make `acorn install` fail :exclamation: 

- [x] #464 
	- cluster up and running: Preflight checks if all nodes are up (FIXME!)
		-	Would it be enough to just test API connectivity?
	- admin privileges: see below
- [x] #547
	- Errors are pretty clear about Kubernetes RBAC permissions already. The preflight check tests if the user can create namespaces as that's highest privilege in Kubernetes and also required for the installation process.

## In-Flight (non-critical) Checks

:warning: Those won't make Acorn fail but limit its functionality

- [x] #476 
	- Test: create Endpoint + Service + Ingress: watch ingress for 10s max. to see if it gets updated by an ingress controller 
- [ ] #545 
- [x] #546 
- [x] #553 
