### PR TITLE
Revert "add t.Cleanup func to clear out the local cert directories creating during api server bootup"

### DIFF
--- a/integration/helper/controller.go
+++ b/integration/helper/controller.go
@@ -40,10 +40,6 @@ var (
 	apiRESTConfig       *rest.Config
 )
 
-const (
-	APIServerLocalCertPath = "apiserver.local.config"
-)
-
 func EnsureCRDs(t *testing.T) {
 	t.Helper()
 
@@ -95,7 +91,6 @@ func ensureNamespace(t *testing.T) {
 		},
 	})
 }
-
 func StartAPI(t *testing.T) *rest.Config {
 	t.Helper()
 
@@ -105,8 +100,6 @@ func StartAPI(t *testing.T) *rest.Config {
 	if apiStarted {
 		return apiRESTConfig
 	}
-
-	t.Cleanup(CleanupAPI)
 
 	ensureNamespace(t)
 
@@ -174,17 +167,6 @@ func StartAPI(t *testing.T) *rest.Config {
 
 	t.Fatal("failed to start API")
 	return nil
-}
-
-func CleanupAPI() {
-	fileInfo, err := os.Stat(APIServerLocalCertPath)
-	if err != nil {
-		return
-	}
-
-	if fileInfo.IsDir() {
-		_ = os.RemoveAll(APIServerLocalCertPath)
-	}
 }
 
 func StartRegistry(t *testing.T) (string, func()) {


### PR DESCRIPTION
This reverts commit b61593e6023d0cfe243b2df1acbaf0bd8ed34bbc.

Signed-off-by: Craig Jellick <craig@acorn.io>
