### PR TITLE
Make creating dirs to files work

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -370,9 +370,12 @@ func buildWithContext(ctx context.Context, c client.Client, cwd string, platform
 	}()
 
 	for _, dir := range build.ContextDirs {
-		err := os.MkdirAll(dir, 0755)
-		if err != nil {
-			return "", fmt.Errorf("creating dir %s: %w", dir, err)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			// don't blindly mkdirall because this could actually be a file
+			err := os.MkdirAll(dir, 0755)
+			if err != nil {
+				return "", fmt.Errorf("creating dir %s: %w", dir, err)
+			}
 		}
 	}
 

--- a/pkg/dev/sync.go
+++ b/pkg/dev/sync.go
@@ -57,6 +57,9 @@ func containerSync(ctx context.Context, app *apiv1.App, opts *Options) error {
 }
 
 func invokeStartSyncForPath(ctx context.Context, client client.Client, con *apiv1.ContainerReplica, cwd, localDir, remoteDir string, bidirectional bool) (chan struct{}, error) {
+	if s, err := os.Stat(localDir); err == nil && !s.IsDir() {
+		return nil, nil
+	}
 	err := os.MkdirAll(localDir, 0755)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If you wish to bind in in a local file to a container file directly you
can now do so with `dirs: "/target/file.txt": "./foo.txt"`  This syntax
is a bit odd, but it works for now, but there is an issue that that
file will not be synced during dev mode.

Signed-off-by: Darren Shepherd <darren@acorn.io>
