### PR TITLE
add acorn run --update/-u flag to update app if exists

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -68,6 +68,7 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
   -q, --quiet                     Do not print status
   -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
       --target-namespace string   The name of the namespace to be created and deleted for the application resources
+  -u, --update                    Update the app if it already exists
   -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
       --wait                      Wait for app to become ready before command exiting (default true)
 ```

--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -25,6 +25,7 @@ acorn update [flags] APP_NAME [deploy flags]
       --profile strings           Profile to assign default values
   -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
   -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
+      --reset                     
   -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
       --target-namespace string   The name of the namespace to be created and deleted for the application resources
   -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)

--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -25,7 +25,7 @@ acorn update [flags] APP_NAME [deploy flags]
       --profile strings           Profile to assign default values
   -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
   -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
-      --reset                     
+      --replace                   Toggle replacing update, resetting undefined fields to default values
   -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
       --target-namespace string   The name of the namespace to be created and deleted for the application resources
   -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -265,7 +265,13 @@ func (s *Run) Run(cmd *cobra.Command, args []string) error {
 			RunArgs: s.RunArgs,
 			out:     s.out,
 		}
-		return u.Run(cmd, append([]string{s.Name}, args...))
+		err := u.Run(cmd, append([]string{s.Name}, args...))
+		if err != nil {
+			return err
+		}
+		if s.Wait == nil || *s.Wait {
+			return wait.App(cmd.Context(), c, s.Name, s.Quiet)
+		}
 	}
 
 	if len(args) > 1 {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -264,7 +264,7 @@ func (s *Run) Run(cmd *cobra.Command, args []string) error {
 			Image:   image,
 			RunArgs: s.RunArgs,
 			out:     s.out,
-			Reset:   true,
+			Replace: true,
 		}
 		err := u.Run(cmd, append([]string{s.Name}, args...))
 		if err != nil {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -264,6 +264,7 @@ func (s *Run) Run(cmd *cobra.Command, args []string) error {
 			Image:   image,
 			RunArgs: s.RunArgs,
 			out:     s.out,
+			Reset:   true,
 		}
 		err := u.Run(cmd, append([]string{s.Name}, args...))
 		if err != nil {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/wait"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/yaml"
 )
 
@@ -73,6 +74,7 @@ type Run struct {
 	BidirectionalSync bool  `usage:"In interactive mode download changes in addition to uploading" short:"b"`
 	Wait              *bool `usage:"Wait for app to become ready before command exiting (default true)"`
 	Quiet             bool  `usage:"Do not print status" short:"q"`
+	Update            bool  `usage:"Update the app if it already exists" short:"u"`
 
 	out io.Writer
 }
@@ -193,6 +195,26 @@ func (s *Run) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Update mode -> early exits on invalid combinations
+	if s.Update {
+		if s.Interactive {
+			return fmt.Errorf("cannot use --update/-u with --dev/-i")
+		}
+		if s.Name == "" {
+			return fmt.Errorf("--name/-n NAME is required when updating an app")
+		}
+
+		// unset update mode if app does not exist
+		_, err := c.AppGet(cmd.Context(), s.Name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				s.Update = false
+			} else {
+				return err
+			}
+		}
+	}
+
 	opts, err := s.ToOpts()
 	if err != nil {
 		return err
@@ -235,6 +257,15 @@ func (s *Run) Run(cmd *cobra.Command, args []string) error {
 		} else if err != nil {
 			return err
 		}
+	}
+
+	if s.Update {
+		u := Update{
+			Image:   image,
+			RunArgs: s.RunArgs,
+			out:     s.out,
+		}
+		return u.Run(cmd, append([]string{s.Name}, args...))
 	}
 
 	if len(args) > 1 {

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -26,6 +26,7 @@ func NewUpdate(out io.Writer) *cobra.Command {
 
 type Update struct {
 	Image string `json:"image,omitempty"`
+	Reset bool   `json:"reset,omitempty"` // Reset sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
 	RunArgs
 
 	out io.Writer
@@ -68,6 +69,9 @@ func (s *Update) Run(cmd *cobra.Command, args []string) error {
 	opts := runOpts.ToUpdate()
 	opts.Image = image
 	opts.DeployArgs = deployParams
+
+	// Overwrite == true means patchMode == false
+	opts.Reset = s.Reset
 
 	if s.Output != "" {
 		app, err := client.ToAppUpdate(cmd.Context(), c, name, &opts)

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -25,8 +25,8 @@ func NewUpdate(out io.Writer) *cobra.Command {
 }
 
 type Update struct {
-	Image string `json:"image,omitempty"`
-	Reset bool   `json:"reset,omitempty"` // Reset sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
+	Image   string `json:"image,omitempty"`
+	Replace bool   `usage:"Toggle replacing update, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
 	RunArgs
 
 	out io.Writer
@@ -71,7 +71,7 @@ func (s *Update) Run(cmd *cobra.Command, args []string) error {
 	opts.DeployArgs = deployParams
 
 	// Overwrite == true means patchMode == false
-	opts.Reset = s.Reset
+	opts.Replace = s.Replace
 
 	if s.Output != "" {
 		app, err := client.ToAppUpdate(cmd.Context(), c, name, &opts)

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -90,19 +90,14 @@ func ToAppUpdate(ctx context.Context, c Client, name string, opts *AppUpdateOpti
 		app.Spec.Image = opts.Image
 	}
 
-	// Reset Mode (Not patch mode)
-	if opts.Reset {
-
+	// Replace/Reset Mode (Not patch mode)
+	if opts.Replace {
 		o := opts.ToRun()
-
 		nApp := ToApp(app.Namespace, opts.Image, &o)
-
 		nApp.Name = app.Name
 		nApp.ObjectMeta.UID = app.ObjectMeta.UID
 		nApp.ObjectMeta.ResourceVersion = app.ObjectMeta.ResourceVersion
-
 		return nApp, nil
-
 	}
 
 	app.Labels = typed.Concat(app.Labels, appScoped(opts.Labels))

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -76,6 +76,7 @@ func (c *client) AppUpdate(ctx context.Context, name string, opts *AppUpdateOpti
 }
 
 func ToAppUpdate(ctx context.Context, c Client, name string, opts *AppUpdateOptions) (*apiv1.App, error) {
+
 	app, err := c.AppGet(ctx, name)
 	if err != nil {
 		return nil, err
@@ -87,6 +88,21 @@ func ToAppUpdate(ctx context.Context, c Client, name string, opts *AppUpdateOpti
 
 	if opts.Image != "" {
 		app.Spec.Image = opts.Image
+	}
+
+	// Reset Mode (Not patch mode)
+	if opts.Reset {
+
+		o := opts.ToRun()
+
+		nApp := ToApp(app.Namespace, opts.Image, &o)
+
+		nApp.Name = app.Name
+		nApp.ObjectMeta.UID = app.ObjectMeta.UID
+		nApp.ObjectMeta.ResourceVersion = app.ObjectMeta.ResourceVersion
+
+		return nApp, nil
+
 	}
 
 	app.Labels = typed.Concat(app.Labels, appScoped(opts.Labels))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -101,6 +101,7 @@ type AppUpdateOptions struct {
 	DevMode         *bool
 	Image           string
 	TargetNamespace string
+	Reset           bool // Reset is used to indicate whether the update should be a patch (reset=false: only change specified fields) or a full update (reset=true: reset unspecified fields to defaults)
 }
 
 type LogOptions apiv1.LogOptions
@@ -124,6 +125,24 @@ type AppRunOptions struct {
 
 func (a AppRunOptions) ToUpdate() AppUpdateOptions {
 	return AppUpdateOptions{
+		Annotations:     a.Annotations,
+		Labels:          a.Labels,
+		PublishMode:     a.PublishMode,
+		Volumes:         a.Volumes,
+		Secrets:         a.Secrets,
+		Links:           a.Links,
+		Ports:           a.Ports,
+		DeployArgs:      a.DeployArgs,
+		DevMode:         a.DevMode,
+		Profiles:        a.Profiles,
+		Permissions:     a.Permissions,
+		Env:             a.Env,
+		TargetNamespace: a.TargetNamespace,
+	}
+}
+
+func (a AppUpdateOptions) ToRun() AppRunOptions {
+	return AppRunOptions{
 		Annotations:     a.Annotations,
 		Labels:          a.Labels,
 		PublishMode:     a.PublishMode,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -101,7 +101,7 @@ type AppUpdateOptions struct {
 	DevMode         *bool
 	Image           string
 	TargetNamespace string
-	Reset           bool // Reset is used to indicate whether the update should be a patch (reset=false: only change specified fields) or a full update (reset=true: reset unspecified fields to defaults)
+	Replace         bool // Replace is used to indicate whether the update should be a patch (replace=false: only change specified fields) or a full update (replace=true: reset unspecified fields to defaults)
 }
 
 type LogOptions apiv1.LogOptions


### PR DESCRIPTION
- triggers acorn update logic if app exists
- does not work with --dev/-i
- requires --name/-n to be specified

Ref #466 

## Notes

- This is not 100% like `kubectl apply`, as that one does a 3-way patch merge, where it takes into account the `last-applied-configuration` annotation. This PR does not consider such annotations.