### PR TITLE
Fix #889 - Don't update brew on pre-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,6 +88,7 @@ brews:
   - description: "Acorn CLI"
     homepage: "https://acorn.io"
     license: "Apache 2.0"
+    skip_upload: auto
     tap:
       owner: acorn-io
       name: homebrew-cli


### PR DESCRIPTION
This change will make it such that RCs, alphas, and other pre-releases
do not get exposed as installable releases via brew.
See: https://goreleaser.com/customization/homebrew/

Addresses https://github.com/acorn-io/acorn/issues/889

Signed-off-by: Craig Jellick <craig@acorn.io>
