### PR TITLE
Revert "Merge client side and server side configs when installing (#790)"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,7 +138,7 @@ func IsDockerDesktop(ctx context.Context, getter kclient.Reader) (bool, error) {
 	return false, nil
 }
 
-func Merge(oldConfig, newConfig *apiv1.Config) *apiv1.Config {
+func merge(oldConfig, newConfig *apiv1.Config) *apiv1.Config {
 	var (
 		mergedConfig apiv1.Config
 	)
@@ -235,7 +235,7 @@ func AsConfigMap(cfg *apiv1.Config) (*corev1.ConfigMap, error) {
 }
 
 func asConfigMap(existing, cfg *apiv1.Config) (*corev1.ConfigMap, error) {
-	newConfig := Merge(existing, cfg)
+	newConfig := merge(existing, cfg)
 
 	configBytes, err := json.Marshal(newConfig)
 	if err != nil {

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -110,18 +110,6 @@ func Install(ctx context.Context, image string, opts *Options) error {
 	klogv2.SetOutput(io.Discard)
 	utilruntime.ErrorHandlers = nil
 
-	kclient, err := k8sclient.Default()
-	if err != nil {
-		return err
-	}
-
-	serverConf, err := config.Get(ctx, kclient)
-	if err != nil {
-		return err
-	}
-
-	opts.Config = *config.Merge(serverConf, &opts.Config)
-
 	// Require E-Mail address when using Let's Encrypt production
 	if opts.Config.LetsEncrypt != nil && *opts.Config.LetsEncrypt == "enabled" {
 		if opts.Config.LetsEncryptTOSAgree == nil || !*opts.Config.LetsEncryptTOSAgree {
@@ -173,6 +161,11 @@ func Install(ctx context.Context, image string, opts *Options) error {
 		} else {
 			s.Success()
 		}
+	}
+
+	kclient, err := k8sclient.Default()
+	if err != nil {
+		return err
 	}
 
 	var installIngressController bool


### PR DESCRIPTION
Reverts acorn-io/acorn#834

 i found a bug with the merging of configs. im going to roll that change back

the config retrieved from the server has default values in it. those defaults should actually be overridden on first install, but pulling them to the client side and merging them in is throwing off the logic

specifically, this is manifesting itself as local.on-acorn.io becoming the cluster domain for installs in the cloud where it should actually be a randomly generated domain name