### PR TITLE
By default truncate generated hostnames over 63 characters

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,7 @@ var (
 	DefaultImageCheckIntervalDefault = "5m"
 
 	// Default HttpEndpointPattern set to enable Let's Encrypt
-	DefaultHttpEndpointPattern = "{{.Container}}-{{.App}}-{{.Hash}}.{{.ClusterDomain}}"
+	DefaultHttpEndpointPattern = "{{printf \"%s-%s-%s\" .Container .App .Hash | truncate}}.{{.ClusterDomain}}"
 )
 
 func complete(c *apiv1.Config, ctx context.Context, getter kclient.Reader) error {

--- a/pkg/publish/ingress.go
+++ b/pkg/publish/ingress.go
@@ -57,6 +57,10 @@ func ValidateEndpointPattern(pattern string) error {
 	return nil
 }
 
+func truncate(s ...string) string {
+	return name.SafeConcatName(s...)
+}
+
 func toEndpoint(pattern, domain, container, appName, appNamespace string) (string, error) {
 	// This should not happen since the pattern in the config (passed to this through pattern) should
 	// always be set to the default if the pattern is "". However,if it is not somehow, set it here.
@@ -79,7 +83,9 @@ func toEndpoint(pattern, domain, container, appName, appNamespace string) (strin
 	}
 
 	var templateBuffer bytes.Buffer
-	t := template.Must(template.New("").Parse(pattern))
+	t := template.Must(template.New("").Funcs(map[string]any{
+		"truncate": truncate,
+	}).Parse(pattern))
 	if err := t.Execute(&templateBuffer, endpointOpts); err != nil {
 		return "", fmt.Errorf("%w %v: %v", ErrInvalidPattern, pattern, err)
 	}

--- a/pkg/publish/ingress_test.go
+++ b/pkg/publish/ingress_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/config"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -160,6 +161,21 @@ func TestToEndpoint(t *testing.T) {
 			},
 			wantEndpoint: "",
 			wantErr:      ErrSegmentExceededMaxLength,
+		},
+		{
+			name: "parsed pattern's segment exceeds maximum length and should be truncated",
+			args: args{
+				domain:      "custom-domain.io",
+				serviceName: "app-name-that-is-very-long-and-should-cause-issues",
+				pattern:     config.DefaultHttpEndpointPattern,
+				appInstance: &v1.AppInstance{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{Name: "green-star", Namespace: "namespace"},
+					Spec:       v1.AppInstanceSpec{},
+					Status:     v1.AppInstanceStatus{},
+				},
+			},
+			wantEndpoint: "app-name-that-is-very-long-and-should-cause-issues-green-8049ce.custom-domain.io",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>
