### PR TITLE
Update doWatch to respect -timeout flag in tests

### DIFF
--- a/integration/helper/wait.go
+++ b/integration/helper/wait.go
@@ -24,7 +24,14 @@ func doWatch[T client.Object](t *testing.T, watchFunc watchFunc, cb func(obj T) 
 	t.Helper()
 
 	ctx := GetCTX(t)
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	var cancel context.CancelFunc
+
+	if deadline, ok := t.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+	} else {
+		ctx, cancel = context.WithTimeout(ctx, 1*time.Minute)
+	}
+
 	defer cancel()
 
 	result, err := watchFunc()


### PR DESCRIPTION
Adding a change to the `doWatch` function that all of the failing tests call eventually while waiting for results. In slower environments a minute (the original default) seems to not be long enough to validate logic. Now we are able to set that value to be higher by running:

```shell
make test TEST_FLAGS="-timeout=7m"
```

And have it be respected. The impact of this is that each test will have the timeout amount of time to run. If a timeout is not set, the original behavior of a timeout set to be 1 minute will be used instead.