### PR TITLE
Allow the default probe to be disabled

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appspec.go
+++ b/pkg/apis/internal.acorn.io/v1/appspec.go
@@ -273,7 +273,7 @@ type Container struct {
 	Environment  EnvVars                `json:"environment,omitempty"`
 	WorkingDir   string                 `json:"workingDir,omitempty"`
 	Ports        Ports                  `json:"ports,omitempty"`
-	Probes       Probes                 `json:"probes,omitempty"`
+	Probes       Probes                 `json:"probes"` // Don't omitempty so that nil vs empty is recorded
 	Dependencies Dependencies           `json:"dependencies,omitempty"`
 	Permissions  *Permissions           `json:"permissions,omitempty"`
 

--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -700,6 +700,9 @@ func (in *Probe) UnmarshalJSON(data []byte) error {
 }
 
 func (in *Probes) UnmarshalJSON(data []byte) error {
+	// ensure not nil if set
+	*in = Probes{}
+
 	if isString(data) {
 		p := Probe{}
 		if err := json.Unmarshal(data, &p); err != nil {

--- a/pkg/appdefinition/appdefinition_test.go
+++ b/pkg/appdefinition/appdefinition_test.go
@@ -2292,6 +2292,26 @@ containers: test: {
 	assert.Equal(t, "blah", appSpec.Containers["test"].Dirs["/foo3"].Volume)
 }
 
+func TestDisableProbes(t *testing.T) {
+	appImage, err := NewAppDefinition([]byte(`
+containers: map: probes: {}
+containers: array: probes: []
+containers: default: image: "foo"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec, err := appImage.AppSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, v1.Probes{}, spec.Containers["array"].Probes)
+	assert.Equal(t, v1.Probes{}, spec.Containers["map"].Probes)
+	assert.Equal(t, v1.Probes(nil), spec.Containers["default"].Probes)
+}
+
 func TestNestedScopedLabels(t *testing.T) {
 	// labels and annotations on a acorn are both unmarshalled into a ScopedLabels struct, which is just a slice
 	// Similar to ports, in the Acornfile you can define them using an object syntax or short-form string syntax.

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -375,7 +375,7 @@ func toProbe(container v1.Container, probeType v1.ProbeType) *corev1.Probe {
 	}
 
 	if probeType == v1.ReadinessProbeType &&
-		len(container.Probes) == 0 {
+		container.Probes == nil {
 		for _, port := range container.Ports {
 			if port.Protocol == v1.ProtocolUDP {
 				continue

--- a/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
@@ -40,7 +40,7 @@ spec:
             "acorn.io/managed": "true"
             "acorn.io/root-prefix": "app-name"
           annotations:
-            acorn.io/container-spec: '{"image":"image-name","schedule":"daily"}'
+            acorn.io/container-spec: '{"image":"image-name","probes":null,"schedule":"daily"}'
         spec:
           imagePullSecrets:
             - name: oneimage-pull-1234567890ab

--- a/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dependencies":[{"targetName":"db"}],"image":"image-name"}'
+        acorn.io/container-spec: '{"dependencies":[{"targetName":"db"}],"image":"image-name","probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false
@@ -68,7 +68,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dependencies":[{"targetName":"container-name"}],"image":"image-name"}'
+        acorn.io/container-spec: '{"dependencies":[{"targetName":"container-name"}],"image":"image-name","probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false

--- a/pkg/controller/appdefinition/testdata/deployspec-stop/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec-stop/expected.yaml
@@ -36,7 +36,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name"}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false
@@ -75,7 +75,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        "acorn.io/container-spec": '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image"}'
+        "acorn.io/container-spec": '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false

--- a/pkg/controller/appdefinition/testdata/deployspec/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/expected.yaml
@@ -37,7 +37,7 @@ spec:
         "port-number.acorn.io/81": "true"
         "port-number.acorn.io/91": "true"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","targetPort":91}]}}}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false
@@ -89,7 +89,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        "acorn.io/container-spec": '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image"}'
+        "acorn.io/container-spec": '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       serviceAccountName: acorn

--- a/pkg/controller/appdefinition/testdata/files-bug/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/files-bug/expected.yaml.d/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"image":"image-name","sidecars":{"sidecar":{"files":{"content-test":{"content":"YmFzZQ==","mode":"0644","secret":{}},"sidecar-content-test-mode":{"content":"c2lkZWNhci1tb2Rl","mode":"0755","secret":{}}},"image":"image-name"}}}'
+        acorn.io/container-spec: '{"image":"image-name","probes":null,"sidecars":{"sidecar":{"files":{"content-test":{"content":"YmFzZQ==","mode":"0644","secret":{}},"sidecar-content-test-mode":{"content":"c2lkZWNhci1tb2Rl","mode":"0755","secret":{}}},"image":"image-name","probes":null}}}'
     spec:
       terminationGracePeriodSeconds: 5
       imagePullSecrets:

--- a/pkg/controller/appdefinition/testdata/files/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/files/expected.yaml.d/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"files":{"content-test":{"content":"YmFzZQ==","mode":"0644","secret":{}},"content-test-mode":{"content":"YmFzZS1tb2Rl","mode":"0123","secret":{}},"secret-test":{"mode":"644","secret":{"key":"key-name","name":"ref"}}},"image":"image-name","sidecars":{"sidecar":{"files":{"sidecar-content-test":{"content":"c2lkZWNhcg==","mode":"0644","secret":{}},"sidecar-content-test-mode":{"content":"c2lkZWNhci1tb2Rl","mode":"0123","secret":{}}},"image":"image-name"}}}'
+        acorn.io/container-spec: '{"files":{"content-test":{"content":"YmFzZQ==","mode":"0644","secret":{}},"content-test-mode":{"content":"YmFzZS1tb2Rl","mode":"0123","secret":{}},"secret-test":{"mode":"644","secret":{"key":"key-name","name":"ref"}}},"image":"image-name","probes":null,"sidecars":{"sidecar":{"files":{"sidecar-content-test":{"content":"c2lkZWNhcg==","mode":"0644","secret":{}},"sidecar-content-test-mode":{"content":"c2lkZWNhci1tb2Rl","mode":"0123","secret":{}}},"image":"image-name","probes":null}}}'
     spec:
       terminationGracePeriodSeconds: 5
       imagePullSecrets:

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"environment":[{"name":"env-name","secret":{},"value":"env-value"}],"image":"image-name"}'
+        acorn.io/container-spec: '{"environment":[{"name":"env-name","secret":{},"value":"env-value"}],"image":"image-name","probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false

--- a/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         "port-number.acorn.io/81": "true"
         "service-name.acorn.io/oneimage": "true"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}]}}}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}}}'
     spec:
       terminationGracePeriodSeconds: 5
       hostname: oneimage
@@ -85,7 +85,7 @@ spec:
         "port-number.acorn.io/81": "true"
         "service-name.acorn.io/buildimage": "true"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}]}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}'
     spec:
       hostname: buildimage
       terminationGracePeriodSeconds: 5

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         "port-number.acorn.io/81": "true"
         "service-name.acorn.io/oneimage": "true"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}]}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       hostname: oneimage

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         "globall1": "value"
         "globall2": "value"
       annotations:
-        acorn.io/container-spec: '{"annotations":{"cona3":"value"},"image":"test","labels":{"conl3":"value"},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}]}'
+        acorn.io/container-spec: '{"annotations":{"cona3":"value"},"image":"test","labels":{"conl3":"value"},"ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null}'
         "allconsa1": "value"
         "cona1": "value"
         "cona3": "value"

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
@@ -30,7 +30,7 @@ spec:
         "acorn.io/job-name": "oneimage"
         "acorn.io/managed": "true"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","targetPort":91}]}}}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
     spec:
       imagePullSecrets:
         - name: oneimage-pull-1234567890ab

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/job.yaml
@@ -35,7 +35,7 @@ spec:
         "global": "value"
         "global2": "value"
       annotations:
-        acorn.io/container-spec: '{"annotations":{"job3a":"value"},"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","labels":{"job3":"value"},"ports":[{"port":80,"protocol":"http","targetPort":81}]}'
+        acorn.io/container-spec: '{"annotations":{"job3a":"value"},"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","labels":{"job3":"value"},"ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null}'
         "alljobsa": "value"
         "job1a": "value"
         "job3a": "value"

--- a/pkg/controller/appdefinition/testdata/probes/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/probes/expected.yaml
@@ -36,7 +36,7 @@ spec:
         "port-number.acorn.io/81": "true"
         "service-name.acorn.io/oneimage": "true"
       annotations:
-        acorn.io/container-spec: '{"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"sidecars":{"left":{"image":"foo","probes":[{"http":{"headers":{"foo":"bar"},"url":"http://localhost/foo/bar"},"type":"readiness"},{"tcp":{"url":"garbage://1.1.1.1:1234/foo/bar"},"type":"startup"},{"exec":{"command":["/bin/true"]},"type":"liveness"}]}}}'
+        acorn.io/container-spec: '{"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","probes":[{"http":{"headers":{"foo":"bar"},"url":"http://localhost/foo/bar"},"type":"readiness"},{"tcp":{"url":"garbage://1.1.1.1:1234/foo/bar"},"type":"startup"},{"exec":{"command":["/bin/true"]},"type":"liveness"}]}}}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false
@@ -112,6 +112,18 @@ type: "kubernetes.io/dockerconfigjson"
 data:
   ".dockerconfigjson": eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
 ---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: nodefault-pull-1234567890ab
+  namespace: app-created-namespace
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+type: "kubernetes.io/dockerconfigjson"
+data:
+  ".dockerconfigjson": eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+---
 kind: AppInstance
 apiVersion: internal.acorn.io/v1
 metadata:
@@ -124,6 +136,13 @@ status:
   namespace: app-created-namespace
   appSpec:
     containers:
+      nodefault:
+        probes: []
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
       oneimage:
         sidecars:
           left:
@@ -150,3 +169,74 @@ status:
       reason: Success
       status: "True"
       success: true
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nodefault
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "nodefault"
+    "acorn.io/managed": "true"
+spec:
+  selector:
+    matchLabels:
+      "acorn.io/app-namespace": "app-namespace"
+      "acorn.io/app-name": "app-name"
+      "acorn.io/container-name": "nodefault"
+      "acorn.io/managed": "true"
+  template:
+    metadata:
+      labels:
+        "acorn.io/app-namespace": "app-namespace"
+        "acorn.io/app-name": "app-name"
+        "acorn.io/container-name": "nodefault"
+        "acorn.io/managed": "true"
+        "acorn.io/root-prefix": "app-name"
+        "port-number.acorn.io/81": "true"
+        "service-name.acorn.io/nodefault": "true"
+      annotations:
+        acorn.io/container-spec: '{"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":[]}'
+    spec:
+      terminationGracePeriodSeconds: 5
+      enableServiceLinks: false
+      serviceAccountName: acorn
+      hostname: nodefault
+      imagePullSecrets:
+        - name: nodefault-pull-1234567890ab
+      containers:
+        - name: nodefault
+          image: "image-name"
+          ports:
+            - containerPort: 81
+              protocol: "TCP"
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nodefault
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/managed": "true"
+    "acorn.io/service-name": "nodefault"
+    "acorn.io/container-name": "nodefault"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 81
+      protocol: "TCP"
+      appProtocol: "HTTP"
+      name: "80"
+  selector:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "service-name.acorn.io/nodefault": "true"
+    "port-number.acorn.io/81": "true"
+    "acorn.io/managed": "true"

--- a/pkg/controller/appdefinition/testdata/probes/input.yaml
+++ b/pkg/controller/appdefinition/testdata/probes/input.yaml
@@ -10,6 +10,13 @@ status:
   namespace: app-created-namespace
   appSpec:
     containers:
+      nodefault:
+        probes: []
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
       oneimage:
         sidecars:
           left:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.yaml.d/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","sidecars":{"left":{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"}}}'
+        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","probes":null,"sidecars":{"left":{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","probes":null}}}'
     spec:
       hostname: oneimage
       terminationGracePeriodSeconds: 5
@@ -65,7 +65,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"}'
+        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","probes":null}'
     spec:
       hostname: buildimage
       terminationGracePeriodSeconds: 5

--- a/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.yaml.d/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","sidecars":{"left":{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"}}}'
+        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","probes":null,"sidecars":{"left":{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","probes":null}}}'
     spec:
       hostname: oneimage
       terminationGracePeriodSeconds: 5
@@ -65,7 +65,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"}'
+        "acorn.io/container-spec": '{"image":"sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300","probes":null}'
     spec:
       hostname: buildimage
       terminationGracePeriodSeconds: 5

--- a/pkg/controller/appdefinition/testdata/secret/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/secret/expected.yaml.d/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         secret-rev.acorn.io/secret_dir_redeploy: "1"
         secret-rev.acorn.io/secret_env_redeploy: "1"
         secret-rev.acorn.io/secret_file_redeploy: "1"
-        acorn.io/container-spec: '{"dirs":{"noaction":{"secret":{"name":"secret_dir_noaction","onChange":"noAction"}},"redeploy":{"secret":{"name":"secret_dir_redeploy","onChange":"redeploy"}}},"environment":[{"name":"NOACTION","secret":{"key":"key","name":"secret_env_noaction","onChange":"noAction"}},{"name":"REDEPLOY","secret":{"key":"key","name":"secret_env_redeploy","onChange":"redeploy"}}],"files":{"mode":{"mode":"0123","secret":{"key":"key","name":"secret_file_noaction","onChange":"noAction"}},"noaction":{"secret":{"key":"key","name":"secret_file_noaction","onChange":"noAction"}},"redeploy":{"secret":{"key":"key","name":"secret_file_redeploy","onChange":"redeploy"}}},"image":"image-name"}'
+        acorn.io/container-spec: '{"dirs":{"noaction":{"secret":{"name":"secret_dir_noaction","onChange":"noAction"}},"redeploy":{"secret":{"name":"secret_dir_redeploy","onChange":"redeploy"}}},"environment":[{"name":"NOACTION","secret":{"key":"key","name":"secret_env_noaction","onChange":"noAction"}},{"name":"REDEPLOY","secret":{"key":"key","name":"secret_env_redeploy","onChange":"redeploy"}}],"files":{"mode":{"mode":"0123","secret":{"key":"key","name":"secret_file_noaction","onChange":"noAction"}},"noaction":{"secret":{"key":"key","name":"secret_file_noaction","onChange":"noAction"}},"redeploy":{"secret":{"key":"key","name":"secret_file_redeploy","onChange":"redeploy"}}},"image":"image-name","probes":null}'
     spec:
       hostname: oneimage
       terminationGracePeriodSeconds: 5

--- a/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         "con1key": "value"
         "both": "con1val"
       annotations:
-        acorn.io/container-spec: '{"annotations":{"both":"con1val","con1":"value"},"image":"foo","ports":[{"port":80,"protocol":"http","publish":true,"serviceName":"svc1","targetPort":81},{"port":80,"protocol":"http","targetPort":81},{"port":90,"protocol":"tcp","serviceName":"svc1","targetPort":91}]}'
+        acorn.io/container-spec: '{"annotations":{"both":"con1val","con1":"value"},"image":"foo","ports":[{"port":80,"protocol":"http","publish":true,"serviceName":"svc1","targetPort":81},{"port":80,"protocol":"http","targetPort":81},{"port":90,"protocol":"tcp","serviceName":"svc1","targetPort":91}],"probes":null}'
         "con1": "value"
         "both": "con1val"
     spec:
@@ -94,7 +94,7 @@ spec:
         "con2key": "value"
         "both": "con2val"
       annotations:
-        acorn.io/container-spec: '{"annotations":{"both":"con2val","con2":"value"},"image":"foo","ports":[{"port":80,"protocol":"http","publish":true,"serviceName":"svc1","targetPort":81},{"port":80,"protocol":"tcp","targetPort":81},{"port":90,"protocol":"tcp","serviceName":"svc1","targetPort":91}]}'
+        acorn.io/container-spec: '{"annotations":{"both":"con2val","con2":"value"},"image":"foo","ports":[{"port":80,"protocol":"http","publish":true,"serviceName":"svc1","targetPort":81},{"port":80,"protocol":"tcp","targetPort":81},{"port":90,"protocol":"tcp","serviceName":"svc1","targetPort":91}],"probes":null}'
         "con2": "value"
         "both": "con2val"
     spec:
@@ -145,7 +145,7 @@ spec:
         "service-name.acorn.io/con3": "true"
         "service-name.acorn.io/svc2": "true"
       annotations:
-        acorn.io/container-spec: '{"image":"foo","ports":[{"port":100,"protocol":"udp","publish":true,"serviceName":"svc2","targetPort":101},{"port":100,"protocol":"udp","targetPort":101}]}'
+        acorn.io/container-spec: '{"image":"foo","ports":[{"port":100,"protocol":"udp","publish":true,"serviceName":"svc2","targetPort":101},{"port":100,"protocol":"udp","targetPort":101}],"probes":null}'
     spec:
       hostname: con3
       terminationGracePeriodSeconds: 5

--- a/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         "port-number.acorn.io/91": "true"
         "port-number.acorn.io/81": "true"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}]}}}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}}}'
     spec:
       hostname: oneimage
       terminationGracePeriodSeconds: 5
@@ -82,7 +82,7 @@ spec:
         "port-number.acorn.io/81": "true"
         "port-number.acorn.io/91": "true"
       annotations:
-        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}]}'
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"custom-dockerfile"},"image":"sha256:build-image","ports":[{"port":80,"protocol":"http","publish":true,"targetPort":81},{"port":443,"protocol":"tcp","publish":true,"targetPort":91}],"probes":null}'
     spec:
       hostname: buildimage
       terminationGracePeriodSeconds: 5

--- a/pkg/controller/appdefinition/testdata/template/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/template/expected.yaml.d/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"image":"image-name"}'
+        acorn.io/container-spec: '{"image":"image-name","probes":null}'
     spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
@@ -38,7 +38,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name"}'
+        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","probes":null}'
     spec:
       imagePullSecrets:
         - name: container-name-pull-1234567890ab

--- a/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.yaml
@@ -35,7 +35,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"build":{"baseImage":"image-name","context":".","contextDirs":{"/var/tmp":"./foo"},"dockerfile":"Dockerfile"},"dirs":{"/var/tmp":{"contextDir":"./foo","secret":{}}},"image":"image-name"}'
+        acorn.io/container-spec: '{"build":{"baseImage":"image-name","context":".","contextDirs":{"/var/tmp":"./foo"},"dockerfile":"Dockerfile"},"dirs":{"/var/tmp":{"contextDir":"./foo","secret":{}}},"image":"image-name","probes":null}'
         acorn.io/image-mapping: '{"image-name":"image-name"}'
     spec:
       hostname: container-name

--- a/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
@@ -38,7 +38,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name"}'
+        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","probes":null}'
     spec:
       imagePullSecrets:
         - name: container-name-pull-1234567890ab

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
@@ -35,7 +35,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name"}'
+        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","probes":null}'
     spec:
       hostname: container-name
       imagePullSecrets:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.yaml
@@ -35,7 +35,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name"}'
+        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","probes":null}'
     spec:
       hostname: container-name
       imagePullSecrets:

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
@@ -38,7 +38,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name"}'
+        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","probes":null}'
     spec:
       imagePullSecrets:
         - name: container-name-pull-1234567890ab

--- a/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
@@ -38,7 +38,7 @@ spec:
         "acorn.io/managed": "true"
         "acorn.io/root-prefix": "app-name"
       annotations:
-        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name"}'
+        acorn.io/container-spec: '{"dirs":{"/var/tmp":{"secret":{},"volume":"foo"}},"image":"image-name","probes":null}'
     spec:
       imagePullSecrets:
         - name: container-name-pull-1234567890ab

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -3368,7 +3368,8 @@ func schema_pkg_apis_internalacornio_v1_Container(ref common.ReferenceCallback) 
 					},
 					"dependencies": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Don't omitempty so that nil vs empty is recorded",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -3421,6 +3422,7 @@ func schema_pkg_apis_internalacornio_v1_Container(ref common.ReferenceCallback) 
 						},
 					},
 				},
+				Required: []string{"probes"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
By default if there are no probes defined acorn will create a TCP probe
to the first open port. This can now be disabled by settings probes to
explicitly zero with probes: {} or probes: []

Signed-off-by: Darren Shepherd <darren@acorn.io>
