### PR TITLE
Fix TLS docs example indentation

### DIFF
--- a/docs/docs/50-running/03-certificates.md
+++ b/docs/docs/50-running/03-certificates.md
@@ -38,11 +38,11 @@ metadata:
 spec:
   dnsNames:
   - my-app.example.com
-    issuerRef:
-      group: cert-manager.io
-      kind: ClusterIssuer
-      name: prod-issuer
-    secretName: my-app-tls-secret
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: prod-issuer
+  secretName: my-app-tls-secret
 ```
 
 Cert-Manager will create a certificate for `my-app.example.com` and store it in a secret `my-app-tls-secret`.


### PR DESCRIPTION
The indentation of the example YAML definition of the the Certificate on the [Acorn Docs TLS Certificates](https://docs.acorn.io/running/certificates#add-with-cert-manager) is wrong.

This leads to YAML parsing errors when trying to apply.