### PR TITLE
Move from emptyDir to persistentVolumeClaim to the registry @ buildkitd. Fixes #974

### DIFF
--- a/pkg/install/role.yaml
+++ b/pkg/install/role.yaml
@@ -63,7 +63,10 @@ rules:
       - roles
       - clusterrolebindings
       - rolebindings
-
+  - verbs: ["get", "list", "watch"]
+    apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/system/constants.go
+++ b/pkg/system/constants.go
@@ -13,6 +13,7 @@ const (
 
 var (
 	RegistryName             = "registry"
+	RegistryStorage          = "10Gi"
 	RegistryPort             = 5000
 	BuildKitName             = "buildkitd"
 	ControllerName           = "acorn-controller"


### PR DESCRIPTION
Solves #974 issue by creating a `persistentVolumeClaim` of 10Gi instead of using an `emptyDir`.

I could iterate the pr further if required, something like:
- Using an external container registry.
- Extend the configuration of the internal registry (external object storage).
- make it configurable while installing acorn: `acorn --install --registry-opts....`.

Let me know if this PR is enough, or if it would be better to implement something else. As it is, it covers what is mentioned in the #974 issue.

Thanks!