### PR TITLE
Empty dockerfile in build should be relative to context

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -933,7 +933,17 @@ func (in *Build) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	type build Build
-	return json.Unmarshal(data, (*build)(in))
+	err := json.Unmarshal(data, (*build)(in))
+	if err != nil {
+		return err
+	}
+	if in.Context == "" {
+		in.Context = "."
+	}
+	if in.Dockerfile == "" {
+		in.Dockerfile = filepath.Join(in.Context, "Dockerfile")
+	}
+	return nil
 }
 
 func isObject(data []byte) bool {

--- a/pkg/appdefinition/appdefinition_test.go
+++ b/pkg/appdefinition/appdefinition_test.go
@@ -2238,6 +2238,25 @@ secrets: template: {
 	assert.Equal(t, "yep", appSpec.Secrets["template"].Data["foo"])
 }
 
+func TestDefaultContextDir(t *testing.T) {
+	data := `
+containers: test: build: "./foo"
+containers: test2: build: context: "./foo"
+`
+	appDef, err := NewAppDefinition([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	appSpec, err := appDef.AppSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "foo/Dockerfile", appSpec.Containers["test"].Build.Dockerfile)
+	assert.Equal(t, "foo/Dockerfile", appSpec.Containers["test2"].Build.Dockerfile)
+}
+
 func TestShortPermissions(t *testing.T) {
 	data := `
 containers: test: {

--- a/schema/v1/app.cue
+++ b/schema/v1/app.cue
@@ -9,7 +9,7 @@ package v1
 #Build: {
 	buildArgs: [string]: string
 	context:    string | *"."
-	dockerfile: string | *"Dockerfile"
+	dockerfile: string | *""
 	target:     string | *""
 }
 


### PR DESCRIPTION
If you only specify the context value in the build section the
dockerfile parameter should default to CONTEXT_DIR/Dockerfile.
The behavior was being done for `build: "./foo"` but not for
`build: {context: "./foo"}`

Signed-off-by: Darren Shepherd <darren@acorn.io>
