### PR TITLE
fix nil pointer deference in Prompt install if first action is run dev mode

### DIFF
--- a/pkg/client/ignore.go
+++ b/pkg/client/ignore.go
@@ -35,7 +35,7 @@ func promptInstall[V any](ctx context.Context, f twoFunc[V]) (V, error) {
 		}
 
 		if shouldInstall {
-			installErr := install.Install(ctx, install.DefaultImage(), nil)
+			installErr := install.Install(ctx, install.DefaultImage(), &install.Options{})
 			if installErr != nil {
 				return v, installErr
 			}


### PR DESCRIPTION
Fix #515 
Signed-off-by: Mohamed Eldafrawi <mohamed@acorn.io>