### PR TITLE
Automatic Let's Encrypt certificates for user-provided domains

### DIFF
--- a/pkg/controller/dns/config.go
+++ b/pkg/controller/dns/config.go
@@ -97,8 +97,10 @@ func (h *configHandler) Handle(req router.Request, resp router.Response) error {
 		return err
 	}
 
-	if err := tls.ProvisionWildcardCert(req, cfg, domain, token); err != nil {
-		return err
+	if !strings.EqualFold(*cfg.LetsEncrypt, "disabled") {
+		if err := tls.ProvisionWildcardCert(req, domain, token); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/controller/dns/config.go
+++ b/pkg/controller/dns/config.go
@@ -6,6 +6,7 @@ import (
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/acorn/pkg/controller/tls"
 	"github.com/acorn-io/acorn/pkg/dns"
 	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/system"
@@ -96,19 +97,8 @@ func (h *configHandler) Handle(req router.Request, resp router.Response) error {
 		return err
 	}
 
-	// Let's Encrypt wildcard certificate for *.<domain>.on-acorn.io
-	if !strings.EqualFold(*cfg.LetsEncrypt, "disabled") {
-		// Ensure that we have a Let's Encrypt account ready
-		leUser, err := ensureLEUser(req.Ctx, cfg, req.Client, domain)
-		if err != nil {
-			return err
-		}
-
-		// Generate wildcard certificate for domain
-		_, err = leUser.ensureWildcardCertificateSecret(req.Ctx, req.Client, *cfg.AcornDNSEndpoint, domain, token)
-		if err != nil {
-			return err
-		}
+	if err := tls.ProvisionWildcardCert(req, cfg, domain, token); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -53,5 +53,5 @@ func routes(router *router.Router) {
 	router.Type(&corev1.Pod{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).Middleware(dns.RequireLBs).Handler(dns.NewDNSHandler())
 	router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName).Handler(dns.NewDNSConfigHandler())
-	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).Middleware(tls.IgnoreWildcardCertSecret).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, excluding the on-acorn.io wildcard cert
+	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, including the on-acorn.io wildcard cert
 }

--- a/pkg/controller/tls/certs.go
+++ b/pkg/controller/tls/certs.go
@@ -1,0 +1,126 @@
+package tls
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/labels"
+	"github.com/acorn-io/baaah/pkg/router"
+	"github.com/rancher/wrangler/pkg/name"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func ProvisionWildcardCert(req router.Request, cfg *apiv1.Config, domain, token string) error {
+	// Let's Encrypt wildcard certificate for *.<domain>.on-acorn.io
+	if !strings.EqualFold(*cfg.LetsEncrypt, "disabled") {
+		// Ensure that we have a Let's Encrypt account ready
+		leUser, err := ensureLEUser(req.Ctx, cfg, req.Client, domain)
+		if err != nil {
+			return err
+		}
+
+		// Generate wildcard certificate for domain
+		_, err = leUser.ensureWildcardCertificateSecret(req.Ctx, req.Client, *cfg.AcornDNSEndpoint, domain, token)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RequireSecretTypeTLS is a middleware that ensures that we only act on TLS-Type secrets
+func RequireSecretTypeTLS(h router.Handler) router.Handler {
+	return router.HandlerFunc(func(req router.Request, resp router.Response) error {
+		sec := req.Object.(*corev1.Secret)
+
+		if sec.Type != corev1.SecretTypeTLS {
+			return nil
+		}
+
+		return h.Handle(req, resp)
+	})
+}
+
+// IgnoreWildcardCertSecret is a middleware that ignores the on-acorn.io wildcard cert secrets
+func IgnoreWildcardCertSecret(h router.Handler) router.Handler {
+	return router.HandlerFunc(func(req router.Request, resp router.Response) error {
+		sec := req.Object.(*corev1.Secret)
+		if v, ok := sec.Annotations[labels.AcornDomain]; ok {
+			if strings.HasSuffix(v, "on-acorn.io") {
+				return nil
+			}
+		}
+		return h.Handle(req, resp)
+	})
+}
+
+// RenewCert handles the renewal of existing TLS certificates
+func RenewCert(req router.Request, resp router.Response) error {
+	logrus.Infof("Renewing TLS cert for %v", req.Key)
+	return nil
+}
+
+// ProvisionCerts handles the provisioning of new TLS certificates for AppInstances
+// Note: this does not actually provision the certificates, it just creates the empty secret
+// which is picked up by the route handled by RenewCert above
+func ProvisionCerts(req router.Request, resp router.Response) error {
+	appInstance := req.Object.(*v1.AppInstance)
+
+	appInstanceIDSegment := strings.SplitN(string(appInstance.GetUID()), "-", 2)[0]
+
+	// FIXME: use error list instead of exiting on first error?
+	for _, pb := range appInstance.Spec.Ports {
+		// Skip: name empty, not FQDN, already covered by on-acorn.io
+		if pb.ServiceName == "" || len(validation.IsFullyQualifiedDomainName(&field.Path{}, pb.ServiceName)) > 0 || strings.HasSuffix(pb.ServiceName, "on-acorn.io") {
+			continue
+		}
+
+		secretName := name.Limit(appInstance.GetName()+"-tls-"+pb.ServiceName, 63-len(appInstanceIDSegment)-1) + "-" + appInstanceIDSegment
+		logrus.Infof("Provisioning TLS cert for %v in secret %s/%s", pb.ServiceName, appInstance.Namespace, secretName)
+
+		// Find existing secret if exists
+		existingSecret := &corev1.Secret{}
+		findSecretErr := req.Client.Get(req.Ctx, router.Key(appInstance.Namespace, secretName), existingSecret)
+		if findSecretErr == nil {
+			// Skip: TLS secret already exists, nothing to do here, renewal will be handled elsewhere
+			continue
+		} else if !apierrors.IsNotFound(findSecretErr) {
+			// Not found is ok, we'll create the secret below.. other errors are bad
+			logrus.Errorf("Error getting secret %s/%s: %v", appInstance.Namespace, secretName, findSecretErr)
+			return findSecretErr
+		}
+
+		newSec := &corev1.Secret{
+			Type: corev1.SecretTypeTLS,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: appInstance.Namespace,
+				Labels: map[string]string{
+					labels.AcornManaged: "true",
+					labels.AcornAppName: appInstance.Name,
+				},
+				Annotations: map[string]string{
+					labels.AcornDomain:             pb.ServiceName,
+					labels.AcornCertNotValidBefore: time.Time{}.Format(time.RFC3339), // Zero time
+					labels.AcornCertNotValidAfter:  time.Time{}.Format(time.RFC3339), // Zero time
+				},
+			},
+		}
+
+		if err := req.Client.Create(req.Ctx, newSec); err != nil {
+			return fmt.Errorf("error creating TLS secret %s/%s: %v", appInstance.Namespace, secretName, err)
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/controller/tls/certs.go
+++ b/pkg/controller/tls/certs.go
@@ -1,12 +1,13 @@
 package tls
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/labels"
+	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/sirupsen/logrus"
@@ -14,26 +15,23 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ProvisionWildcardCert provisions a Let's Encrypt wildcard certificate for *.<domain>.on-acorn.io
-func ProvisionWildcardCert(req router.Request, cfg *apiv1.Config, domain, token string) error {
-	if !strings.EqualFold(*cfg.LetsEncrypt, "disabled") {
-		logrus.Infof("Provisioning wildcard cert for %v", domain)
-		// Ensure that we have a Let's Encrypt account ready
-		leUser, err := ensureLEUser(req.Ctx, req.Client)
-		if err != nil {
-			return err
-		}
-
-		// Generate wildcard certificate for domain
-		_, err = leUser.ensureWildcardCertificateSecret(req.Ctx, req.Client, *cfg.AcornDNSEndpoint, domain, token)
-		if err != nil {
-			return err
-		}
+func ProvisionWildcardCert(req router.Request, domain, token string) error {
+	logrus.Infof("Provisioning wildcard cert for %v", domain)
+	// Ensure that we have a Let's Encrypt account ready
+	leUser, err := ensureLEUser(req.Ctx, req.Client)
+	if err != nil {
+		return err
 	}
 
-	return nil
+	wildcardDomain := fmt.Sprintf("*.%s", strings.TrimPrefix(domain, "."))
+
+	// Generate wildcard certificate for domain
+	return leUser.provisionCertIfNotExists(req.Ctx, req.Client, wildcardDomain, system.Namespace, system.TLSSecretName)
+
 }
 
 // RequireSecretTypeTLS is a middleware that ensures that we only act on TLS-Type secrets
@@ -49,22 +47,11 @@ func RequireSecretTypeTLS(h router.Handler) router.Handler {
 	})
 }
 
-// IgnoreWildcardCertSecret is a middleware that ignores the on-acorn.io wildcard cert secrets
-func IgnoreWildcardCertSecret(h router.Handler) router.Handler {
-	return router.HandlerFunc(func(req router.Request, resp router.Response) error {
-		sec := req.Object.(*corev1.Secret)
-		if v, ok := sec.Annotations[labels.AcornDomain]; ok {
-			if strings.HasSuffix(v, "on-acorn.io") {
-				return nil
-			}
-		}
-		return h.Handle(req, resp)
-	})
-}
-
 // RenewCert handles the renewal of existing TLS certificates
 func RenewCert(req router.Request, resp router.Response) error {
 	sec := req.Object.(*corev1.Secret)
+
+	logrus.Infof("Renewing certificate for %v", sec.Name)
 
 	leUser, err := ensureLEUser(req.Ctx, req.Client)
 	if err != nil {
@@ -73,6 +60,7 @@ func RenewCert(req router.Request, resp router.Response) error {
 
 	// Early exit if existing cert is still valid
 	if !leUser.mustRenew(sec) {
+		logrus.Infof("Certificate for %v is still valid", sec.Name)
 		return nil
 	}
 
@@ -112,7 +100,7 @@ func ProvisionCerts(req router.Request, resp router.Response) error {
 		return err
 	}
 
-	// FIXME: use error list instead of exiting on first error?
+	// FIXME: use error list instead of exiting on first error
 	for _, pb := range appInstance.Spec.Ports {
 		// Skip: name empty, not FQDN, already covered by on-acorn.io
 		if pb.ServiceName == "" || len(validation.IsFullyQualifiedDomainName(&field.Path{}, pb.ServiceName)) > 0 || strings.HasSuffix(pb.ServiceName, "on-acorn.io") {
@@ -121,33 +109,39 @@ func ProvisionCerts(req router.Request, resp router.Response) error {
 
 		secretName := name.Limit(appInstance.GetName()+"-tls-"+pb.ServiceName, 63-len(appInstanceIDSegment)-1) + "-" + appInstanceIDSegment
 
-		// Find existing secret if exists
-		existingSecret := &corev1.Secret{}
-		findSecretErr := req.Client.Get(req.Ctx, router.Key(appInstance.Namespace, secretName), existingSecret)
-		if findSecretErr == nil {
-			// Skip: TLS secret already exists, nothing to do here, renewal will be handled elsewhere
-			continue
-		} else if !apierrors.IsNotFound(findSecretErr) {
-			// Not found is ok, we'll create the secret below.. other errors are bad
-			logrus.Errorf("Error getting secret %s/%s: %v", appInstance.Namespace, secretName, findSecretErr)
-			return findSecretErr
-		}
+		return leUser.provisionCertIfNotExists(req.Ctx, req.Client, pb.ServiceName, appInstance.Namespace, secretName)
 
-		logrus.Infof("Provisioning TLS cert for %v in secret %s/%s", pb.ServiceName, appInstance.Namespace, secretName)
-		cert, err := leUser.getCert(req.Ctx, pb.ServiceName)
-		if err != nil {
-			return fmt.Errorf("Error getting cert for %v: %v", pb.ServiceName, err)
-		}
+	}
 
-		newSec, err := leUser.certToSecret(cert, pb.ServiceName, appInstance.Namespace, secretName)
-		if err != nil {
-			return fmt.Errorf("Error converting cert to secret: %v", err)
-		}
+	return nil
+}
 
-		if err := req.Client.Create(req.Ctx, newSec); err != nil {
-			return fmt.Errorf("error creating TLS secret %s/%s: %v", appInstance.Namespace, secretName, err)
-		}
+func (u *LEUser) provisionCertIfNotExists(ctx context.Context, client kclient.Client, domain string, namespace string, secretName string) error {
+	// Find existing secret if exists
+	existingSecret := &corev1.Secret{}
+	findSecretErr := client.Get(ctx, router.Key(namespace, secretName), existingSecret)
+	if findSecretErr == nil {
+		// Skip: TLS secret already exists, nothing to do here, renewal will be handled elsewhere
+		return nil
+	} else if !apierrors.IsNotFound(findSecretErr) {
+		// Not found is ok, we'll create the secret below.. other errors are bad
+		logrus.Errorf("Error getting secret %s/%s: %v", namespace, secretName, findSecretErr)
+		return findSecretErr
+	}
 
+	logrus.Infof("Provisioning TLS cert for %v in secret %s/%s", domain, namespace, secretName)
+	cert, err := u.getCert(ctx, domain)
+	if err != nil {
+		return fmt.Errorf("Error getting cert for %v: %v", domain, err)
+	}
+
+	newSec, err := u.certToSecret(cert, domain, namespace, secretName)
+	if err != nil {
+		return fmt.Errorf("Error converting cert to secret: %v", err)
+	}
+
+	if err := client.Create(ctx, newSec); err != nil {
+		return fmt.Errorf("error creating TLS secret %s/%s: %v", namespace, secretName, err)
 	}
 
 	return nil

--- a/pkg/controller/tls/letsencrypt.go
+++ b/pkg/controller/tls/letsencrypt.go
@@ -1,4 +1,4 @@
-package dns
+package tls
 
 import (
 	"context"

--- a/pkg/controller/tls/provider.go
+++ b/pkg/controller/tls/provider.go
@@ -1,4 +1,4 @@
-package dns
+package tls
 
 import (
 	"strings"


### PR DESCRIPTION
**Note**: This uses the HTTP01 challenge, which requires port 80 (on the ingress controller) to be accessible from the outside.

### Other Changes

- moved let's encrypt logic to its own package (including the wildcard certificate logic)
- the on-acorn.io wildcard certificate is now treated just like any other certificate, meaning that the certificate secret handler will renew it if needed (independent from the DNS config handler)

### To-Do

- [x] Move long-running jobs to goroutines
- [x] Proper "locking" for running requests
- [x] Hashing the ACME Account should include the Private Key which is the actual identifier
	- Scratch that, the private key should be re-generated if URL/E-Mail changed as we'd re-register an ACME account in that case.

Ref #206 & #486