### PR TITLE
Introduce a linter configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+run:
+  timeout: 5m
+
+output:
+  format: github-actions
+
+skip-files:
+  - "*generated*.go$"
+
+linters:
+  disable-all: true
+  enable:
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - typecheck
+  - unused
+  fast: false

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ image:
 	docker build .
 
 validate:
-	golangci-lint --timeout 5m run
+	golangci-lint run
 
 validate-ci:
 	go generate


### PR DESCRIPTION
This PR introduces a basic `.golangci.yml` file to the repo. It additionally edits `Makefile` so that `make validate` respects the linter timeout specified in said file.