### PR TITLE
Add -c / --container flag to images

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_image.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image.md
@@ -20,6 +20,7 @@ acorn images
 
 ```
   -a, --all             Include untagged images
+  -c, --containers      Show containers for images
   -h, --help            help for image
       --no-trunc        Don't truncate IDs
   -o, --output string   Output format (json, yaml, {{gotemplate}})

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -84,7 +84,7 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	return out.Err()
 }
 
-type ImageContainer struct {
+type imageContainer struct {
 	Container string
 	Repo      string
 	Tag       string
@@ -118,8 +118,8 @@ func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Cl
 	return out.Err()
 }
 
-func getImageContainers(c client.Client, ctx context.Context, image apiv1.Image) ([]ImageContainer, error) {
-	imageContainers := []ImageContainer{}
+func getImageContainers(c client.Client, ctx context.Context, image apiv1.Image) ([]imageContainer, error) {
+	imageContainers := []imageContainer{}
 
 	imgDetails, err := c.ImageDetails(ctx, image.Name, nil)
 	if err != nil {
@@ -150,11 +150,11 @@ func getImageContainers(c client.Client, ctx context.Context, image apiv1.Image)
 	return imageContainers, nil
 }
 
-func newImageContainerList(image apiv1.Image, containers map[string]v1.ContainerData) []ImageContainer {
-	imageContainers := []ImageContainer{}
+func newImageContainerList(image apiv1.Image, containers map[string]v1.ContainerData) []imageContainer {
+	imageContainers := []imageContainer{}
 
 	for k, v := range containers {
-		ImgContainer := ImageContainer{
+		ImgContainer := imageContainer{
 			Repo:      image.Repository,
 			Tag:       image.Tag,
 			Container: k,
@@ -164,7 +164,7 @@ func newImageContainerList(image apiv1.Image, containers map[string]v1.Container
 		imageContainers = append(imageContainers, ImgContainer)
 
 		for sidecar, img := range v.Sidecars {
-			ic := ImageContainer{
+			ic := imageContainer{
 				Repo:      image.Repository,
 				Tag:       image.Tag,
 				Container: sidecar,

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"context"
 	"strings"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/cli/builder/table"
 	"github.com/acorn-io/acorn/pkg/client"
@@ -25,16 +27,35 @@ acorn images`,
 }
 
 type Image struct {
-	All     bool   `usage:"Include untagged images" short:"a"`
-	Quiet   bool   `usage:"Output only names" short:"q"`
-	NoTrunc bool   `usage:"Don't truncate IDs"`
-	Output  string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
+	All       bool   `usage:"Include untagged images" short:"a"`
+	Quiet     bool   `usage:"Output only names" short:"q"`
+	NoTrunc   bool   `usage:"Don't truncate IDs"`
+	Output    string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
+	Container bool   `usage:"Show containers for images" short:"c"`
 }
 
 func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	c, err := client.Default()
 	if err != nil {
 		return err
+	}
+
+	var images []apiv1.Image
+	if len(args) == 1 {
+		img, err := c.ImageGet(cmd.Context(), args[0])
+		if err != nil {
+			return err
+		}
+		images = []apiv1.Image{*img}
+	} else {
+		images, err = c.ImageList(cmd.Context())
+		if err != nil {
+			return err
+		}
+	}
+
+	if a.Container {
+		return printContainerImages(images, cmd.Context(), c, a.Output, a.Quiet)
 	}
 
 	out := table.NewWriter(tables.Image, system.UserNamespace(), false, a.Output)
@@ -51,20 +72,6 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 		return strings.TrimPrefix(str, "sha256:")[:12]
 	})
 
-	var images []apiv1.Image
-	if len(args) == 1 {
-		img, err := c.ImageGet(cmd.Context(), args[0])
-		if err != nil {
-			return err
-		}
-		images = []apiv1.Image{*img}
-	} else {
-		images, err = c.ImageList(cmd.Context())
-		if err != nil {
-			return err
-		}
-	}
-
 	for _, image := range images {
 		if image.Tag == "" && image.Repository == "" && !a.All {
 			continue
@@ -73,4 +80,75 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return out.Err()
+}
+
+type ImageContainer struct {
+	Container string
+	Repo      string
+	Tag       string
+	Image     string
+}
+
+func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Client, output string, quiet bool) error {
+	out := table.NewWriter(tables.ImageContainers, system.UserNamespace(), quiet, output)
+
+	if quiet {
+		out = table.NewWriter([][]string{
+			{"Name", "{{.Repo}}:{{.Tag}}@{{.Image}}"},
+		}, system.UserNamespace(), quiet, output)
+	}
+
+	for _, image := range images {
+		imgDetails, err := c.ImageDetails(ctx, image.Name, &client.ImageDetailsOptions{})
+		if err != nil {
+			return err
+		}
+
+		if image.Tag == "" && image.Repository == "" {
+			continue
+		}
+
+		for _, imgContainer := range newImageContainer(image, imgDetails.AppImage.ImageData) {
+			out.Write(imgContainer)
+		}
+
+	}
+
+	return out.Err()
+}
+
+func newImageContainer(image apiv1.Image, imageData v1.ImagesData) []ImageContainer {
+	imageContainers := []ImageContainer{}
+
+	imageContainers = append(imageContainers, parseContainerData(image.Repository, image.Tag, imageData.Containers)...)
+	imageContainers = append(imageContainers, parseContainerData(image.Repository, image.Tag, imageData.Jobs)...)
+
+	return imageContainers
+}
+
+func parseContainerData(repo, tag string, containers map[string]v1.ContainerData) []ImageContainer {
+	imageContainers := []ImageContainer{}
+
+	for k, v := range containers {
+		ImgContainer := ImageContainer{
+			Repo:      repo,
+			Tag:       tag,
+			Container: k,
+			Image:     v.Image,
+		}
+
+		imageContainers = append(imageContainers, ImgContainer)
+
+		for sidecar, img := range v.Sidecars {
+			ic := ImageContainer{
+				Repo:      repo,
+				Tag:       tag,
+				Container: sidecar,
+				Image:     img.Image,
+			}
+			imageContainers = append(imageContainers, ic)
+		}
+	}
+
+	return imageContainers
 }

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -33,6 +33,7 @@ var (
 	ImageContainer = [][]string{
 		{"Repository", "{{ .Repo }}"},
 		{"Tag", "{{ .Tag }}"},
+		{"Image-ID", "{{trunc .ImageID }}"},
 		{"Container", "{{ .Container}}"},
 		{"Digest", "{{ .Digest }}"},
 	}

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -30,6 +30,14 @@ var (
 	}
 	ImageConverter = MustConverter(Image)
 
+	ImageContainers = [][]string{
+		{"Repository", "{{ .Repo }}"},
+		{"Tag", "{{ .Tag }}"},
+		{"Container", "{{ .Container}}"},
+		{"Digest", "{{ .Image }}"},
+	}
+	ImageContainerConverter = MustConverter(ImageContainers)
+
 	Container = [][]string{
 		{"Name", "{{ . | name }}"},
 		{"App", "Status.Columns.App"},

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -30,13 +30,13 @@ var (
 	}
 	ImageConverter = MustConverter(Image)
 
-	ImageContainers = [][]string{
+	ImageContainer = [][]string{
 		{"Repository", "{{ .Repo }}"},
 		{"Tag", "{{ .Tag }}"},
 		{"Container", "{{ .Container}}"},
-		{"Digest", "{{ .Image }}"},
+		{"Digest", "{{ .Digest }}"},
 	}
-	ImageContainerConverter = MustConverter(ImageContainers)
+	ImageContainerConverter = MustConverter(ImageContainer)
 
 	Container = [][]string{
 		{"Name", "{{ . | name }}"},


### PR DESCRIPTION
The new flags show the container images that are a part of the Acorn
image.

acorn images:
```shell
REPOSITORY                          TAG              IMAGE-ID
ghcr.io/acorn-io/library/registry   v2.8.1-acorn.1   c041941788cb
monitoring-operator                 latest           c3a97c6e0d4f
ghcr.io/acorn-io/library/mariadb    latest           6a447c6a81c2
```

```shell
acorn images -c
REPOSITORY                          TAG              CONTAINER                   DIGEST
ghcr.io/acorn-io/library/registry   v2.8.1-acorn.1   registry                    sha256:4562d45e6464f3d730e3df444e907a17bb1d85c1c59e701af4d0b1ef4b9ae23e
ghcr.io/acorn-io/library/registry   v2.8.1-acorn.1   htpasswd-create             sha256:b9ae2b67047a0f4e1963f6b1c2ba5935919de1fddc441a1215a64693cc9c4c90
monitoring-operator                 latest           prom                        sha256:ef691daf5c0961759efcbaf6fa6dba37ea5e138e1447245fa9f10fdd71841f1d
monitoring-operator                 latest           acorn-file-init             sha256:5d17873afc03589bfe09361aee3207ce3e30736282060daf222158cc9bec20db
monitoring-operator                 latest           acorn-monitoring-operator   sha256:7211be2296b7642aaec786ae05288a3b9564770de2c621d3373433d263dd9302
ghcr.io/acorn-io/library/mariadb    latest           mariadb-0                   sha256:2d2b4f1128dd88aae18f5b79e773ebba3f5d7187434588287d0c90398901b81a
ghcr.io/acorn-io/library/mariadb    latest           backup                      sha256:5e5d4802b2013ae044aa90161c844cb7fd25a2c79ded77ad514a89e5113fcf7a
ghcr.io/acorn-io/library/mariadb    latest           restore-from-backup         sha256:5e5d4802b2013ae044aa90161c844cb7fd25a2c79ded77ad514a89e5113fcf7a
```


Signed-off-by: Bill Maxwell <cloudnautique@users.noreply.github.com>