### PR TITLE
fix: add err msg to acorn app output when target-namespace is used

### DIFF
--- a/pkg/controller/appdefinition/namespace.go
+++ b/pkg/controller/appdefinition/namespace.go
@@ -48,12 +48,14 @@ func ensureNamespaceOwned(req router.Request, appInstance *v1.AppInstance) error
 
 	if ns.Labels[labels.AcornAppNamespace] != appInstance.Namespace ||
 		ns.Labels[labels.AcornAppName] != appInstance.Name {
-		return fmt.Errorf("can not use namespace %s, existing namespace must have labels "+
+		err := fmt.Errorf("[controller: can not use namespace %s, existing namespace must have labels "+
 			"acorn.io/app-namespace"+" and acorn.io/app-name (Apply Using: kubectl label namespaces %s acorn.io/app-name=%s "+
 			"kubectl label namespaces %s acorn.io/app-namespace=acorn) "+
-			"Namespace will be deleted when the app is deleted",
+			"Namespace will be deleted when the app is deleted]",
 			appInstance.Spec.TargetNamespace, appInstance.Spec.TargetNamespace, appInstance.Name,
 			appInstance.Spec.TargetNamespace)
+		appInstance.Status.Columns.Message = err.Error()
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Issue: #660 
Signed-off-by: Joshua Silverio <joshua@acorn.io>