### PR TITLE
fix: acorn rm refactor and include rm subcmds

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_container_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_container_rm.md
@@ -1,30 +1,25 @@
 ---
-title: "acorn rm"
+title: "acorn container rm"
 ---
-## acorn rm
+## acorn container rm
 
-Delete an app, container, or volume
+Delete a container
 
 ```
-acorn rm [flags] [APP_NAME]
+acorn container rm [CONTAINER_NAME...] [flags]
 ```
 
 ### Examples
 
 ```
 
-acorn rm APP_NAME
-acorn rm -t container,volume APP_NAME
+acorn container rm my-container
 ```
 
 ### Options
 
 ```
-  -a, --all          Delete all types
-  -t, --type         Delete by type (container, volume, app, secret, or c, v, a, s)
-  -f, --force        Force Delete
-  -h, --help         help for rm
-  
+  -h, --help   help for rm
 ```
 
 ### Options inherited from parent commands
@@ -36,9 +31,11 @@ acorn rm -t container,volume APP_NAME
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Location of a kubeconfig file
       --namespace string    Namespace to work in (default "acorn")
+  -o, --output string       Output format (json, yaml, {{gotemplate}})
+  -q, --quiet               Output only names
 ```
 
 ### SEE ALSO
 
-* [acorn](acorn.md)	 - 
+* [acorn container](acorn_container.md)	 - Manage containers
 

--- a/docs/docs/100-reference/01-command-line/acorn_image_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_rm.md
@@ -1,30 +1,25 @@
 ---
-title: "acorn rm"
+title: "acorn image rm"
 ---
-## acorn rm
+## acorn image rm
 
-Delete an app, container, or volume
+Delete a image
 
 ```
-acorn rm [flags] [APP_NAME]
+acorn image rm [IMAGE_NAME...] [flags]
 ```
 
 ### Examples
 
 ```
 
-acorn rm APP_NAME
-acorn rm -t container,volume APP_NAME
+acorn image rm my-image
 ```
 
 ### Options
 
 ```
-  -a, --all          Delete all types
-  -t, --type         Delete by type (container, volume, app, secret, or c, v, a, s)
-  -f, --force        Force Delete
-  -h, --help         help for rm
-  
+  -h, --help   help for rm
 ```
 
 ### Options inherited from parent commands
@@ -36,9 +31,11 @@ acorn rm -t container,volume APP_NAME
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Location of a kubeconfig file
       --namespace string    Namespace to work in (default "acorn")
+  -o, --output string       Output format (json, yaml, {{gotemplate}})
+  -q, --quiet               Output only names
 ```
 
 ### SEE ALSO
 
-* [acorn](acorn.md)	 - 
+* [acorn image](acorn_image.md)	 - Manage images
 

--- a/docs/docs/100-reference/01-command-line/acorn_volume_rm.md
+++ b/docs/docs/100-reference/01-command-line/acorn_volume_rm.md
@@ -1,30 +1,25 @@
 ---
-title: "acorn rm"
+title: "acorn volume rm"
 ---
-## acorn rm
+## acorn volume rm
 
-Delete an app, container, or volume
+Delete a secret
 
 ```
-acorn rm [flags] [APP_NAME]
+acorn secret rm [VOLUME_NAME...] [flags]
 ```
 
 ### Examples
 
 ```
 
-acorn rm APP_NAME
-acorn rm -t container,volume APP_NAME
+acorn volume rm my-volume
 ```
 
 ### Options
 
 ```
-  -a, --all          Delete all types
-  -t, --type         Delete by type (container, volume, app, secret, or c, v, a, s)
-  -f, --force        Force Delete
-  -h, --help         help for rm
-  
+  -h, --help   help for rm
 ```
 
 ### Options inherited from parent commands
@@ -36,9 +31,11 @@ acorn rm -t container,volume APP_NAME
       --debug-level int     Debug log level (valid 0-9) (default 7)
       --kubeconfig string   Location of a kubeconfig file
       --namespace string    Namespace to work in (default "acorn")
+  -o, --output string       Output format (json, yaml, {{gotemplate}})
+  -q, --quiet               Output only names
 ```
 
 ### SEE ALSO
 
-* [acorn](acorn.md)	 - 
+* [acorn volume](acorn_volume.md)	 - Manage volumes
 

--- a/pkg/cli/containers.go
+++ b/pkg/cli/containers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewContainer() *cobra.Command {
-	return cli.Command(&Container{}, cobra.Command{
+	cmd := cli.Command(&Container{}, cobra.Command{
 		Use:     "container [flags] [APP_NAME...]",
 		Aliases: []string{"containers", "c"},
 		Example: `
@@ -19,6 +19,8 @@ acorn containers`,
 		SilenceUsage: true,
 		Short:        "List or get running containers",
 	})
+	cmd.AddCommand(NewContainerDelete())
+	return cmd
 }
 
 type Container struct {

--- a/pkg/cli/containers_rm.go
+++ b/pkg/cli/containers_rm.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"fmt"
+
+	cli "github.com/acorn-io/acorn/pkg/cli/builder"
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+func NewContainerDelete() *cobra.Command {
+	cmd := cli.Command(&ContainerDelete{}, cobra.Command{
+		Use: "rm [CONTAINER_NAME...]",
+		Example: `
+acorn container rm my-container`,
+		SilenceUsage: true,
+		Short:        "Delete a container",
+	})
+	return cmd
+}
+
+type ContainerDelete struct {
+}
+
+func (a *ContainerDelete) Run(cmd *cobra.Command, args []string) error {
+	client, err := client.Default()
+	if err != nil {
+		return err
+	}
+
+	for _, container := range args {
+		app, err := client.AppDelete(cmd.Context(), container)
+		if err != nil {
+			return fmt.Errorf("deleting app %s: %w", container, err)
+		}
+		if app != nil {
+			fmt.Println(container)
+			continue
+		}
+
+		replicaDelete, err := client.ContainerReplicaDelete(cmd.Context(), container)
+		if err != nil {
+			return fmt.Errorf("deleting %s: %w", container, err)
+		}
+		if replicaDelete != nil {
+			fmt.Println(container)
+		} else {
+			fmt.Printf("Error: No such container: %s\n", container)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -15,7 +15,7 @@ import (
 )
 
 func NewImage() *cobra.Command {
-	return cli.Command(&Image{}, cobra.Command{
+	cmd := cli.Command(&Image{}, cobra.Command{
 		Use:     "image [flags] [APP_NAME...]",
 		Aliases: []string{"images", "i"},
 		Example: `
@@ -24,6 +24,8 @@ acorn images`,
 		Short:        "List images",
 		Args:         cobra.MaximumNArgs(1),
 	})
+	cmd.AddCommand(NewImageDelete())
+	return cmd
 }
 
 type Image struct {

--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"fmt"
+
+	cli "github.com/acorn-io/acorn/pkg/cli/builder"
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+func NewImageDelete() *cobra.Command {
+	cmd := cli.Command(&ImageDelete{}, cobra.Command{
+		Use: "rm [IMAGE_NAME...]",
+		Example: `
+acorn image rm my-image`,
+		SilenceUsage: true,
+		Short:        "Delete an Image",
+	})
+	return cmd
+}
+
+type ImageDelete struct {
+}
+
+func (a *ImageDelete) Run(cmd *cobra.Command, args []string) error {
+	client, err := client.Default()
+	if err != nil {
+		return err
+	}
+
+	for _, image := range args {
+		deleted, err := client.ImageDelete(cmd.Context(), image)
+		if err != nil {
+			return fmt.Errorf("deleting %s: %w", image, err)
+		}
+		if deleted != nil {
+			fmt.Println(image)
+		} else {
+			fmt.Printf("Error: No such image: %s\n", image)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/rm_helper.go
+++ b/pkg/cli/rm_helper.go
@@ -1,0 +1,207 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/acorn-io/acorn/pkg/prompt"
+	"github.com/pterm/pterm"
+	"strings"
+
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+func addRmObject(rmObjects *RmObjects, obj string) {
+	switch strings.ToLower(obj) {
+	case "app":
+		rmObjects.App = true
+	case "container":
+		rmObjects.Container = true
+	case "secret":
+		rmObjects.Secret = true
+	case "volume":
+		rmObjects.Volume = true
+	case "a":
+		rmObjects.App = true
+	case "c":
+		rmObjects.Container = true
+	case "s":
+		rmObjects.Secret = true
+	case "v":
+		rmObjects.Volume = true
+	}
+}
+func getSecretsToRemove(arg string, client client.Client, cmd *cobra.Command) ([]string, error) {
+	var result []string
+	secrets, err := client.SecretList(cmd.Context())
+	apps, _ := client.AppList(cmd.Context())
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, secret := range secrets {
+		if arg == strings.Split(aliases(&secret, apps)[0], ".")[0] {
+			result = append(result, secret.Name)
+		}
+	}
+	return result, nil
+}
+func getVolumesToDelete(arg string, client client.Client, cmd *cobra.Command) ([]string, error) {
+	var result []string
+	volumes, err := client.VolumeList(cmd.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, volume := range volumes {
+		if arg == volume.Status.AppName {
+			result = append(result, volume.Name)
+		}
+
+	}
+	return result, nil
+}
+func getContainersToDelete(arg string, client client.Client, cmd *cobra.Command) ([]string, error) {
+	var result []string
+	containers, err := client.ContainerReplicaList(cmd.Context(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range containers {
+		if arg == strings.Split(container.Name, ".")[0] {
+			result = append(result, container.Name)
+		}
+	}
+	return result, nil
+}
+func removeContainer(arg string, c client.Client, cmd *cobra.Command, f bool) error {
+	conToDel, err := getContainersToDelete(arg, c, cmd)
+
+	if !f {
+		if len(conToDel) == 0 {
+			pterm.Info.Println("No containers associated with " + arg)
+			return nil
+		}
+		for _, con := range conToDel {
+			pterm.FgRed.Println(con)
+		}
+		err := promptUser("containers")
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+	for _, con := range conToDel {
+		_, err := c.ContainerReplicaDelete(cmd.Context(), con)
+		if err != nil {
+			return fmt.Errorf("deleting container %s: %w", con, err)
+		}
+
+		fmt.Println("Removed: " + con)
+		continue
+
+	}
+	return nil
+}
+func removeVolume(arg string, c client.Client, cmd *cobra.Command, f bool) error {
+	volToDel, err := getVolumesToDelete(arg, c, cmd)
+	if err != nil {
+		return err
+	}
+
+	if !f {
+		if len(volToDel) == 0 {
+			pterm.Info.Println("No volumes associated with " + arg)
+			return nil
+		}
+		for _, vol := range volToDel {
+			pterm.FgRed.Println(vol)
+		}
+		err = promptUser("volumes")
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	for _, vol := range volToDel {
+		v, err := c.VolumeDelete(cmd.Context(), vol)
+		if err != nil {
+			return fmt.Errorf("deleting volume %s: %w", arg, err)
+		}
+		if v != nil {
+			fmt.Println("Removed: " + vol)
+			continue
+		} else {
+			fmt.Printf("Error: No such volume: %s\n", vol)
+		}
+
+	}
+	return nil
+}
+func removeApp(arg string, c client.Client, cmd *cobra.Command, f bool) error {
+	if !f {
+		pterm.FgRed.Println(arg)
+		err := promptUser("app")
+		if err != nil {
+			return err
+		}
+	}
+	app, err := c.AppDelete(cmd.Context(), arg)
+
+	if err != nil {
+		return fmt.Errorf("deleting app %s: %w", arg, err)
+	}
+	if app != nil {
+		fmt.Println("Removed: " + arg)
+	} else {
+		fmt.Printf("Error: No such app: %s\n", arg)
+	}
+	return nil
+}
+
+func removeSecret(arg string, c client.Client, cmd *cobra.Command, f bool) error {
+	secToDel, err := getSecretsToRemove(arg, c, cmd)
+	if !f {
+		if len(secToDel) == 0 {
+			pterm.Info.Println("No secrets associated with " + arg)
+			return nil
+		}
+		for _, sec := range secToDel {
+			pterm.FgRed.Println(sec)
+		}
+		err = promptUser("secrets")
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+	for _, sec := range secToDel {
+		secret, err := c.SecretDelete(cmd.Context(), sec)
+		if err != nil {
+			return fmt.Errorf("deleting secret %s: %w", sec, err)
+		}
+		if secret != nil {
+			fmt.Println("Removed: " + sec)
+			continue
+		}
+	}
+	return nil
+}
+func promptUser(obj string) error {
+	msg := "Do you want to remove the above " + obj
+	if ok, err := prompt.Bool(msg, false); err != nil {
+		return err
+	} else if !ok {
+		pterm.Warning.Println("Aborting remove")
+		return fmt.Errorf("aborting remove")
+	}
+	return nil
+}

--- a/pkg/cli/secret_rm.go
+++ b/pkg/cli/secret_rm.go
@@ -35,6 +35,8 @@ func (a *SecretDelete) Run(cmd *cobra.Command, args []string) error {
 		}
 		if deleted != nil {
 			fmt.Println(secret)
+		} else {
+			fmt.Printf("Error: No such secret: %s\n", secret)
 		}
 	}
 

--- a/pkg/cli/volume_rm.go
+++ b/pkg/cli/volume_rm.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"fmt"
+
+	cli "github.com/acorn-io/acorn/pkg/cli/builder"
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+func NewVolumeDelete() *cobra.Command {
+	cmd := cli.Command(&VolumeDelete{}, cobra.Command{
+		Use: "rm [VOLUME_NAME...]",
+		Example: `
+acorn volume rm my-volume`,
+		SilenceUsage: true,
+		Short:        "Delete a volume",
+	})
+	return cmd
+}
+
+type VolumeDelete struct {
+}
+
+func (a *VolumeDelete) Run(cmd *cobra.Command, args []string) error {
+	client, err := client.Default()
+	if err != nil {
+		return err
+	}
+
+	for _, volume := range args {
+		deleted, err := client.VolumeDelete(cmd.Context(), volume)
+		if err != nil {
+			return fmt.Errorf("deleting %s: %w", volume, err)
+		}
+		if deleted != nil {
+			fmt.Println(volume)
+		} else {
+			fmt.Printf("Error: No such volume: %s\n", volume)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/volumes.go
+++ b/pkg/cli/volumes.go
@@ -17,8 +17,9 @@ func NewVolume() *cobra.Command {
 		Example: `
 acorn volume`,
 		SilenceUsage: true,
-		Short:        "List or get volumes",
+		Short:        "Manage volumes",
 	})
+	cmd.AddCommand(NewVolumeDelete())
 	return cmd
 }
 


### PR DESCRIPTION
Issue: #346 

This PR address the acorn rm not being user friendly. It adds the rm command to each subcommand (image, volume, container). It also refactors acorn rm to included types and force flags and be centered around acorn app-names. A user can do
 ``` 
 acorn rm -t container,volume APP_NAME 
 ```
and this will prompt user to remove all containers/volumes associated with the acorn.
Another example to delete all would be
 ``` 
 acorn rm -a -f APP_NAME 
 ```
This will force delete all resources associated with the acorn