### PR TITLE
Default write verbs to be explicit verbs

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -21,6 +21,8 @@ var (
 	MinSizeQuantity     = Quantity("5M")
 	DefaultSize         = MustParseResourceQuantity(DefaultSizeQuantity)
 	MinSize             = MustParseResourceQuantity(MinSizeQuantity)
+	DefaultVerbs        = []string{"get", "list", "watch", "update", "patch", "delete", "deletecollection", "create"}
+	ReadVerbs           = []string{"get", "list", "watch"}
 )
 
 type routeTarget struct {
@@ -533,9 +535,9 @@ func (in *PolicyRule) UnmarshalJSON(data []byte) error {
 	resource, apiGroup, _ := strings.Cut(s, ".")
 	in.Resources = []string{resource}
 	in.APIGroups = []string{apiGroup}
-	in.Verbs = []string{"*"}
+	in.Verbs = DefaultVerbs
 	if read {
-		in.Verbs = []string{"get", "list", "watch"}
+		in.Verbs = ReadVerbs
 	}
 
 	return nil

--- a/pkg/appdefinition/appdefinition_test.go
+++ b/pkg/appdefinition/appdefinition_test.go
@@ -2198,7 +2198,7 @@ containers: test: {
 
 	assert.Equal(t, "pods", appSpec.Containers["test"].Permissions.Rules[0].Resources[0])
 	assert.Equal(t, "api.group", appSpec.Containers["test"].Permissions.Rules[0].APIGroups[0])
-	assert.Equal(t, "*", appSpec.Containers["test"].Permissions.Rules[0].Verbs[0])
+	assert.Equal(t, v1.DefaultVerbs, appSpec.Containers["test"].Permissions.Rules[0].Verbs)
 	assert.Equal(t, "secrets", appSpec.Containers["test"].Permissions.Rules[1].Resources[0])
 	assert.Equal(t, "", appSpec.Containers["test"].Permissions.Rules[1].APIGroups[0])
 	assert.Equal(t, []string{"get", "list", "watch"}, appSpec.Containers["test"].Permissions.Rules[1].Verbs)


### PR DESCRIPTION
Don't grant '*' by default as that might have unintended consequences
with custom verbs like "impersonate."

Signed-off-by: Darren Shepherd <darren@acorn.io>
