### PR TITLE
Support numbers with G suffix in AML

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -75,7 +75,11 @@ func (in *Quantity) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &s); err != nil {
 			return err
 		}
-		*in = (Quantity)(fmt.Sprintf("%dG", s))
+		if s < 1000000 {
+			*in = (Quantity)(fmt.Sprintf("%dG", s))
+		} else {
+			*in = (Quantity)(fmt.Sprintf("%d", s))
+		}
 		return nil
 	}
 	s, err := parseString(data)

--- a/pkg/appdefinition/appdefinition_test.go
+++ b/pkg/appdefinition/appdefinition_test.go
@@ -15,6 +15,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParse5GLiteralVolume(t *testing.T) {
+	appImage, err := NewAppDefinition([]byte(`
+volumes: {
+  "data": {
+    size: 5G
+    accessModes: ["readWriteOnce"]
+  }
+  "data2": {
+    size: 999999
+    accessModes: ["readWriteOnce"]
+  }
+  "data3": {
+    size: 1000000
+    accessModes: ["readWriteOnce"]
+  }
+}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec, err := appImage.AppSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "5000000000", string(spec.Volumes["data"].Size))
+	assert.Equal(t, "999999G", string(spec.Volumes["data2"].Size))
+	assert.Equal(t, "1000000", string(spec.Volumes["data3"].Size))
+}
+
 func TestAppImageBuildSpec(t *testing.T) {
 	appImage, err := NewAppDefinition([]byte(`
 containers: {


### PR DESCRIPTION
The size of a volume was assumed to be a string but numbers were
supported also.  If a number was put in like 5 it was assumed to be
gigabytes.  The issue happens where in the field you put 5G instead
of "5G" (quoted). The 5G syntax is parsed by AML and turned into
5000000000.  Then we assume that is gigabytes turning into
5000000000G.

The fix is a bit of a hack where we basically say if the number is less
than 1000000 we treat it as gigabytes.
