### PR TITLE
fix: do not skip validation if image didn't change

### DIFF
--- a/pkg/server/registry/apps/strategy.go
+++ b/pkg/server/registry/apps/strategy.go
@@ -90,10 +90,7 @@ func (s *Strategy) Validate(ctx context.Context, obj runtime.Object) (result fie
 }
 
 func (s *Strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) (result field.ErrorList) {
-	oldParams, newParams := old.(*apiv1.App), obj.(*apiv1.App)
-	if oldParams.Spec.Image == newParams.Spec.Image {
-		return nil
-	}
+	newParams := obj.(*apiv1.App)
 	return s.Validate(ctx, newParams)
 }
 


### PR DESCRIPTION
Ref #915 

Simple fix as per @ibuildthecloud's recommendation.
Basically we will run validation on update even if the image didn't change.
This will re-request approval for permissions on update.