### PR TITLE
Fix: make render -o equivalent to render --output

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_render.md
+++ b/docs/docs/100-reference/01-command-line/acorn_render.md
@@ -14,7 +14,7 @@ acorn render [flags] DIRECTORY [acorn args]
 ```
   -f, --file string       Name of the dev file (default "DIRECTORY/Acornfile")
   -h, --help              help for render
-      --output string     Output in JSON or YAML (default "json")
+  -o, --output string     Output in JSON or YAML (default "json")
       --profile strings   Profile to assign default values
 ```
 

--- a/pkg/cli/render.go
+++ b/pkg/cli/render.go
@@ -23,7 +23,7 @@ func NewRender() *cobra.Command {
 type Render struct {
 	File    string   `short:"f" usage:"Name of the dev file" default:"DIRECTORY/Acornfile"`
 	Profile []string `usage:"Profile to assign default values"`
-	Output  string   `usage:"Output in JSON or YAML" default:"json"`
+	Output  string   `usage:"Output in JSON or YAML" default:"json" short:"o"`
 }
 
 func (s *Render) Run(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Signed-off-by: Craig Jellick <craig@acorn.io>
