### PR TITLE
updating to go1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/acorn-io/acorn
 
-go 1.18
+go 1.19
 
 replace (
 	cloud.google.com/go v0.93.3 => cloud.google.com/go v0.100.2


### PR DESCRIPTION
can't actually compile acorn with go1.18 any more due to this

```
..\..\go\pkg\mod\github.com\acorn-io\baaah@v0.0.0-20221014212228-a04e8e4a639a\pkg\lasso\backend.go:29:22: undefined: atomic.Bool
```

updating go.mod to reflect that
