### PR TITLE
Add dynamic CLI completion

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_image.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image.md
@@ -6,7 +6,7 @@ title: "acorn image"
 Manage images
 
 ```
-acorn image [flags] [APP_NAME...]
+acorn image [flags] [IMAGE_REPO:TAG|IMAGE_ID]
 ```
 
 ### Examples

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -16,8 +16,9 @@ func NewApp(c client.CommandContext) *cobra.Command {
 		Aliases: []string{"apps", "a", "ps"},
 		Example: `
 acorn app`,
-		SilenceUsage: true,
-		Short:        "List or get apps",
+		SilenceUsage:      true,
+		Short:             "List or get apps",
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
 	})
 }
 
@@ -29,7 +30,7 @@ type App struct {
 }
 
 func (a *App) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
@@ -37,7 +38,7 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 	out := table.NewWriter(tables.App, system.UserNamespace(), a.Quiet, a.Output)
 
 	if len(args) == 1 {
-		app, err := client.AppGet(cmd.Context(), args[0])
+		app, err := c.AppGet(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -45,7 +46,7 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 		return out.Err()
 	}
 
-	apps, err := client.AppList(cmd.Context())
+	apps, err := c.AppList(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -207,3 +207,19 @@ func imagesCompletion(allowDigest bool) completionFunc {
 		return result, nil
 	}
 }
+
+func credentialsCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	credentials, err := c.CredentialList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, credential := range credentials {
+		if strings.HasPrefix(credential.Name, toComplete) {
+			result = append(result, credential.Name)
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -239,3 +239,19 @@ func volumesCompletion(ctx context.Context, c client.Client, toComplete string) 
 
 	return result, nil
 }
+
+func secretsCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	secrets, err := c.SecretList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, secret := range secrets {
+		if strings.HasPrefix(secret.Name, toComplete) {
+			result = append(result, secret.Name)
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/baaah/pkg/typed"
+	"github.com/spf13/cobra"
+	"k8s.io/utils/strings/slices"
+)
+
+type completionFunc func(context.Context, client.Client, string) ([]string, error)
+
+// These define instances when the completion should not happen and the default completion (usually file/directory
+// completion should occur). For example, exec should only have one argument, everything after that is completed as
+// default by the user's terminal.
+type noCompletionOption func([]string) bool
+
+type completion struct {
+	client           client.ClientFactory
+	completionFunc   completionFunc
+	successDirective cobra.ShellCompDirective
+
+	noCompletionOptions []noCompletionOption
+}
+
+func removeExistingArgs(result, args []string) []string {
+	for i := 0; i < len(result); {
+		if slices.Contains(args, result[i]) {
+			result = append(result[:i], result[i+1:]...)
+		} else {
+			i++
+		}
+	}
+
+	return result
+}
+
+func onlyNumArgs(n int) noCompletionOption {
+	return func(args []string) bool {
+		return len(args) >= n
+	}
+}
+
+func newCompletion(c client.ClientFactory, cf completionFunc) *completion {
+	return &completion{
+		client:           c,
+		completionFunc:   cf,
+		successDirective: cobra.ShellCompDirectiveNoFileComp,
+	}
+}
+
+func (a *completion) withShouldCompleteOptions(opts ...noCompletionOption) *completion {
+	a.noCompletionOptions = append(a.noCompletionOptions, opts...)
+	return a
+}
+
+func (a *completion) withSuccessDirective(d cobra.ShellCompDirective) *completion {
+	a.successDirective = d
+	return a
+}
+
+func (a *completion) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	for _, o := range a.noCompletionOptions {
+		if o(args) {
+			return nil, cobra.ShellCompDirectiveDefault
+		}
+	}
+	c, err := a.client.CreateDefault()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	result, err := a.completionFunc(cmd.Context(), c, toComplete)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	return removeExistingArgs(result, args), a.successDirective
+}
+
+func appsThenContainersCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	// If the toComplete has a '.', then the user is looking for a container.
+	if strings.Contains(toComplete, ".") {
+		return containersCompletion(ctx, c, toComplete)
+	}
+
+	return appsCompletion(ctx, c, toComplete)
+}
+
+func appsCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	var result []string
+	apps, err := c.AppList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, app := range apps {
+		if strings.HasPrefix(app.Name, toComplete) {
+			result = append(result, app.Name)
+		}
+	}
+
+	return result, nil
+}
+
+func containersCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	var result []string
+	var opts *client.ContainerReplicaListOptions
+	if strings.Contains(toComplete, ".") {
+		opts = &client.ContainerReplicaListOptions{App: strings.Split(toComplete, ".")[0]}
+	}
+
+	containers, err := c.ContainerReplicaList(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range containers {
+		if strings.HasPrefix(container.Name, toComplete) {
+			result = append(result, container.Name)
+		}
+	}
+
+	return result, nil
+}
+
+// acornContainerCompletion will complete the `-c` flag for various commands like exec. It must look at all apps and
+// then for all containers on status.appSpec.Containers to produce a list of possibilities.
+func acornContainerCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	apps, err := c.AppList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, app := range apps {
+		for _, entry := range typed.Sorted(app.Status.AppSpec.Containers) {
+			if strings.HasPrefix(entry.Key, toComplete) {
+				result = append(result, entry.Key)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// onlyAppsWithAcornContainer will look for completions for apps and pods containers when the container name is
+// empty. If the container name is not empty, then it will only look for apps that have the specified container name in
+// their appSpec.
+func onlyAppsWithAcornContainer(containerName string) completionFunc {
+	return func(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+		// If no container is specified, then look for apps and pod containers.
+		if containerName == "" {
+			return appsThenContainersCompletion(ctx, c, toComplete)
+		}
+
+		// If a container has been specified, then only produce completions of apps that have such a container.
+		apps, err := c.AppList(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var result []string
+		for _, app := range apps {
+			for container := range app.Status.AppSpec.Containers {
+				if container == containerName && strings.HasPrefix(app.Name, toComplete) {
+					result = append(result, app.Name)
+					break
+				}
+			}
+		}
+
+		return result, nil
+	}
+}

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -223,3 +223,19 @@ func credentialsCompletion(ctx context.Context, c client.Client, toComplete stri
 
 	return result, nil
 }
+
+func volumesCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	volumes, err := c.VolumeList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, volume := range volumes {
+		if strings.HasPrefix(volume.Name, toComplete) {
+			result = append(result, volume.Name)
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -175,3 +175,35 @@ func onlyAppsWithAcornContainer(containerName string) completionFunc {
 		return result, nil
 	}
 }
+
+func imagesCompletion(allowDigest bool) completionFunc {
+	return func(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+		images, err := c.ImageList(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var result []string
+		var tagMatched bool
+		for _, image := range images {
+			tagMatched = false
+			for _, tag := range image.Tags {
+				if strings.HasPrefix(tag, toComplete) {
+					result = append(result, tag)
+					tagMatched = true
+				}
+			}
+
+			// Don't include the digest if a tag matched.
+			if allowDigest && !tagMatched {
+				digest := strings.TrimPrefix(image.Digest, "sha256:")[:12]
+				if strings.HasPrefix(digest, toComplete) {
+					result = append(result, digest)
+				}
+			}
+
+		}
+
+		return result, nil
+	}
+}

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -826,3 +826,77 @@ func TestVolumesCompletion(t *testing.T) {
 		})
 	}
 }
+
+func TestSecretsCompletion(t *testing.T) {
+	names := []string{"acorn.secret-1", "acorn.secret-2", "my-secret", "empty"}
+	secrets := make([]apiv1.Secret, 0, len(names))
+	for _, name := range names {
+		secrets = append(secrets, apiv1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	}
+	mockClientFactory := &testdata.MockClientFactory{
+		SecretList: secrets,
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name          string
+		args          []string
+		toComplete    string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "Nothing to complete, return all",
+			wantNames:     names,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with a",
+			toComplete:    "a",
+			wantNames:     []string{"acorn.secret-1", "acorn.secret-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with a, but acorn.volume-1 already in args",
+			toComplete:    "a",
+			args:          []string{"acorn.secret-1"},
+			wantNames:     []string{"acorn.secret-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with a, but all a's in args",
+			toComplete:    "a",
+			args:          []string{"acorn.secret-2", "acorn.secret-1"},
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete my-secret, only my-secret returned",
+			toComplete:    "my-secret",
+			wantNames:     []string{"my-secret"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete empty, but all names already in args",
+			args:          names,
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete something that doesn't exist",
+			toComplete:    "hello",
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	comp := newCompletion(mockClientFactory, secretsCompletion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := comp.complete(cmd, tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantNames, got, "secretsCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantDirective, got1, "secretsCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+		})
+	}
+}

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -1,0 +1,601 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	acornv1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/cli/testdata"
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/baaah/pkg/typed"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppsThenContainersCompletion(t *testing.T) {
+	appNames := []string{"test-1", "acorn-1", "acorn-2", "hub", "test-2"}
+	containerNames := []string{"test-1.container-1", "acorn-1.container-1", "acorn-2.container-1", "hub.container", "hub.other-container", "test-2.container-1"}
+	apps := make([]apiv1.App, 0, len(appNames))
+	for _, name := range appNames {
+		apps = append(apps, apiv1.App{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	}
+	containers := make([]apiv1.ContainerReplica, 0, len(containerNames))
+	for _, name := range containerNames {
+		containers = append(containers, apiv1.ContainerReplica{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: apiv1.ContainerReplicaSpec{AppName: strings.Split(name, ".")[0]}})
+	}
+	mockClientFactory := &testdata.MockClientFactory{
+		AppList:       apps,
+		ContainerList: containers,
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name          string
+		args          []string
+		toComplete    string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "Nothing to complete, return all app names",
+			wantNames:     appNames,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with t, only app names returned",
+			toComplete:    "t",
+			wantNames:     []string{"test-1", "test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with t, but test-1 already in args",
+			toComplete:    "t",
+			args:          []string{"test-1"},
+			wantNames:     []string{"test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with a, but acorn-1 and acorn-2 already in args",
+			toComplete:    "a",
+			args:          []string{"acorn-2", "acorn-1"},
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete hub, only hub returned",
+			toComplete:    "hub",
+			wantNames:     []string{"hub"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete empty, but all names already in args",
+			args:          appNames,
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with hub.",
+			toComplete:    "hub.",
+			wantNames:     []string{"hub.container", "hub.other-container"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with hub.c",
+			toComplete:    "hub.c",
+			wantNames:     []string{"hub.container"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete hub.container, only hub.container returned",
+			toComplete:    "hub.container",
+			wantNames:     []string{"hub.container"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete hub.c, but hub.container already in args",
+			args:          []string{"hub.container"},
+			toComplete:    "hub.c",
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete empty, but all container names already in args",
+			args:          containerNames,
+			wantNames:     appNames,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete something that doesn't exist",
+			toComplete:    "hello",
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	comp := newCompletion(mockClientFactory, appsThenContainersCompletion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := comp.complete(cmd, tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantNames, got, "appsThenContainersCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantDirective, got1, "appsThenContainersCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+		})
+	}
+}
+
+func TestAppsCompletion(t *testing.T) {
+	names := []string{"test-1", "acorn-1", "acorn-2", "hub", "test-2"}
+	apps := make([]apiv1.App, 0, len(names))
+	for _, name := range names {
+		apps = append(apps, apiv1.App{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	}
+	mockClientFactory := &testdata.MockClientFactory{
+		AppList: apps,
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name          string
+		args          []string
+		toComplete    string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "Nothing to complete, return all",
+			wantNames:     names,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with t",
+			toComplete:    "t",
+			wantNames:     []string{"test-1", "test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with t, but test-1 already in args",
+			toComplete:    "t",
+			args:          []string{"test-1"},
+			wantNames:     []string{"test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with a, but acorn-1 and acorn-2 already in args",
+			toComplete:    "a",
+			args:          []string{"acorn-2", "acorn-1"},
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete hub, only hub returned",
+			toComplete:    "hub",
+			wantNames:     []string{"hub"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete empty, but all names already in args",
+			args:          names,
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete something that doesn't exist",
+			toComplete:    "hello",
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	comp := newCompletion(mockClientFactory, appsCompletion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := comp.complete(cmd, tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantNames, got, "appsCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantDirective, got1, "appsCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+		})
+	}
+}
+
+func TestContainersCompletion(t *testing.T) {
+	names := []string{"test-1.container-1", "acorn-1.container-1", "acorn-2.container-1", "hub.container", "hub.other-container", "test-2.container-1"}
+	containers := make([]apiv1.ContainerReplica, 0, len(names))
+	for _, name := range names {
+		containers = append(containers, apiv1.ContainerReplica{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: apiv1.ContainerReplicaSpec{AppName: strings.Split(name, ".")[0]}})
+	}
+	mockClientFactory := &testdata.MockClientFactory{
+		ContainerList: containers,
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name          string
+		args          []string
+		toComplete    string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "Nothing to complete, return all",
+			wantNames:     names,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with t",
+			toComplete:    "t",
+			wantNames:     []string{"test-1.container-1", "test-2.container-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with test-1",
+			toComplete:    "test-1",
+			wantNames:     []string{"test-1.container-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with t, but test-1.container-1 already in args",
+			toComplete:    "t",
+			args:          []string{"test-1.container-1"},
+			wantNames:     []string{"test-2.container-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with hub.",
+			toComplete:    "hub.",
+			wantNames:     []string{"hub.container", "hub.other-container"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete starting with hub.c",
+			toComplete:    "hub.c",
+			wantNames:     []string{"hub.container"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete hub.container, only hub.container returned",
+			toComplete:    "hub.container",
+			wantNames:     []string{"hub.container"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete empty, but all names already in args",
+			args:          names,
+			wantNames:     []string{},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete app that doesn't exist",
+			toComplete:    "hello",
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Complete container that doesn't exist",
+			toComplete:    "hello.bye",
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	comp := newCompletion(mockClientFactory, containersCompletion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := comp.complete(cmd, tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantNames, got, "containersCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantDirective, got1, "containersCompletion(_, _, %v, %v)", tt.args, tt.toComplete)
+		})
+	}
+}
+
+func TestWithSuccessDirective(t *testing.T) {
+	names := []string{"success"}
+	mockClientFactory := &testdata.MockClientFactory{}
+	cf := func(_ context.Context, _ client.Client, toComplete string) ([]string, error) {
+		if toComplete == "error" {
+			return nil, fmt.Errorf("error")
+		}
+		return names, nil
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name             string
+		toComplete       string
+		successDirective cobra.ShellCompDirective
+		wantNames        []string
+		wantDirective    cobra.ShellCompDirective
+	}{
+		{
+			name:             "Default success directive",
+			successDirective: cobra.ShellCompDirectiveDefault,
+			wantNames:        names,
+			wantDirective:    cobra.ShellCompDirectiveDefault,
+		},
+		{
+			name:             "NoSpace success directive",
+			successDirective: cobra.ShellCompDirectiveNoSpace,
+			wantNames:        names,
+			wantDirective:    cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			name:             "NoSpace success directive, but error occurs",
+			successDirective: cobra.ShellCompDirectiveNoSpace,
+			toComplete:       "error",
+			wantDirective:    cobra.ShellCompDirectiveError,
+		},
+	}
+
+	comp := newCompletion(mockClientFactory, cf)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := comp.withSuccessDirective(tt.successDirective).complete(cmd, nil, tt.toComplete)
+			assert.Equalf(t, tt.wantNames, got, "onlyNumArgs returned names %v, wanted %v", got, tt.wantNames)
+			assert.Equalf(t, tt.wantDirective, got1, "onlyNumArgs returned directive %v, wanted %v", got1, tt.wantDirective)
+		})
+	}
+}
+
+func TestOnlyNumArgsCompletion(t *testing.T) {
+	names := []string{"fail"}
+	mockClientFactory := &testdata.MockClientFactory{}
+	cf := func(context.Context, client.Client, string) ([]string, error) {
+		return names, nil
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name          string
+		args          []string
+		numArgs       int
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "max one arg with no args",
+			numArgs:       1,
+			args:          []string{},
+			wantNames:     names,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "max one arg with one arg",
+			numArgs:       1,
+			args:          []string{""},
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveDefault,
+		},
+		{
+			name:          "max ten args with one arg",
+			numArgs:       10,
+			args:          []string{""},
+			wantNames:     names,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:    "max ten args with nine args",
+			numArgs: 10,
+			// Will have length 9
+			args:          strings.Split(strings.Repeat(".", 8), "."),
+			wantNames:     names,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:    "max ten args with ten args",
+			numArgs: 10,
+			// Will have length 10
+			args:          strings.Split(strings.Repeat(".", 9), "."),
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveDefault,
+		},
+		{
+			name:    "max ten args with twenty args",
+			numArgs: 10,
+			// Will have length 20
+			args:          strings.Split(strings.Repeat(".", 19), "."),
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := newCompletion(mockClientFactory, cf).withShouldCompleteOptions(onlyNumArgs(tt.numArgs)).complete(cmd, tt.args, "")
+			assert.Equalf(t, tt.wantNames, got, "onlyNumArgs returned names %v, wanted %v", got, tt.wantNames)
+			assert.Equalf(t, tt.wantDirective, got1, "onlyNumArgs returned directive %v, wanted %v", got1, tt.wantDirective)
+		})
+	}
+}
+
+func TestAcornContainerCompletion(t *testing.T) {
+	names := map[string]map[string]acornv1.Container{
+		"test-1": {
+			"container-1": {},
+			"container-2": {},
+		},
+		"test-2": {
+			"container-1": {},
+		},
+		"hub": {
+			"web":        {},
+			"db":         {},
+			"controller": {},
+		},
+	}
+	apps := make([]apiv1.App, 0, len(names))
+	for _, entry := range typed.Sorted(names) {
+		apps = append(apps, apiv1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: entry.Key},
+			Status: acornv1.AppInstanceStatus{
+				AppSpec: acornv1.AppSpec{Containers: entry.Value},
+			},
+		})
+	}
+	mockClientFactory := &testdata.MockClientFactory{
+		AppList: apps,
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name          string
+		toComplete    string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "Nothing to complete, return all",
+			wantNames:     []string{"controller", "db", "web", "container-1", "container-2", "container-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Completing c",
+			toComplete:    "c",
+			wantNames:     []string{"controller", "container-1", "container-2", "container-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Completing container",
+			toComplete:    "container",
+			wantNames:     []string{"container-1", "container-2", "container-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	comp := newCompletion(mockClientFactory, acornContainerCompletion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := comp.complete(cmd, nil, tt.toComplete)
+			assert.Equalf(t, tt.wantNames, got, "acornContainerCompletion(_, _, nil, %v)", tt.toComplete)
+			assert.Equalf(t, tt.wantDirective, got1, "acornContainerCompletion(_, _, nil, %v)", tt.toComplete)
+		})
+	}
+}
+
+func TestOnlyAppsWithAcornContainer(t *testing.T) {
+	names := map[string]map[string]acornv1.Container{
+		"test-1": {
+			"container-1": {},
+			"container-2": {},
+		},
+		"test-2": {
+			"container-1": {},
+		},
+		"hub": {
+			"web":        {},
+			"db":         {},
+			"controller": {},
+		},
+	}
+	apps := make([]apiv1.App, 0, len(names))
+	containers := make([]apiv1.ContainerReplica, 0, len(names))
+	for _, entry := range typed.Sorted(names) {
+		appName := entry.Key
+		apps = append(apps, apiv1.App{
+			ObjectMeta: metav1.ObjectMeta{Name: appName},
+			Status: acornv1.AppInstanceStatus{
+				AppSpec: acornv1.AppSpec{Containers: entry.Value},
+			},
+		})
+		for _, c := range typed.Sorted(entry.Value) {
+			containers = append(containers, apiv1.ContainerReplica{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.%s", appName, c.Key)},
+				Spec:       apiv1.ContainerReplicaSpec{AppName: appName},
+			})
+		}
+	}
+	mockClientFactory := &testdata.MockClientFactory{
+		AppList:       apps,
+		ContainerList: containers,
+	}
+	cmd := new(cobra.Command)
+	cmd.SetContext(context.Background())
+
+	tests := []struct {
+		name          string
+		container     string
+		toComplete    string
+		args          []string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		{
+			name:          "Nothing to complete and no container, return apps",
+			wantNames:     []string{"hub", "test-1", "test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Nothing to complete and no container, return apps except those in args",
+			args:          []string{"hub", "test-2"},
+			wantNames:     []string{"test-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Something to complete and no container should be the apps completion",
+			toComplete:    "t",
+			wantNames:     []string{"test-1", "test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Something with '.' to complete and no container should be the k8s container completion",
+			toComplete:    "hub.",
+			wantNames:     []string{"hub.controller", "hub.db", "hub.web"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Something with '.' to complete and no container should be the k8s container completion except those in args",
+			toComplete:    "hub.",
+			args:          []string{"hub.db"},
+			wantNames:     []string{"hub.controller", "hub.web"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Nothing to complete and 'container-1' for container should produce 'test' apps",
+			container:     "container-1",
+			wantNames:     []string{"test-1", "test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Nothing to complete and 'container-1' for container should produce 'test' apps except those in args",
+			container:     "container-1",
+			args:          []string{"test-1"},
+			wantNames:     []string{"test-2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "'test-1' to complete and 'container-1' for container should produce test-1",
+			container:     "container-1",
+			toComplete:    "test-1",
+			wantNames:     []string{"test-1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Container that doesn't exist should produce nil completions",
+			container:     "container",
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			name:          "Container exists, but no app completion should produce nil completions",
+			container:     "db",
+			toComplete:    "t",
+			wantNames:     nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := newCompletion(mockClientFactory, onlyAppsWithAcornContainer(tt.container)).complete(cmd, tt.args, tt.toComplete)
+			assert.Equalf(t, tt.wantNames, got, "onlyAppsWithAcornContainer(_, _, nil, %v)", tt.toComplete)
+			assert.Equalf(t, tt.wantDirective, got1, "onlyAppsWithAcornContainer(_, _, nil, %v)", tt.toComplete)
+		})
+	}
+}

--- a/pkg/cli/containers.go
+++ b/pkg/cli/containers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/acorn/pkg/tables"
 	"github.com/spf13/cobra"
+
 	"k8s.io/utils/strings/slices"
 )
 
@@ -16,8 +17,9 @@ func NewContainer(c client.CommandContext) *cobra.Command {
 		Aliases: []string{"containers", "c"},
 		Example: `
 acorn containers`,
-		SilenceUsage: true,
-		Short:        "Manage containers",
+		SilenceUsage:      true,
+		Short:             "Manage containers",
+		ValidArgsFunction: newCompletion(c.ClientFactory, containersCompletion).complete,
 	})
 	cmd.AddCommand(NewContainerDelete(c))
 	return cmd
@@ -31,7 +33,7 @@ type Container struct {
 }
 
 func (a *Container) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
@@ -39,7 +41,7 @@ func (a *Container) Run(cmd *cobra.Command, args []string) error {
 	out := table.NewWriter(tables.Container, system.UserNamespace(), a.Quiet, a.Output)
 
 	if len(args) == 1 {
-		app, err := client.ContainerReplicaGet(cmd.Context(), args[0])
+		app, err := c.ContainerReplicaGet(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -47,7 +49,7 @@ func (a *Container) Run(cmd *cobra.Command, args []string) error {
 		return out.Err()
 	}
 
-	containers, err := client.ContainerReplicaList(cmd.Context(), nil)
+	containers, err := c.ContainerReplicaList(cmd.Context(), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/containers_rm.go
+++ b/pkg/cli/containers_rm.go
@@ -9,13 +9,15 @@ import (
 )
 
 func NewContainerDelete(c client.CommandContext) *cobra.Command {
-	cmd := cli.Command(&ContainerDelete{client: c.ClientFactory}, cobra.Command{
+	cd := &ContainerDelete{client: c.ClientFactory}
+	cmd := cli.Command(cd, cobra.Command{
 		Use: "kill [CONTAINER_NAME...]",
 		Example: `
 acorn container kill app-name.containername-generated-hash`,
-		SilenceUsage: true,
-		Short:        "Delete a container",
-		Aliases:      []string{"rm"},
+		SilenceUsage:      true,
+		Short:             "Delete a container",
+		Aliases:           []string{"rm"},
+		ValidArgsFunction: newCompletion(c.ClientFactory, containersCompletion).complete,
 	})
 	return cmd
 }
@@ -25,13 +27,13 @@ type ContainerDelete struct {
 }
 
 func (a *ContainerDelete) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
 
 	for _, container := range args {
-		replicaDelete, err := client.ContainerReplicaDelete(cmd.Context(), container)
+		replicaDelete, err := c.ContainerReplicaDelete(cmd.Context(), container)
 		if err != nil {
 			return fmt.Errorf("deleting %s: %w", container, err)
 		}

--- a/pkg/cli/credential.go
+++ b/pkg/cli/credential.go
@@ -16,8 +16,9 @@ func NewCredential(c client.CommandContext) *cobra.Command {
 		Aliases: []string{"credentials", "creds"},
 		Example: `
 acorn credential`,
-		SilenceUsage: true,
-		Short:        "Manage registry credentials",
+		SilenceUsage:      true,
+		Short:             "Manage registry credentials",
+		ValidArgsFunction: newCompletion(c.ClientFactory, credentialsCompletion).complete,
 	})
 	cmd.AddCommand(NewCredentialLogin(false, c))
 	cmd.AddCommand(NewCredentialLogout(false, c))
@@ -31,7 +32,7 @@ type Credential struct {
 }
 
 func (a *Credential) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
@@ -39,7 +40,7 @@ func (a *Credential) Run(cmd *cobra.Command, args []string) error {
 	out := table.NewWriter(tables.Credential, system.UserNamespace(), a.Quiet, a.Output)
 
 	if len(args) == 1 {
-		credential, err := client.CredentialGet(cmd.Context(), args[0])
+		credential, err := c.CredentialGet(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -47,7 +48,7 @@ func (a *Credential) Run(cmd *cobra.Command, args []string) error {
 		return out.Err()
 	}
 
-	credentials, err := client.CredentialList(cmd.Context())
+	credentials, err := c.CredentialList(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/credential_logout.go
+++ b/pkg/cli/credential_logout.go
@@ -14,9 +14,10 @@ func NewCredentialLogout(root bool, c client.CommandContext) *cobra.Command {
 		Aliases: []string{"rm"},
 		Example: `
 acorn logout ghcr.io`,
-		SilenceUsage: true,
-		Short:        "Remove registry credentials",
-		Args:         cobra.ExactArgs(1),
+		SilenceUsage:      true,
+		Short:             "Remove registry credentials",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, credentialsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 	})
 	if root {
 		cmd.Aliases = nil

--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/spf13/cobra"
@@ -9,10 +10,11 @@ import (
 
 func NewImageDelete(c client.CommandContext) *cobra.Command {
 	cmd := cli.Command(&ImageDelete{client: c.ClientFactory}, cobra.Command{
-		Use:          "rm [IMAGE_NAME...]",
-		Example:      `acorn image rm my-image`,
-		SilenceUsage: true,
-		Short:        "Delete an Image",
+		Use:               "rm [IMAGE_NAME...]",
+		Example:           `acorn image rm my-image`,
+		SilenceUsage:      true,
+		Short:             "Delete an Image",
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).complete,
 	})
 	return cmd
 }

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -49,7 +49,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\ntesttag1     latest    found-image-\ntesttag2     latest    found-image-\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
 		},
 		{
 			name: "acorn image --no-trunc", fields: fields{
@@ -68,7 +68,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1234567\ntesttag1     latest    found-image-two-tags1234567\ntesttag2     latest    found-image-two-tags1234567\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1234567\ntesttag1     latest    found-image-two-tags1234567\ntesttag2     v1        found-image-two-tags1234567\n",
 		},
 		{
 			name: "acorn image -a", fields: fields{
@@ -87,7 +87,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\n<none>       <none>    found-image-\ntesttag1     latest    found-image-\ntesttag2     latest    found-image-\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\n<none>       <none>    found-image-\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
 		},
 		{
 			name: "acorn image -c ", fields: fields{
@@ -106,7 +106,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID                      CONTAINER                      DIGEST\ntesttag      latest    found-image1234567            test-image-running-container   test-image-running-container\ntesttag1     latest    found-image-two-tags1234567   test-image-running-container   test-image-running-container\ntesttag2     latest    found-image-two-tags1234567   test-image-running-container   test-image-running-container\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID                      CONTAINER                      DIGEST\ntesttag      latest    found-image1234567            test-image-running-container   test-image-running-container\ntesttag1     latest    found-image-two-tags1234567   test-image-running-container   test-image-running-container\ntesttag2     v1        found-image-two-tags1234567   test-image-running-container   test-image-running-container\n",
 		},
 		{
 			name: "acorn image -q ", fields: fields{
@@ -144,7 +144,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "testtag:latest@test-image-running-container\ntesttag1:latest@test-image-running-container\ntesttag2:latest@test-image-running-container\n"},
+			wantOut: "testtag:latest@test-image-running-container\ntesttag1:latest@test-image-running-container\ntesttag2:v1@test-image-running-container\n"},
 		{
 			name: "acorn image -q -a", fields: fields{
 				All:    false,

--- a/pkg/cli/log.go
+++ b/pkg/cli/log.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/acorn-io/acorn/pkg/log"
@@ -9,12 +10,15 @@ import (
 )
 
 func NewLogs(c client.CommandContext) *cobra.Command {
-	return cli.Command(&Logs{client: c.ClientFactory}, cobra.Command{
-		Use:          "logs [flags] APP_NAME|CONTAINER_NAME",
-		SilenceUsage: true,
-		Short:        "Log all pods from app",
-		Args:         cobra.RangeArgs(1, 1),
+	logs := &Logs{client: c.ClientFactory}
+	return cli.Command(logs, cobra.Command{
+		Use:               "logs [flags] APP_NAME|CONTAINER_NAME",
+		SilenceUsage:      true,
+		Short:             "Log all pods from app",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsThenContainersCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 	})
+
 }
 
 type Logs struct {

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -9,10 +9,11 @@ import (
 
 func NewPush(c client.CommandContext) *cobra.Command {
 	return cli.Command(&Push{client: c.ClientFactory}, cobra.Command{
-		Use:          "push [flags] IMAGE",
-		SilenceUsage: true,
-		Short:        "Push an image to a remote registry",
-		Args:         cobra.RangeArgs(1, 1),
+		Use:               "push [flags] IMAGE",
+		SilenceUsage:      true,
+		Short:             "Push an image to a remote registry",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(false)).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 	})
 }
 

--- a/pkg/cli/rm.go
+++ b/pkg/cli/rm.go
@@ -13,15 +13,15 @@ import (
 )
 
 func NewRm(c client.CommandContext) *cobra.Command {
-	cmd := cli.Command(&Rm{client: c.ClientFactory}, cobra.Command{
+	return cli.Command(&Rm{client: c.ClientFactory}, cobra.Command{
 		Use: "rm [flags] [APP_NAME...]",
 		Example: `
 acorn rm APP_NAME
 acorn rm -t volume,container APP_NAME`,
-		SilenceUsage: true,
-		Short:        "Delete an app, container, secret or volume",
+		SilenceUsage:      true,
+		Short:             "Delete an app, container, secret or volume",
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
 	})
-	return cmd
 }
 
 type Rm struct {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -25,9 +25,10 @@ import (
 
 func NewRun(c client.CommandContext) *cobra.Command {
 	cmd := cli.Command(&Run{out: c.StdOut, client: c.ClientFactory}, cobra.Command{
-		Use:          "run [flags] IMAGE|DIRECTORY [acorn args]",
-		SilenceUsage: true,
-		Short:        "Run an app from an image or Acornfile",
+		Use:               "run [flags] IMAGE|DIRECTORY [acorn args]",
+		SilenceUsage:      true,
+		Short:             "Run an app from an image or Acornfile",
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).withSuccessDirective(cobra.ShellCompDirectiveDefault).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 		Example: `# Publish and Expose Port Syntax
   # Publish port 80 for any containers that define it as a port
   acorn run -p 80 .

--- a/pkg/cli/secret.go
+++ b/pkg/cli/secret.go
@@ -22,8 +22,9 @@ func NewSecret(c client.CommandContext) *cobra.Command {
 		Aliases: []string{"secrets", "s"},
 		Example: `
 acorn secret`,
-		SilenceUsage: true,
-		Short:        "Manage secrets",
+		SilenceUsage:      true,
+		Short:             "Manage secrets",
+		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).complete,
 	})
 	cmd.AddCommand(NewSecretCreate(c))
 	cmd.AddCommand(NewSecretDelete(c))

--- a/pkg/cli/secret_expose.go
+++ b/pkg/cli/secret_expose.go
@@ -16,9 +16,10 @@ func NewSecretReveal(c client.CommandContext) *cobra.Command {
 		Aliases: []string{"secrets", "s"},
 		Example: `
 acorn secret`,
-		SilenceUsage: true,
-		Short:        "Manage secrets",
-		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage:      true,
+		Short:             "Manage secrets",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).complete,
 	})
 	return cmd
 }

--- a/pkg/cli/secret_rm.go
+++ b/pkg/cli/secret_rm.go
@@ -13,8 +13,9 @@ func NewSecretDelete(c client.CommandContext) *cobra.Command {
 		Use: "rm [SECRET_NAME...]",
 		Example: `
 acorn secret rm my-secret`,
-		SilenceUsage: true,
-		Short:        "Delete a secret",
+		SilenceUsage:      true,
+		Short:             "Delete a secret",
+		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).complete,
 	})
 	return cmd
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -15,8 +15,9 @@ func NewStart(c client.CommandContext) *cobra.Command {
 acorn start my-app
 
 acorn start my-app1 my-app2`,
-		SilenceUsage: true,
-		Short:        "Start an app",
+		SilenceUsage:      true,
+		Short:             "Start an app",
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
 	})
 }
 
@@ -25,13 +26,13 @@ type Start struct {
 }
 
 func (a *Start) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
 
 	for _, arg := range args {
-		err := client.AppStart(cmd.Context(), arg)
+		err := c.AppStart(cmd.Context(), arg)
 		if err != nil {
 			return fmt.Errorf("starting %s: %w", arg, err)
 		}

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -15,8 +15,9 @@ func NewStop(c client.CommandContext) *cobra.Command {
 acorn stop my-app
 
 acorn stop my-app1 my-app2`,
-		SilenceUsage: true,
-		Short:        "Stop an app",
+		SilenceUsage:      true,
+		Short:             "Stop an app",
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
 	})
 }
 
@@ -25,13 +26,13 @@ type Stop struct {
 }
 
 func (a *Stop) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
 
 	for _, arg := range args {
-		err := client.AppStop(cmd.Context(), arg)
+		err := c.AppStop(cmd.Context(), arg)
 		if err != nil {
 			return fmt.Errorf("stopping %s: %w", arg, err)
 		}

--- a/pkg/cli/tag.go
+++ b/pkg/cli/tag.go
@@ -8,10 +8,11 @@ import (
 
 func NewTag(c client.CommandContext) *cobra.Command {
 	return cli.Command(&Tag{client: c.ClientFactory}, cobra.Command{
-		Use:          "tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
-		SilenceUsage: true,
-		Short:        "Tag an image",
-		Args:         cobra.RangeArgs(2, 2),
+		Use:               "tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
+		SilenceUsage:      true,
+		Short:             "Tag an image",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).withShouldCompleteOptions(onlyNumArgs(2)).complete,
 	})
 }
 

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -17,6 +17,7 @@ type MockClientFactory struct {
 	AppList        []apiv1.App
 	ContainerList  []apiv1.ContainerReplica
 	CredentialList []apiv1.Credential
+	VolumeList     []apiv1.Volume
 }
 
 func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
@@ -24,6 +25,7 @@ func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 		Apps:        dc.AppList,
 		Containers:  dc.ContainerList,
 		Credentials: dc.CredentialList,
+		Volumes:     dc.VolumeList,
 	}, nil
 }
 
@@ -31,6 +33,7 @@ type MockClient struct {
 	Apps        []apiv1.App
 	Containers  []apiv1.ContainerReplica
 	Credentials []apiv1.Credential
+	Volumes     []apiv1.Volume
 }
 
 func (m *MockClient) AppPullImage(ctx context.Context, name string) error {
@@ -332,7 +335,10 @@ func (m *MockClient) ContainerReplicaExec(ctx context.Context, name string, args
 }
 
 func (m *MockClient) VolumeList(ctx context.Context) ([]apiv1.Volume, error) {
-	return []apiv1.Volume{apiv1.Volume{
+	if m.Volumes != nil {
+		return m.Volumes, nil
+	}
+	return []apiv1.Volume{{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: "found.volume"},
 		Spec:       apiv1.VolumeSpec{},

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -14,20 +14,23 @@ import (
 )
 
 type MockClientFactory struct {
-	AppList       []apiv1.App
-	ContainerList []apiv1.ContainerReplica
+	AppList        []apiv1.App
+	ContainerList  []apiv1.ContainerReplica
+	CredentialList []apiv1.Credential
 }
 
 func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 	return &MockClient{
-		Apps:       dc.AppList,
-		Containers: dc.ContainerList,
+		Apps:        dc.AppList,
+		Containers:  dc.ContainerList,
+		Credentials: dc.CredentialList,
 	}, nil
 }
 
 type MockClient struct {
-	Apps       []apiv1.App
-	Containers []apiv1.ContainerReplica
+	Apps        []apiv1.App
+	Containers  []apiv1.ContainerReplica
+	Credentials []apiv1.Credential
 }
 
 func (m *MockClient) AppPullImage(ctx context.Context, name string) error {
@@ -170,7 +173,10 @@ func (m *MockClient) CredentialCreate(ctx context.Context, serverAddress, userna
 }
 
 func (m *MockClient) CredentialList(ctx context.Context) ([]apiv1.Credential, error) {
-	return []apiv1.Credential{apiv1.Credential{
+	if m.Credentials != nil {
+		return m.Credentials, nil
+	}
+	return []apiv1.Credential{{
 		TypeMeta:      metav1.TypeMeta{},
 		ObjectMeta:    metav1.ObjectMeta{Name: "test-cred"},
 		ServerAddress: "test-server-address",

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -18,6 +18,7 @@ type MockClientFactory struct {
 	ContainerList  []apiv1.ContainerReplica
 	CredentialList []apiv1.Credential
 	VolumeList     []apiv1.Volume
+	SecretList     []apiv1.Secret
 }
 
 func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
@@ -26,6 +27,7 @@ func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 		Containers:  dc.ContainerList,
 		Credentials: dc.CredentialList,
 		Volumes:     dc.VolumeList,
+		Secrets:     dc.SecretList,
 	}, nil
 }
 
@@ -34,6 +36,7 @@ type MockClient struct {
 	Containers  []apiv1.ContainerReplica
 	Credentials []apiv1.Credential
 	Volumes     []apiv1.Volume
+	Secrets     []apiv1.Secret
 }
 
 func (m *MockClient) AppPullImage(ctx context.Context, name string) error {
@@ -220,7 +223,10 @@ func (m *MockClient) SecretCreate(ctx context.Context, name, secretType string, 
 }
 
 func (m *MockClient) SecretList(ctx context.Context) ([]apiv1.Secret, error) {
-	return []apiv1.Secret{apiv1.Secret{
+	if m.Secrets != nil {
+		return m.Secrets, nil
+	}
+	return []apiv1.Secret{{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: "found.secret"},
 		Type:       "",

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -14,13 +14,20 @@ import (
 )
 
 type MockClientFactory struct {
+	AppList       []apiv1.App
+	ContainerList []apiv1.ContainerReplica
 }
 
 func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
-	return &MockClient{}, nil
+	return &MockClient{
+		Apps:       dc.AppList,
+		Containers: dc.ContainerList,
+	}, nil
 }
 
 type MockClient struct {
+	Apps       []apiv1.App
+	Containers []apiv1.ContainerReplica
 }
 
 func (m *MockClient) AppPullImage(ctx context.Context, name string) error {
@@ -28,10 +35,13 @@ func (m *MockClient) AppPullImage(ctx context.Context, name string) error {
 }
 
 func (m *MockClient) AppList(ctx context.Context) ([]apiv1.App, error) {
-	return []apiv1.App{apiv1.App{
+	if m.Apps != nil {
+		return m.Apps, nil
+	}
+	return []apiv1.App{{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: "found"},
-		Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+		Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 		Status:     v1.AppInstanceStatus{},
 	}}, nil
 }
@@ -56,14 +66,14 @@ func (m *MockClient) AppGet(ctx context.Context, name string) (*apiv1.App, error
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{Ready: true},
 		}, nil
 	case "found.container":
 		return &apiv1.App{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
-			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{v1.SecretBinding{Secret: "found.secret", Target: "found"}}},
+			Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
 			Status:     v1.AppInstanceStatus{},
 		}, nil
 	}
@@ -257,7 +267,20 @@ func (m *MockClient) SecretDelete(ctx context.Context, name string) (*apiv1.Secr
 }
 
 func (m *MockClient) ContainerReplicaList(ctx context.Context, opts *client.ContainerReplicaListOptions) ([]apiv1.ContainerReplica, error) {
-	return []apiv1.ContainerReplica{apiv1.ContainerReplica{
+	if m.Containers != nil {
+		if opts == nil {
+			return m.Containers, nil
+		}
+		// Do the filtering to make testing simpler
+		result := make([]apiv1.ContainerReplica, 0, len(m.Containers))
+		for _, c := range m.Containers {
+			if c.Spec.AppName == opts.App {
+				result = append(result, c)
+			}
+		}
+		return result, nil
+	}
+	return []apiv1.ContainerReplica{{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
 		Spec:       apiv1.ContainerReplicaSpec{AppName: "found"},

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -359,17 +359,20 @@ func (m *MockClient) VolumeDelete(ctx context.Context, name string) (*apiv1.Volu
 }
 
 func (m *MockClient) ImageList(ctx context.Context) ([]apiv1.Image, error) {
-	return []apiv1.Image{apiv1.Image{
+	return []apiv1.Image{{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
 		Tags:       []string{"testtag:latest"},
-	}, apiv1.Image{
+		Digest:     "1234567890asdfghkl",
+	}, {
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
-	}, apiv1.Image{
+		Digest:     "lkjhgfdsa0987654321",
+	}, {
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-		Tags:       []string{"testtag1:latest", "testtag2:latest"},
+		Tags:       []string{"testtag1:latest", "testtag2:v1"},
+		Digest:     "lkjhgfdsa1234567890",
 	}}, nil
 }
 

--- a/pkg/cli/testdata/all/all_test_i.txt
+++ b/pkg/cli/testdata/all/all_test_i.txt
@@ -19,4 +19,4 @@ IMAGES:
 REPOSITORY   TAG       IMAGE-ID
 testtag      latest    found-image1
 testtag1     latest    found-image-
-testtag2     latest    found-image-
+testtag2     v1        found-image-

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -15,10 +15,11 @@ import (
 
 func NewUpdate(c client.CommandContext) *cobra.Command {
 	cmd := cli.Command(&Update{out: c.StdOut, client: c.ClientFactory}, cobra.Command{
-		Use:          "update [flags] APP_NAME [deploy flags]",
-		SilenceUsage: true,
-		Short:        "Update a deployed app",
-		Args:         cobra.MinimumNArgs(1),
+		Use:               "update [flags] APP_NAME [deploy flags]",
+		SilenceUsage:      true,
+		Short:             "Update a deployed app",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 	})
 	cmd.PersistentFlags().Lookup("dangerous").Hidden = true
 	cmd.Flags().SetInterspersed(false)

--- a/pkg/cli/volume_rm.go
+++ b/pkg/cli/volume_rm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+
 	"github.com/acorn-io/acorn/pkg/client"
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
@@ -10,10 +11,11 @@ import (
 
 func NewVolumeDelete(c client.CommandContext) *cobra.Command {
 	cmd := cli.Command(&VolumeDelete{client: c.ClientFactory}, cobra.Command{
-		Use:          "rm [VOLUME_NAME...]",
-		Example:      `acorn volume rm my-volume`,
-		SilenceUsage: true,
-		Short:        "Delete a volume",
+		Use:               "rm [VOLUME_NAME...]",
+		Example:           `acorn volume rm my-volume`,
+		SilenceUsage:      true,
+		Short:             "Delete a volume",
+		ValidArgsFunction: newCompletion(c.ClientFactory, volumesCompletion).complete,
 	})
 	return cmd
 }
@@ -23,13 +25,13 @@ type VolumeDelete struct {
 }
 
 func (a *VolumeDelete) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
 
 	for _, volume := range args {
-		deleted, err := client.VolumeDelete(cmd.Context(), volume)
+		deleted, err := c.VolumeDelete(cmd.Context(), volume)
 		if err != nil {
 			return fmt.Errorf("deleting %s: %w", volume, err)
 		}

--- a/pkg/cli/volumes.go
+++ b/pkg/cli/volumes.go
@@ -16,8 +16,9 @@ func NewVolume(c client.CommandContext) *cobra.Command {
 		Aliases: []string{"volumes", "v"},
 		Example: `
 acorn volume`,
-		SilenceUsage: true,
-		Short:        "Manage volumes",
+		SilenceUsage:      true,
+		Short:             "Manage volumes",
+		ValidArgsFunction: newCompletion(c.ClientFactory, volumesCompletion).complete,
 	})
 	cmd.AddCommand(NewVolumeDelete(c))
 	return cmd
@@ -30,7 +31,7 @@ type Volume struct {
 }
 
 func (a *Volume) Run(cmd *cobra.Command, args []string) error {
-	client, err := a.client.CreateDefault()
+	c, err := a.client.CreateDefault()
 	if err != nil {
 		return err
 	}
@@ -38,7 +39,7 @@ func (a *Volume) Run(cmd *cobra.Command, args []string) error {
 	out := table.NewWriter(tables.Volume, system.UserNamespace(), a.Quiet, a.Output)
 
 	if len(args) == 1 {
-		volume, err := client.VolumeGet(cmd.Context(), args[0])
+		volume, err := c.VolumeGet(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -46,7 +47,7 @@ func (a *Volume) Run(cmd *cobra.Command, args []string) error {
 		return out.Err()
 	}
 
-	volumes, err := client.VolumeList(cmd.Context())
+	volumes, err := c.VolumeList(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/wait.go
+++ b/pkg/cli/wait.go
@@ -9,10 +9,11 @@ import (
 
 func NewWait(c client.CommandContext) *cobra.Command {
 	return cli.Command(&Wait{client: c.ClientFactory}, cobra.Command{
-		Use:          "wait [flags] APP_NAME",
-		SilenceUsage: true,
-		Short:        "Wait an app to be ready then exit with status code 0",
-		Args:         cobra.ExactArgs(1),
+		Use:               "wait [flags] APP_NAME",
+		SilenceUsage:      true,
+		Short:             "Wait an app to be ready then exit with status code 0",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 	})
 }
 

--- a/pkg/imagesystem/registry.go
+++ b/pkg/imagesystem/registry.go
@@ -140,7 +140,7 @@ func getRegistryPort(ctx context.Context, c client.Reader) (int, error) {
 	var service corev1.Service
 	err := c.Get(ctx, client.ObjectKey{Name: system.RegistryName, Namespace: system.ImagesNamespace}, &service)
 	if err != nil {
-		return 0, fmt.Errorf("getting %s/%s service: %w", system.Namespace, system.RegistryName, err)
+		return 0, fmt.Errorf("getting %s/%s service: %w", system.ImagesNamespace, system.RegistryName, err)
 	}
 	for _, port := range service.Spec.Ports {
 		if port.Name == system.RegistryName && port.NodePort > 0 {
@@ -148,7 +148,7 @@ func getRegistryPort(ctx context.Context, c client.Reader) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("failed to find node port for registry %s/%s", system.Namespace, system.RegistryName)
+	return 0, fmt.Errorf("failed to find node port for registry %s/%s", system.ImagesNamespace, system.RegistryName)
 }
 
 func ParseAndEnsureNotInternalRepo(ctx context.Context, c client.Reader, image string) (name.Reference, error) {


### PR DESCRIPTION
These changes add dynamic completion to the CLI. The majority of the changes are in the first commit. Each subsequent commit simply adds to the changes for the new types (with a few caveats).

There are a couple commands (`logs` and `exec`) that take either an app name or a container name. The completion will suggest app names unless there is a '.' in the name to be completed. In this case, it can be determined that the user is looking for a container name and the completion will adjust accordingly.

For the logs command specifically, the user can use the `-c` flag to specify a container name from the Acornfile (this is also dynamically completed). If the user has specified such a container, then the completion will only suggest apps with containers of the given name.

Anywhere there could be an image completion, the completion will always prefer tags to digests. That is, if an image has a tag, then the completion will not suggest the digest for that image. The exception to this is if the user is trying to get completions for something that matches the digest but doesn't match the tag. In this case, the digest will be suggested.

For the push command, it doesn't make sense to suggest images without tags.

Finally, during my testing of image completion, there was one spot where I found two log messages that were incorrect. I fixed them in the commit for images. Also, the `Use` description for the `images` command seemed incorrect to me, so I updated it and ran `make gen-docs`.

Issues:
https://github.com/acorn-io/acorn/issues/841
https://github.com/acorn-io/acorn/issues/1023