### PR TITLE
Don't run install checks in CI test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,5 +30,5 @@ jobs:
       - run: make build
       - run: docker buildx install
       - run: make setup-ci-image
-      - run: ./bin/acorn install --image acorn:v-ci
+      - run: ./bin/acorn install --image acorn:v-ci --skip-checks --acorn-dns=disabled
       - run: TEST_ACORN_CONTROLLER=external make test


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>
