### PR TITLE
Fix typo for .github/aws-eks-test.yml

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-       - name: report success to slack
+      - name: report success to slack
         id: slack-success
         uses: slackapi/slack-github-action@v1.23.0
         with:


### PR DESCRIPTION
This space was causing the action to not parse 🙃 

https://github.com/acorn-io/acorn/actions/runs/3894939496