### PR TITLE
Add test flags and increase timeout for the nightly EKS tests #796

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -1,5 +1,6 @@
 name: test acorn on EKS
 on:
+  workflow_dispatch:
   schedule:
     - cron: '00 7 * * *'   # time in UTC
 jobs:
@@ -49,7 +50,7 @@ jobs:
 
       - name: run acorn integration tests
         run: |
-          make test
+          make TEST_ACORN_CONTROLLER=external TEST_FLAGS="-timeout=7m" test
         env:
           KUBECONFIG: "/home/runner/.kube/config"
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ validate-ci:
 	;fi
 
 test:
-	go test ./...
+	go test $(TEST_FLAGS) ./...
 
 goreleaser:
 	goreleaser build --snapshot --single-target --rm-dist


### PR DESCRIPTION
Adding in the ability to specify testing flags that are then utilized by the nightly EKS action. Also add the `workflow_dispatch` attribute to the nightly EKS action so we can run it on demand.