### PR TITLE
Enable the thelper linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,5 +16,6 @@ linters:
   - ineffassign
   - staticcheck
   - typecheck
+  - thelper
   - unused
   fast: false

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -8,6 +8,8 @@ import (
 )
 
 func NewImage2(t *testing.T, namespace string) string {
+	t.Helper()
+
 	image, err := build.Build(helper.GetCTX(t), "../testdata/nginx2/Acornfile", &build.Options{
 		Client: helper.BuilderClient(t, namespace),
 		Cwd:    "../testdata/nginx2",
@@ -19,6 +21,8 @@ func NewImage2(t *testing.T, namespace string) string {
 }
 
 func NewImage(t *testing.T, namespace string) string {
+	t.Helper()
+
 	image, err := build.Build(helper.GetCTX(t), "../testdata/nginx/Acornfile", &build.Options{
 		Client: helper.BuilderClient(t, namespace),
 		Cwd:    "../testdata/nginx",

--- a/integration/client/depends_test.go
+++ b/integration/client/depends_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func depImage(t *testing.T, c client.Client) string {
+	t.Helper()
+
 	image, err := build.Build(helper.GetCTX(t), "./testdata/dependson/Acornfile", &build.Options{
 		Client: c,
 		Cwd:    "./testdata/dependson",
@@ -30,6 +32,8 @@ func depImage(t *testing.T, c client.Client) string {
 }
 
 func toRevision(t *testing.T, obj kclient.Object) int {
+	t.Helper()
+
 	i, err := strconv.Atoi(obj.GetResourceVersion())
 	if err != nil {
 		t.Fatalf("Invalid resource version %s on %s/%s", obj.GetResourceVersion(), obj.GetNamespace(), obj.GetName())

--- a/integration/client/nested_test.go
+++ b/integration/client/nested_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func nestedImage(t *testing.T, c client.Client) string {
+	t.Helper()
+
 	image, err := build.Build(helper.GetCTX(t), "./testdata/nested/Acornfile", &build.Options{
 		Client: c,
 		Cwd:    "./testdata/nested",

--- a/integration/helper/controller.go
+++ b/integration/helper/controller.go
@@ -45,6 +45,8 @@ const (
 )
 
 func EnsureCRDs(t *testing.T) {
+	t.Helper()
+
 	ctx := GetCTX(t)
 	if err := crds.Create(ctx, scheme.Scheme, v1.SchemeGroupVersion); err != nil {
 		t.Fatal(err)
@@ -65,6 +67,8 @@ func EnsureCRDs(t *testing.T) {
 }
 
 func ClientAndNamespace(t *testing.T) (client.Client, *corev1.Namespace) {
+	t.Helper()
+
 	StartController(t)
 	kclient := MustReturn(hclient.Default)
 	ns := TempNamespace(t, kclient)
@@ -72,6 +76,8 @@ func ClientAndNamespace(t *testing.T) (client.Client, *corev1.Namespace) {
 }
 
 func BuilderClient(t *testing.T, namespace string) client.Client {
+	t.Helper()
+
 	c, err := client.New(StartAPI(t), namespace)
 	if err != nil {
 		t.Fatal(err)
@@ -80,6 +86,8 @@ func BuilderClient(t *testing.T, namespace string) client.Client {
 }
 
 func ensureNamespace(t *testing.T) {
+	t.Helper()
+
 	kclient := MustReturn(hclient.Default)
 	_ = kclient.Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -89,6 +97,8 @@ func ensureNamespace(t *testing.T) {
 }
 
 func StartAPI(t *testing.T) *rest.Config {
+	t.Helper()
+
 	apiStartLock.Lock()
 	defer apiStartLock.Unlock()
 
@@ -170,11 +180,15 @@ func CleanupAPI() {
 }
 
 func StartRegistry(t *testing.T) (string, func()) {
+	t.Helper()
+
 	srv := httptest.NewServer(registry.New())
 	return srv.Listener.Addr().String(), srv.Close
 }
 
 func StartController(t *testing.T) {
+	t.Helper()
+
 	if os.Getenv("TEST_ACORN_CONTROLLER") == "external" {
 		return
 	}

--- a/integration/helper/ctx.go
+++ b/integration/helper/ctx.go
@@ -7,6 +7,8 @@ import (
 )
 
 func GetCTX(t *testing.T) context.Context {
+	t.Helper()
+
 	ctx := context.Background()
 	deadline, ok := t.Deadline()
 	if !ok {

--- a/integration/helper/namespace.go
+++ b/integration/helper/namespace.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TempNamespace(t *testing.T, client client.Client) *corev1.Namespace {
+	t.Helper()
+
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "acorn-test-",

--- a/integration/helper/wait.go
+++ b/integration/helper/wait.go
@@ -21,6 +21,8 @@ type WatchFunc func(ctx context.Context, obj client.ObjectList, opts ...client.L
 type watchFunc func() (watch.Interface, error)
 
 func doWatch[T client.Object](t *testing.T, watchFunc watchFunc, cb func(obj T) bool) bool {
+	t.Helper()
+
 	ctx := GetCTX(t)
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
@@ -62,6 +64,8 @@ func doWatch[T client.Object](t *testing.T, watchFunc watchFunc, cb func(obj T) 
 }
 
 func retryWatch[T client.Object](t *testing.T, watchFunc watchFunc, cb func(obj T) bool) {
+	t.Helper()
+
 	for {
 		if done := doWatch(t, watchFunc, cb); done {
 			return
@@ -70,6 +74,8 @@ func retryWatch[T client.Object](t *testing.T, watchFunc watchFunc, cb func(obj 
 }
 
 func Wait[T client.Object](t *testing.T, watchFunc WatchFunc, list client.ObjectList, cb func(obj T) bool) T {
+	t.Helper()
+
 	var last T
 	retryWatch(t, func() (watch.Interface, error) {
 		ctx := GetCTX(t)
@@ -82,6 +88,8 @@ func Wait[T client.Object](t *testing.T, watchFunc WatchFunc, list client.Object
 }
 
 func WaitForObject[T client.Object](t *testing.T, watchFunc WatchFunc, list client.ObjectList, obj T, cb func(obj T) bool) T {
+	t.Helper()
+
 	if done := cb(obj); done {
 		return obj
 	}

--- a/pkg/apis/internal.acorn.io/v1/labelsannotations_test.go
+++ b/pkg/apis/internal.acorn.io/v1/labelsannotations_test.go
@@ -28,6 +28,8 @@ func TestParseScopedLabels(t *testing.T) {
 }
 
 func simpleTest(t *testing.T, input string, expected ScopedLabel) {
+	t.Helper()
+
 	actual, err := ParseScopedLabels(input)
 	assert.NoError(t, err)
 	assert.Len(t, actual, 1)

--- a/pkg/appdefinition/appdefinition_test.go
+++ b/pkg/appdefinition/appdefinition_test.go
@@ -2004,6 +2004,8 @@ args: {
 }
 
 func getVals(t *testing.T, appDef *AppDefinition) map[string]any {
+	t.Helper()
+
 	data := map[string]any{}
 	appSpec, err := appDef.AppSpec()
 	if err != nil {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func ArgsToApp(t *testing.T, args ...string) *apiv1.App {
+	t.Helper()
+
 	buf := &bytes.Buffer{}
 	cmd := NewRun(buf)
 	cmd.SetArgs(append([]string{"-o", "json"}, args...))

--- a/pkg/controller/appdefinition/deploy_test.go
+++ b/pkg/controller/appdefinition/deploy_test.go
@@ -43,6 +43,8 @@ func TestProbe(t *testing.T) {
 }
 
 func ToDeploymentsTest(t *testing.T, appInstance *v1.AppInstance, tag name.Reference, pullSecrets *PullSecrets) (result []kclient.Object) {
+	t.Helper()
+
 	req := tester.NewRequest(t, scheme.Scheme, appInstance)
 	deps, err := ToDeployments(req, appInstance, tag, pullSecrets)
 	if err != nil {

--- a/pkg/dns/helpers_test.go
+++ b/pkg/dns/helpers_test.go
@@ -33,6 +33,8 @@ func TestToRecordRequests(t *testing.T) {
 }
 
 func assrt(t *testing.T, domain string, specRulesHosts, statusIPv4s, statusIPv6s, statusHosts []string, expectedRRs []RecordRequest) {
+	t.Helper()
+
 	ingress := ing(specRulesHosts, statusIPv4s, statusIPv6s, statusHosts)
 	recordReqs, _ := ToRecordRequestsAndHash(domain, ingress)
 	assert.Equal(t, expectedRRs, recordReqs)

--- a/pkg/image/service_test.go
+++ b/pkg/image/service_test.go
@@ -22,6 +22,8 @@ var (
 )
 
 func Registry(t *testing.T) name.Registry {
+	t.Helper()
+
 	reg := reg.New()
 	srv := httptest.NewServer(reg)
 


### PR DESCRIPTION
This PR enables the `thelper` linter in `.golangci.yml`. It additionally decorates existing tests with a call to `(*testing.T).Helper` for better stack traces.

Signed-off-by: Panagiotis Siatras <azazeal@users.noreply.github.com>