### PR TITLE
Add info on using '*' and '**' in the CLI

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -62,6 +62,9 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
   # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
   acorn run myorg/hello-world:v#.#-**
 
+  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
+  acorn run "myorg/hello-world:v#.#-**" 
+
   # Automatic upgrades can be configured explicitly via a flag.
   # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
   acorn run --auto-upgrade myorg/hello-world:latest

--- a/docs/docs/50-running/45-auto-upgrades.md
+++ b/docs/docs/50-running/45-auto-upgrades.md
@@ -12,7 +12,7 @@ This example deploys the hello-world app with auto-upgrade enabled and matching 
 acorn run myorg/hello-world:v#.#.#
 ```
 
-`*` denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
+`*` denotes a segment of the image tag that should be sorted alphabetically when finding the latest tag.
 
 In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
 ```shell
@@ -26,6 +26,11 @@ This example would sort numerically according to major and minor version (ie v1.
 
 ```shell
 acorn run myorg/hello-world:v#.#-**
+```
+
+NOTE: Depending on your shell, you may see errors when using `*` and `**`. Using quotes will tell the shell to ignore them so Acorn can parse them:
+```shell
+acorn run "myorg/hello-world:v#.#-**"
 ```
 
 Automatic upgrades can be configured explicitly via a flag.

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -78,6 +78,9 @@ func NewRun(c client.CommandContext) *cobra.Command {
   # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
   acorn run myorg/hello-world:v#.#-**
 
+  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
+  acorn run "myorg/hello-world:v#.#-**" 
+
   # Automatic upgrades can be configured explicitly via a flag.
   # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
   acorn run --auto-upgrade myorg/hello-world:latest


### PR DESCRIPTION
Certain shells will try to parse '*' and '**' before sending arguments to the CLI. This results in errors from the shell. This change adds info about using quotes when such errors happen.

Issue:
https://github.com/acorn-io/acorn/issues/1032