### PR TITLE
git: ignore the top-level .envrc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /pkg/ui/server/static/dashboard
 
 apiserver.local.config
+/.envrc


### PR DESCRIPTION
This PR appends `./envrc` to `.gitignore`.

Signed-off-by: Panagiotis Siatras <azazeal@users.noreply.github.com>
