### PR TITLE
Add validation for http-endpoint-pattern domains and update messaging

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -165,7 +165,7 @@ func Install(ctx context.Context, image string, opts *Options) error {
 	// Validate the non-default http-endpoint-pattern
 	if opts.Config.HttpEndpointPattern != nil && *opts.Config.HttpEndpointPattern != "" {
 		if err := publish.ValidateEndpointPattern(*opts.Config.HttpEndpointPattern); err != nil {
-			return fmt.Errorf("invalid http-endpoint-pattern: %w", err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
Adding tests for `ValidateEndpointPattern`, add logic for validating the constructed domain earlier than app runtime, and condense messaging.