### PR TITLE
Replace secret/credential reference to expose with reveal (#348, #842)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_secret.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret.md
@@ -40,6 +40,6 @@ acorn secret
 * [acorn](acorn.md)	 - 
 * [acorn secret create](acorn_secret_create.md)	 - Create a secret
 * [acorn secret encrypt](acorn_secret_encrypt.md)	 - Encrypt string information with clusters public key
-* [acorn secret expose](acorn_secret_expose.md)	 - Manage secrets
+* [acorn secret reveal](acorn_secret_reveal.md)	 - Manage secrets
 * [acorn secret rm](acorn_secret_rm.md)	 - Delete a secret
 

--- a/docs/docs/100-reference/01-command-line/acorn_secret_reveal.md
+++ b/docs/docs/100-reference/01-command-line/acorn_secret_reveal.md
@@ -1,12 +1,12 @@
 ---
-title: "acorn secret expose"
+title: "acorn secret reveal"
 ---
-## acorn secret expose
+## acorn secret reveal
 
 Manage secrets
 
 ```
-acorn secret expose [flags] [SECRET_NAME...]
+acorn secret reveal [flags] [SECRET_NAME...]
 ```
 
 ### Examples
@@ -19,7 +19,7 @@ acorn secret
 ### Options
 
 ```
-  -h, --help            help for expose
+  -h, --help            help for reveal
   -o, --output string   Output format (json, yaml, {{gotemplate}})
   -q, --quiet           Output only names
 ```

--- a/docs/docs/37-getting-started.md
+++ b/docs/docs/37-getting-started.md
@@ -375,7 +375,7 @@ ALIAS                                  NAME                       TYPE      KEYS
 awesome-acorn.quickstart-pg-pass          quickstart-pg-pass-sqlv9   token     [token]   139m ago
 
 # Reveal the one for the current app
-$ acorn secret expose awesome-acorn.quickstart-pg-pass
+$ acorn secret reveal awesome-acorn.quickstart-pg-pass
 NAME                       TYPE      KEY       VALUE
 quickstart-pg-pass-sqlv9   token     token     mssl8692sk47tfklx9bqnqflw7pqrk2ldb6cd9tckjlttpk4vsvpvl
 ```

--- a/docs/docs/60-architecture/02-security-considerations.md
+++ b/docs/docs/60-architecture/02-security-considerations.md
@@ -36,7 +36,7 @@ Users will require CRUD access to all types from the `api.acorn.io` API group wi
 "containerreplicas/exec"
 "credentials"
 "secrets"
-"secrets/expose"
+"secrets/reveal"
 "infos"
 ```
 

--- a/integration/client/secrets/secrets_test.go
+++ b/integration/client/secrets/secrets_test.go
@@ -100,7 +100,7 @@ func TestSecretGet(t *testing.T) {
 	assert.Equal(t, secret, newSecret)
 }
 
-func TestSecretExpose(t *testing.T) {
+func TestSecretReveal(t *testing.T) {
 	helper.StartController(t)
 	restConfig := helper.StartAPI(t)
 
@@ -123,7 +123,7 @@ func TestSecretExpose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newSecret, err := c.SecretExpose(ctx, "secret2")
+	newSecret, err := c.SecretReveal(ctx, "secret2")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/secrets/secret_test.go
+++ b/integration/secrets/secret_test.go
@@ -57,7 +57,7 @@ func TestText(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gen2, err := c.SecretExpose(context.Background(), app.Name+".gen2")
+	gen2, err := c.SecretReveal(context.Background(), app.Name+".gen2")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cli/secret.go
+++ b/pkg/cli/secret.go
@@ -27,7 +27,7 @@ acorn secret`,
 	})
 	cmd.AddCommand(NewSecretCreate(c))
 	cmd.AddCommand(NewSecretDelete(c))
-	cmd.AddCommand(NewSecretExpose(c))
+	cmd.AddCommand(NewSecretReveal(c))
 	cmd.AddCommand(NewSecretEncrypt(c))
 	return cmd
 }

--- a/pkg/cli/secret_expose.go
+++ b/pkg/cli/secret_expose.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewSecretExpose(c client.CommandContext) *cobra.Command {
-	cmd := cli.Command(&Expose{client: c.ClientFactory}, cobra.Command{
-		Use:     "expose [flags] [SECRET_NAME...]",
+func NewSecretReveal(c client.CommandContext) *cobra.Command {
+	cmd := cli.Command(&Reveal{client: c.ClientFactory}, cobra.Command{
+		Use:     "reveal [flags] [SECRET_NAME...]",
 		Aliases: []string{"secrets", "s"},
 		Example: `
 acorn secret`,
@@ -23,20 +23,20 @@ acorn secret`,
 	return cmd
 }
 
-type Expose struct {
+type Reveal struct {
 	Quiet  bool   `usage:"Output only names" short:"q"`
 	Output string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o"`
 	client client.ClientFactory
 }
 
-type exposeEntry struct {
+type revealEntry struct {
 	Name  string
 	Type  string
 	Key   string
 	Value string
 }
 
-func (a *Expose) Run(cmd *cobra.Command, args []string) error {
+func (a *Reveal) Run(cmd *cobra.Command, args []string) error {
 	client, err := a.client.CreateDefault()
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func (a *Expose) Run(cmd *cobra.Command, args []string) error {
 	var matchedSecrets []apiv1.Secret
 
 	for _, arg := range args {
-		secret, err := client.SecretExpose(cmd.Context(), arg)
+		secret, err := client.SecretReveal(cmd.Context(), arg)
 		if err != nil {
 			return err
 		}
@@ -61,7 +61,7 @@ func (a *Expose) Run(cmd *cobra.Command, args []string) error {
 
 	for _, secret := range matchedSecrets {
 		for _, entry := range typed.Sorted(secret.Data) {
-			out.Write(&exposeEntry{
+			out.Write(&revealEntry{
 				Name:  secret.Name,
 				Type:  secret.Type,
 				Key:   entry.Key,

--- a/pkg/cli/secret_test.go
+++ b/pkg/cli/secret_test.go
@@ -165,7 +165,7 @@ func TestSecret(t *testing.T) {
 			wantOut: "Error: No such secret: dne\n",
 		},
 		{
-			name: "acorn secret expose found.secret", fields: fields{
+			name: "acorn secret reveal found.secret", fields: fields{
 				All:    false,
 				Quiet:  false,
 				Output: "",
@@ -177,14 +177,14 @@ func TestSecret(t *testing.T) {
 				StdIn:         strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"expose", "found.secret"},
+				args:   []string{"reveal", "found.secret"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
 			wantOut: "NAME      TYPE      KEY       VALUE\n",
 		},
 		{
-			name: "acorn secret expose dne", fields: fields{
+			name: "acorn secret reveal dne", fields: fields{
 				All:    false,
 				Quiet:  false,
 				Output: "",
@@ -196,7 +196,7 @@ func TestSecret(t *testing.T) {
 				StdIn:         strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"expose", "dne"},
+				args:   []string{"reveal", "dne"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: true,

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -226,7 +226,7 @@ func (m *MockClient) SecretGet(ctx context.Context, name string) (*apiv1.Secret,
 	return nil, nil
 }
 
-func (m *MockClient) SecretExpose(ctx context.Context, name string) (*apiv1.Secret, error) {
+func (m *MockClient) SecretReveal(ctx context.Context, name string) (*apiv1.Secret, error) {
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: Secret %s does not exist", name)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -217,7 +217,7 @@ type Client interface {
 	SecretCreate(ctx context.Context, name, secretType string, data map[string][]byte) (*apiv1.Secret, error)
 	SecretList(ctx context.Context) ([]apiv1.Secret, error)
 	SecretGet(ctx context.Context, name string) (*apiv1.Secret, error)
-	SecretExpose(ctx context.Context, name string) (*apiv1.Secret, error)
+	SecretReveal(ctx context.Context, name string) (*apiv1.Secret, error)
 	SecretUpdate(ctx context.Context, name string, data map[string][]byte) (*apiv1.Secret, error)
 	SecretDelete(ctx context.Context, name string) (*apiv1.Secret, error)
 

--- a/pkg/client/ignore.go
+++ b/pkg/client/ignore.go
@@ -243,8 +243,8 @@ func (c IgnoreUninstalled) SecretGet(ctx context.Context, name string) (*apiv1.S
 	return c.client.SecretGet(ctx, name)
 }
 
-func (c IgnoreUninstalled) SecretExpose(ctx context.Context, name string) (*apiv1.Secret, error) {
-	return c.client.SecretExpose(ctx, name)
+func (c IgnoreUninstalled) SecretReveal(ctx context.Context, name string) (*apiv1.Secret, error) {
+	return c.client.SecretReveal(ctx, name)
 }
 
 func (c IgnoreUninstalled) SecretUpdate(ctx context.Context, name string, data map[string][]byte) (*apiv1.Secret, error) {

--- a/pkg/client/secrets.go
+++ b/pkg/client/secrets.go
@@ -35,13 +35,13 @@ func (c *client) SecretGet(ctx context.Context, name string) (*apiv1.Secret, err
 	}, secret)
 }
 
-func (c *client) SecretExpose(ctx context.Context, name string) (*apiv1.Secret, error) {
+func (c *client) SecretReveal(ctx context.Context, name string) (*apiv1.Secret, error) {
 	result := &apiv1.Secret{}
 	err := c.RESTClient.Get().
 		Namespace(c.Namespace).
 		Resource("secrets").
 		Name(name).
-		SubResource("expose").
+		SubResource("reveal").
 		Do(ctx).Into(result)
 	return result, err
 }

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -73,7 +73,7 @@ var (
 					"images/push",
 					"images/pull",
 					"containerreplicas/exec",
-					"secrets/expose",
+					"secrets/reveal",
 				},
 			},
 		},

--- a/pkg/server/registry/credentials/translator.go
+++ b/pkg/server/registry/credentials/translator.go
@@ -18,7 +18,7 @@ import (
 
 type Translator struct {
 	client kclient.Client
-	expose bool
+	reveal bool
 }
 
 func (t *Translator) FromPublicName(ctx context.Context, namespace, name string) (string, string, error) {
@@ -52,7 +52,7 @@ func (t *Translator) ToPublic(objs ...runtime.Object) (result []types.Object) {
 		cred.Name = cred.ServerAddress
 		cred.OwnerReferences = nil
 		cred.ManagedFields = nil
-		if t.expose {
+		if t.reveal {
 			pass := string(secret.Data["password"])
 			cred.Password = &pass
 		}

--- a/pkg/server/registry/registry.go
+++ b/pkg/server/registry/registry.go
@@ -78,7 +78,7 @@ func APIStores(c kclient.WithWatch, cfg, localCfg *clientgo.Config) (map[string]
 		"containerreplicas/exec": containerExec,
 		"credentials":            credentials.NewStore(c),
 		"secrets":                secrets.NewStorage(c),
-		"secrets/expose":         secrets.NewExpose(c),
+		"secrets/reveal":         secrets.NewReveal(c),
 		"infos":                  info.NewStorage(c),
 	}
 

--- a/pkg/server/registry/secrets/expose.go
+++ b/pkg/server/registry/secrets/expose.go
@@ -10,10 +10,10 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewExpose(c kclient.WithWatch) rest.Storage {
+func NewReveal(c kclient.WithWatch) rest.Storage {
 	remoteResource := remote.NewWithTranslation(&Translator{
 		c:      c,
-		expose: true,
+		reveal: true,
 	}, &corev1.Secret{}, c)
 	return stores.NewBuilder(c.Scheme(), &apiv1.Secret{}).
 		WithGet(remoteResource).

--- a/pkg/server/registry/secrets/translator.go
+++ b/pkg/server/registry/secrets/translator.go
@@ -20,7 +20,7 @@ import (
 
 type Translator struct {
 	c      kclient.Client
-	expose bool
+	reveal bool
 }
 
 func (t *Translator) FromPublicName(ctx context.Context, namespace, name string) (string, string, error) {
@@ -91,7 +91,7 @@ func (t *Translator) ToPublic(objs ...runtime.Object) (result []types.Object) {
 			Keys:       keys,
 		}
 		sec.UID = sec.UID + "-s"
-		if t.expose {
+		if t.reveal {
 			sec.Data = secret.Data
 		}
 		result = append(result, sec)


### PR DESCRIPTION
This solves both https://github.com/acorn-io/acorn/issues/348 and https://github.com/acorn-io/acorn/issues/842.

In addition to updating the acorn secret expose to be acorn secret reveal, I also updated the registry code to use reveal instead of expose terminology for credentials.

Replaces #969 