### PR TITLE
feat: Add "-n --tail" and "-s --since" to acorn logs to limit outputted lines by num and time

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_logs.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logs.md
@@ -15,7 +15,7 @@ acorn logs [flags] APP_NAME|CONTAINER_NAME
   -f, --follow         Follow log output
   -h, --help           help for logs
   -s, --since string   Show logs since timestamp (e.g. 42m for 42 minutes)
-  -n, --tail-lines int   Number of lines in log output
+  -n, --tail int       Number of lines in log output
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/100-reference/01-command-line/acorn_logs.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logs.md
@@ -12,8 +12,9 @@ acorn logs [flags] APP_NAME|CONTAINER_NAME
 ### Options
 
 ```
-  -f, --follow           Follow log output
-  -h, --help             help for logs
+  -f, --follow         Follow log output
+  -h, --help           help for logs
+  -s, --since string   Show logs since timestamp (e.g. 42m for 42 minutes)
   -n, --tail-lines int   Number of lines in log output
 ```
 

--- a/docs/docs/100-reference/01-command-line/acorn_logs.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logs.md
@@ -12,8 +12,9 @@ acorn logs [flags] APP_NAME|CONTAINER_NAME
 ### Options
 
 ```
-  -f, --follow   Follow log output
-  -h, --help     help for logs
+  -f, --follow           Follow log output
+  -h, --help             help for logs
+  -n, --tail-lines int   Number of lines in log output
 ```
 
 ### Options inherited from parent commands

--- a/pkg/apis/api.acorn.io/v1/conversion.go
+++ b/pkg/apis/api.acorn.io/v1/conversion.go
@@ -37,8 +37,8 @@ func Convert_url_Values_To__ContainerReplicaExecOptions(in, out interface{}, s c
 
 func convert_url_Values_To__LogOptions(in *url.Values, out *LogOptions, s conversion.Scope) error {
 	if values, ok := map[string][]string(*in)["tailLines"]; ok && len(values) > 0 {
-		out.TailLines = new(int64)
-		if err := runtime.Convert_Slice_string_To_int64(&values, out.TailLines, s); err != nil {
+		out.Tail = new(int64)
+		if err := runtime.Convert_Slice_string_To_int64(&values, out.Tail, s); err != nil {
 			return err
 		}
 	}

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -131,6 +131,7 @@ type LogOptions struct {
 	TailLines        *int64 `json:"tailLines,omitempty"`
 	Follow           bool   `json:"follow,omitempty"`
 	ContainerReplica string `json:"containerReplica,omitempty"`
+	Since            string `json:"since,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -128,7 +128,7 @@ type LogMessage struct {
 type LogOptions struct {
 	metav1.TypeMeta `json:",inline"`
 
-	TailLines        *int64 `json:"tailLines,omitempty"`
+	Tail             *int64 `json:"tailLines,omitempty"`
 	Follow           bool   `json:"follow,omitempty"`
 	ContainerReplica string `json:"containerReplica,omitempty"`
 	Since            string `json:"since,omitempty"`

--- a/pkg/apis/api.acorn.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/api.acorn.io/v1/zz_generated.deepcopy.go
@@ -761,8 +761,8 @@ func (in *LogMessage) DeepCopy() *LogMessage {
 func (in *LogOptions) DeepCopyInto(out *LogOptions) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.TailLines != nil {
-		in, out := &in.TailLines, &out.TailLines
+	if in.Tail != nil {
+		in, out := &in.Tail, &out.Tail
 		*out = new(int64)
 		**out = **in
 	}

--- a/pkg/cli/builder/builder.go
+++ b/pkg/cli/builder/builder.go
@@ -124,6 +124,8 @@ func Command(obj Runnable, cmd cobra.Command) *cobra.Command {
 		switch fieldType.Type.Kind() {
 		case reflect.Int:
 			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
+		case reflect.Int64:
+			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
 		case reflect.String:
 			flags.StringVarP((*string)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defValue, usage)
 		case reflect.Slice:

--- a/pkg/cli/log.go
+++ b/pkg/cli/log.go
@@ -20,7 +20,7 @@ func NewLogs() *cobra.Command {
 type Logs struct {
 	Follow bool   `short:"f" usage:"Follow log output"`
 	Since  string `short:"s" usage:"Show logs since timestamp (e.g. 42m for 42 minutes)"`
-	TailLines int64 `short:"n" usage:"Number of lines in log output"`
+	Tail   int64  `short:"n" usage:"Number of lines in log output"`
 }
 
 func (s *Logs) Run(cmd *cobra.Command, args []string) error {
@@ -29,15 +29,17 @@ func (s *Logs) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	var tailLines *int64
-	if s.TailLines < 0 {
-		err := fmt.Errorf("TailLines: Invalid value: %d: must be greater than or equal to 0", s.TailLines)
+	if s.Tail < 0 {
+		err := fmt.Errorf("Tail: Invalid value: %d: must be greater than or equal to 0", s.Tail)
 		return err
+	} else if s.Tail == 0 {
+		tailLines = nil
 	} else {
-		tailLines = &s.TailLines
+		tailLines = &s.Tail
 	}
 	return log.Output(cmd.Context(), c, args[0], &client.LogOptions{
-		Follow:    s.Follow,
-		TailLines: tailLines,
+		Follow: s.Follow,
+		Tail:   tailLines,
 		Since:  s.Since,
 	})
 }

--- a/pkg/cli/log.go
+++ b/pkg/cli/log.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/acorn-io/acorn/pkg/log"
@@ -17,7 +18,8 @@ func NewLogs() *cobra.Command {
 }
 
 type Logs struct {
-	Follow bool `short:"f" usage:"Follow log output"`
+	Follow    bool  `short:"f" usage:"Follow log output"`
+	TailLines int64 `short:"n" usage:"Number of lines in log output"`
 }
 
 func (s *Logs) Run(cmd *cobra.Command, args []string) error {
@@ -25,8 +27,15 @@ func (s *Logs) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
+	var tailLines *int64
+	if s.TailLines < 0 {
+		err := fmt.Errorf("TailLines: Invalid value: %d: must be greater than or equal to 0", s.TailLines)
+		return err
+	} else {
+		tailLines = &s.TailLines
+	}
 	return log.Output(cmd.Context(), c, args[0], &client.LogOptions{
-		Follow: s.Follow,
+		Follow:    s.Follow,
+		TailLines: tailLines,
 	})
 }

--- a/pkg/cli/log.go
+++ b/pkg/cli/log.go
@@ -18,7 +18,8 @@ func NewLogs() *cobra.Command {
 }
 
 type Logs struct {
-	Follow    bool  `short:"f" usage:"Follow log output"`
+	Follow bool   `short:"f" usage:"Follow log output"`
+	Since  string `short:"s" usage:"Show logs since timestamp (e.g. 42m for 42 minutes)"`
 	TailLines int64 `short:"n" usage:"Number of lines in log output"`
 }
 
@@ -37,5 +38,6 @@ func (s *Logs) Run(cmd *cobra.Command, args []string) error {
 	return log.Output(cmd.Context(), c, args[0], &client.LogOptions{
 		Follow:    s.Follow,
 		TailLines: tailLines,
+		Since:  s.Since,
 	})
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -69,7 +69,7 @@ type Options struct {
 	RestConfig       *rest.Config
 	Client           client.WithWatch
 	PodClient        v12.PodsGetter
-	TailLines        *int64
+	Tail             *int64
 	Follow           bool
 	ContainerReplica string
 }
@@ -159,9 +159,9 @@ func Container(ctx context.Context, pod *corev1.Pod, name string, output chan<- 
 	}
 
 	var (
-		first     = true
-		since     *metav1.Time
-		tailLines = options.TailLines
+		first = true
+		since *metav1.Time
+		tail  = options.Tail
 	)
 
 	for {
@@ -190,7 +190,7 @@ func Container(ctx context.Context, pod *corev1.Pod, name string, output chan<- 
 			Follow:     options.Follow,
 			SinceTime:  since,
 			Timestamps: true,
-			TailLines:  tailLines,
+			TailLines:  tail,
 		})
 		readCloser, err := req.Stream(ctx)
 		if err != nil {
@@ -223,7 +223,7 @@ func Container(ctx context.Context, pod *corev1.Pod, name string, output chan<- 
 		}
 		if lastTS != nil {
 			since = lastTS
-			tailLines = nil
+			tail = nil
 		}
 
 		if !options.Follow {

--- a/pkg/log/output.go
+++ b/pkg/log/output.go
@@ -2,11 +2,12 @@ package log
 
 import (
 	"context"
-	"strings"
-
+	v1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
+	"strings"
+	"time"
 )
 
 var (
@@ -36,18 +37,35 @@ func Output(ctx context.Context, c client.Client, name string, opts *client.LogO
 	containerColors := map[string]pterm.Color{}
 
 	for msg := range msgs {
-		if msg.Error == "" {
-			color, ok := containerColors[msg.ContainerName]
-			if !ok {
-				color = nextColor()
-				containerColors[msg.ContainerName] = color
-			}
+		result, err := SinceLogCheck(opts.Since, msg)
+		if err != nil {
+			return err
+		}
+		if result {
+			if msg.Error == "" {
+				color, ok := containerColors[msg.ContainerName]
+				if !ok {
+					color = nextColor()
+					containerColors[msg.ContainerName] = color
+				}
 
-			pterm.Printf("%s: %s\n", color.Sprint(msg.ContainerName), msg.Line)
-		} else if !strings.Contains(msg.Error, "context canceled") {
-			logrus.Error(msg.Error)
+				pterm.Printf("%s: %s\n", color.Sprint(msg.ContainerName), msg.Line)
+			} else if !strings.Contains(msg.Error, "context canceled") {
+				logrus.Error(msg.Error)
+			}
 		}
 	}
 
 	return nil
+}
+
+func SinceLogCheck(since string, msg v1.LogMessage) (bool, error) {
+	if since == "" {
+		return true, nil
+	}
+	beforeTime, err := time.ParseDuration(since)
+	if err != nil {
+		return false, err
+	}
+	return msg.Time.After(time.Now().Add(-beforeTime)), nil
 }

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -1826,6 +1826,12 @@ func schema_pkg_apis_apiacornio_v1_LogOptions(ref common.ReferenceCallback) comm
 							Format: "",
 						},
 					},
+					"since": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/server/registry/apps/logs.go
+++ b/pkg/server/registry/apps/logs.go
@@ -66,7 +66,7 @@ func (i *Logs) Connect(ctx context.Context, id string, options runtime.Object, r
 		err := log.App(ctx, app, output, &log.Options{
 			Client:           i.client,
 			PodClient:        i.k8s.CoreV1(),
-			TailLines:        opts.TailLines,
+			Tail:             opts.Tail,
 			Follow:           opts.Follow,
 			ContainerReplica: opts.ContainerReplica,
 		})


### PR DESCRIPTION
Issue: #518 
Signed-off-by: Joshua Silverio <joshua@acorn.io>