### PR TITLE
Bump linter version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ goreleaser:
 	goreleaser build --snapshot --single-target --rm-dist
 
 setup-ci-env:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.46.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.49.0
 
 # This will initialize the node_modules needed to run the docs dev server. Run this before running serve-docs
 init-docs:


### PR DESCRIPTION
This PR bumps `golangc-lint`'s version to `v1.49.0`. This will, probably, allow #593 to not break its build.

Signed-off-by: Panagiotis Siatras <azazeal@users.noreply.github.com>