### PR TITLE
Fix job builds not being watched in dev mode

### DIFF
--- a/pkg/appdefinition/appdefinition.go
+++ b/pkg/appdefinition/appdefinition.go
@@ -306,6 +306,7 @@ func (a *AppDefinition) WatchFiles(cwd string) (result []string, _ error) {
 	}
 
 	addContainerFiles(fileSet, spec.Containers, cwd)
+	addContainerFiles(fileSet, spec.Jobs, cwd)
 	addFiles(fileSet, spec.Images, cwd)
 	addAcorns(fileSet, spec.Acorns, cwd)
 


### PR DESCRIPTION
Dockerfiles from builds from jobs were not being added to the watch list

Signed-off-by: Darren Shepherd <darren@acorn.io>
