### PR TITLE
Fix profiles with permissions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,13 +18,21 @@
             "args": ["controller"], 
         },
         {
-            "name": "Run Acornfile",
+            "name": "Run Acorn",
             "type": "go",
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceRoot}",
-            "args": ["run", "."],
+            "args": ["run", "${input:acornfile}"],
             "console": "integratedTerminal",
         }
-    ]
+    ],
+    "inputs": [
+		{
+			"id": "acornfile",
+			"type": "promptString",
+			"default": ".",
+			"description": "The location of the Acorn to debug with. Can be a file or image."
+		},
+	]
 }


### PR DESCRIPTION
Fixing an issue where an Acorn that defines permissions conditionally based on profiles would always request the conditional permissions. 

Before, `acorn run registry/org/repo:conditional-permissions` would ask for permissions the same way that `acorn run --profile=with-permissions registry/org/repo:conditional-permissions` would. 

Now, `acorn run registry/org/repo:conditional-permissions` does not ask for permissions and `acorn run --profile=with-permissions registry/org/repo:conditional-permissions` does. 

Also, I added an input prompt for the Acorn file or image to run for vscode's `acorn run` launch configuration.