### PR TITLE
Require to hit enter on TOS prompt

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -17,6 +17,7 @@ import (
 	k8sclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	labels2 "github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/podstatus"
+	"github.com/acorn-io/acorn/pkg/prompt"
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/acorn/pkg/term"
 	"github.com/acorn-io/acorn/pkg/version"
@@ -118,7 +119,7 @@ func Install(ctx context.Context, image string, opts *Options) error {
 	// Require E-Mail address when using Let's Encrypt production
 	if opts.Config.LetsEncrypt != nil && *opts.Config.LetsEncrypt == "enabled" {
 		if opts.Config.LetsEncryptTOSAgree == nil || !*opts.Config.LetsEncryptTOSAgree {
-			ok, err := pterm.DefaultInteractiveConfirm.Show("You are choosing to enable Let's Encrypt for TLS certificates. To do so, you must agree to their Terms of Service: https://community.letsencrypt.org/tos\nTip: use --lets-encrypt-tos-agree to skip this prompt\nDo you agree to Let's Encrypt TOS?")
+			ok, err := prompt.Bool("You are choosing to enable Let's Encrypt for TLS certificates. To do so, you must agree to their Terms of Service: https://community.letsencrypt.org/tos\nTip: use --lets-encrypt-tos-agree to skip this prompt\nDo you agree to Let's Encrypt TOS?", false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
If enabling Let's Encrypt, we need to ask the user if they agree to
Let's Encrypt's TOS. Previously, the prompt would continue as soon as
you entered 'y'. If you instinctively followed that with 'enter', the
enter applied to the next prompt, which then failed.

Signed-off-by: Craig Jellick <craig@acorn.io>
