### PR TITLE
Add .vscode launch configurations for Visual Studio Code's debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch API",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}",
+            "args": ["api-server"], 
+        },
+        {
+            "name": "Launch Controller",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}",
+            "args": ["controller"], 
+        },
+        {
+            "name": "Run Acornfile",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}",
+            "args": ["run", "."],
+            "console": "integratedTerminal",
+        }
+    ]
+}


### PR DESCRIPTION
Adding in some launch configurations to make those using vscode to develop Acorn be able to use the debugger by default. 

Along with this I'm also going to update the wiki a bit to describe the intricacies of debugging the API Server.