### PR TITLE
fix: respect render output type for json

### DIFF
--- a/pkg/cli/render.go
+++ b/pkg/cli/render.go
@@ -54,7 +54,9 @@ func (s *Render) Run(cmd *cobra.Command, args []string) error {
 	case "yaml":
 		v, err = appDef.YAML()
 	case "json":
-		v, err = appDef.YAML()
+		if v, err = appDef.JSON(); err == nil {
+			v += "\n" // appDef.YAML() appends a line break
+		}
 	default:
 		return fmt.Errorf("unsupported output format %s", s.Output)
 	}


### PR DESCRIPTION
This PR reworks the `render` command so that it outputs JSON when required.