### PR TITLE
change: do not use default ingressClass annotation and fix traefik uninstall warning

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -129,6 +129,21 @@ func Install(ctx context.Context, image string, opts *Options) error {
 		}
 	}
 
+	kclient, err := k8sclient.Default()
+	if err != nil {
+		return err
+	}
+
+	var installIngressController bool
+	if ok, err := config.IsDockerDesktop(ctx, kclient); err != nil {
+		return err
+	} else if ok {
+		if opts.Config.IngressClassName == nil {
+			installIngressController = true
+			opts.Config.IngressClassName = &[]string{"traefik"}[0]
+		}
+	}
+
 	apply, err := newApply(ctx)
 	if err != nil {
 		return err
@@ -157,14 +172,7 @@ func Install(ctx context.Context, image string, opts *Options) error {
 		}
 		s.Success()
 
-		kclient, err := k8sclient.Default()
-		if err != nil {
-			return err
-		}
-
-		if ok, err := config.IsDockerDesktop(ctx, kclient); err != nil {
-			return err
-		} else if ok {
+		if installIngressController {
 			if err := installTraefik(ctx, opts.Progress, kclient, apply); err != nil {
 				return err
 			}
@@ -190,6 +198,8 @@ func Install(ctx context.Context, image string, opts *Options) error {
 			}
 		}
 		s.SuccessWithWarning(msg)
+	} else {
+		s.Success()
 	}
 
 	pterm.Success.Println("Installation done")
@@ -212,26 +222,18 @@ func traefikResources() (result []runtime.Object, _ error) {
 		return nil, err
 	}
 	for _, obj := range objs {
-		if obj.GetObjectKind().GroupVersionKind().Kind == "IngressClass" {
-			m, err := meta.Accessor(obj)
-			if err != nil {
-				return nil, err
-			}
-
-			anno := m.GetAnnotations()
-			if anno == nil {
-				anno = map[string]string{}
-			}
-			anno["ingressclass.kubernetes.io/is-default-class"] = "true"
-			m.SetAnnotations(anno)
-
-			labels := m.GetLabels()
-			if labels == nil {
-				labels = map[string]string{}
-			}
-			labels[labels2.AcornManaged] = "true"
-			m.SetLabels(labels)
+		m, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
 		}
+
+		labels := m.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[labels2.AcornManaged] = "true"
+		m.SetLabels(labels)
+
 	}
 
 	return objs, nil

--- a/pkg/install/traefik.yaml
+++ b/pkg/install/traefik.yaml
@@ -188,8 +188,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  annotations:
-    ingressclass.kubernetes.io/is-default-class: "true"
   labels:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/managed-by: Acorn
@@ -199,30 +197,25 @@ spec:
   controller: traefik.io/ingress-controller
 ---
 apiVersion: v1
-kind: List
+kind: Service
 metadata:
   name: traefik
-items:
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      name: traefik
-      namespace: acorn-system
-      labels:
-        app.kubernetes.io/name: traefik
-        app.kubernetes.io/managed-by: Acorn
-        app.kubernetes.io/instance: traefik
-    spec:
-      type: LoadBalancer
-      selector:
-        app.kubernetes.io/name: traefik
-        app.kubernetes.io/instance: traefik
-      ports:
-      - port: 80
-        name: web
-        targetPort: "web"
-        protocol: TCP
-      - port: 443
-        name: websecure
-        targetPort: "websecure"
-        protocol: TCP
+  namespace: acorn-system
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/managed-by: Acorn
+    app.kubernetes.io/instance: traefik
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: traefik
+  ports:
+  - port: 80
+    name: web
+    targetPort: "web"
+    protocol: TCP
+  - port: 443
+    name: websecure
+    targetPort: "websecure"
+    protocol: TCP


### PR DESCRIPTION
Ref: #649

Additional info:

- before this change, `acorn uninstall` yielded an error `Error: an empty namespace may not be set when a resource name is provided` because the Service wasn't assigned to a namespace
- Traefik will only be installed, if no `ingressClassName` was specified via flag
- this PR also adds the success message for the Post-install checks

Signed-off-by: Thorsten Klein <tk@thklein.io>