### PR TITLE
Support re-pull through --image flag (issue #948)

### DIFF
--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -62,7 +62,7 @@ func (s *Update) Run(cmd *cobra.Command, args []string) error {
 
 	if s.Pull || image == app.Spec.Image {
 		if s.Pull && image != "" && image != app.Spec.Image {
-			return fmt.Errorf("cannot change image (%v) and speficy --pull at the same time", image)
+			return fmt.Errorf("cannot change image (%v) and specify --pull at the same time", image)
 		}
 
 		err := c.AppPullImage(cmd.Context(), name)


### PR DESCRIPTION
Previously, we introduced a way to force an app to re-pull its image
via:
```
acorn update --pull <app name>
```

This introduces a different way to achieve the same functionality:
```
acorn update --image <image name> <app name>
```

Signed-off-by: Craig Jellick <craig@acorn.io>
