### PR TITLE
Issue 664 traefik service namespace

### DIFF
--- a/pkg/install/traefik.yaml
+++ b/pkg/install/traefik.yaml
@@ -207,6 +207,7 @@ items:
     kind: Service
     metadata:
       name: traefik
+      namespace: acorn-system
       labels:
         app.kubernetes.io/name: traefik
         app.kubernetes.io/managed-by: Acorn

--- a/pkg/uninstall/uninstall.go
+++ b/pkg/uninstall/uninstall.go
@@ -233,7 +233,7 @@ func Uninstall(ctx context.Context, opts *Options) error {
 		apiVersion, kind := resource.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 		pterm.Info.Printf("Deleting %s %s %s\n", key(resource), kind, apiVersion)
 		if err := c.Delete(ctx, resource); err != nil && !apierror.IsNotFound(err) {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("failed to delete %s %s: %w", kind, key(resource), err))
 		}
 	}
 


### PR DESCRIPTION
Small change to add a missing namespace to the Traefik `Service` resource and improve the error messages when deleting during an uninstall which helps identify the other issue.