### PR TITLE
fix: Make Get logic use existing Exist logic

### DIFF
--- a/pkg/build/buildkit/deploy.go
+++ b/pkg/build/buildkit/deploy.go
@@ -61,19 +61,19 @@ func SyncBuildkitPod(ctx context.Context, client client.Client) error {
 }
 
 func GetBuildkitPod(ctx context.Context, client client.WithWatch) (int, *corev1.Pod, error) {
-	port, err := getRegistryPort(ctx, client)
-	if err == nil {
-		err = checkDeployment(ctx, client)
+	ok, err := Exists(ctx, client)
+	if err != nil {
+		return 0, nil, err
 	}
-	if apierror.IsNotFound(err) {
+
+	if !ok {
 		err = applyObjects(ctx)
 		if err != nil {
 			return 0, nil, err
 		}
-
-		port, err = getRegistryPort(ctx, client)
-
 	}
+
+	port, err := getRegistryPort(ctx, client)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/pkg/build/buildkit/template.go
+++ b/pkg/build/buildkit/template.go
@@ -21,11 +21,6 @@ func GetRegistryPort(ctx context.Context, c client.Reader) (int, error) {
 	return getRegistryPort(ctx, c)
 }
 
-func checkDeployment(ctx context.Context, c client.Reader) error {
-	var dep appsv1.Deployment
-	return c.Get(ctx, client.ObjectKey{Name: system.BuildKitName, Namespace: system.Namespace}, &dep)
-}
-
 func checkControllerDeployment(ctx context.Context, c client.Reader) error {
 	var dep appsv1.Deployment
 	return c.Get(ctx, client.ObjectKey{Name: system.ControllerName, Namespace: system.Namespace}, &dep)


### PR DESCRIPTION
The get logic was slightly different than exist causes builds
to fail if the containerd daemonset was manually deleted.

Signed-off-by: Darren Shepherd <darren@acorn.io>
