### PR TITLE
Set ingress class name when we need it

### DIFF
--- a/pkg/install/check.go
+++ b/pkg/install/check.go
@@ -10,6 +10,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/client/term"
 	"github.com/acorn-io/acorn/pkg/k8schannel"
 	"github.com/acorn-io/acorn/pkg/k8sclient"
+	"github.com/acorn-io/acorn/pkg/publish"
 	"github.com/acorn-io/acorn/pkg/scheme"
 	"github.com/acorn-io/acorn/pkg/streams"
 	"github.com/acorn-io/acorn/pkg/system"
@@ -324,6 +325,13 @@ func CheckIngressCapability(ctx context.Context, opts CheckOptions) CheckResult 
 		},
 	}
 
+	ingressClassName, err := publish.IngressClassNameIfNoDefault(ctx, cli)
+	if err != nil {
+		result.Passed = false
+		result.Message = fmt.Sprintf("Error ingress class: %v", err)
+		return result
+	}
+
 	// Create a new ingress object
 	pt := networkingv1.PathTypeImplementationSpecific
 	ing := &networkingv1.Ingress{
@@ -332,6 +340,7 @@ func CheckIngressCapability(ctx context.Context, opts CheckOptions) CheckResult 
 			Namespace: *opts.Namespace,
 		},
 		Spec: networkingv1.IngressSpec{
+			IngressClassName: ingressClassName,
 			Rules: []networkingv1.IngressRule{
 				{
 					Host: "inflight-check.acorn.io",

--- a/pkg/install/role.yaml
+++ b/pkg/install/role.yaml
@@ -37,6 +37,10 @@ rules:
     apiGroups: ["networking.k8s.io"]
     resources:
       - ingresses
+  - verbs: ["get", "list", "watch"]
+    apiGroups: ["networking.k8s.io"]
+    resources:
+    - ingressclasses
   - verbs: ["*"]
     apiGroups: ["batch"]
     resources:


### PR DESCRIPTION
A common scenario we see is that even though ingress-nginx is installed,
it isn't set as the default ingress class. In this case, when we create an
ingress, it never gets picked up.

So, to make ingress work in this scenario, if we detect that the cluster
has exactly one ingressClass and it isn't set at the default, we are
just going to assume the user wants to use it and set it when we create
an ingress.

Bonus: found a bug where if Docker Desktop has an ingress already
installed, we still set acorn's ingress class name to "traefik". We
should only set the ingressClassName field for Docker Desktop if we are
installing traefik.

Signed-off-by: Craig Jellick <craig@acorn.io>
