### PR TITLE
Avoid object lookups in config if acorn dns is disabled

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+)
+
+func TestAcornDNSDisabledNoLookupsHappen(t *testing.T) {
+	s := "not exactly disabled, but any string that doesn't equal" +
+		" auto or enabled should be treated as disabled"
+	_ = complete(context.Background(), &apiv1.Config{
+		AcornDNS: &s,
+	}, nil)
+	// if a lookup is going to happen this method would panic as the getter is nil
+}


### PR DESCRIPTION
Currently we always lookup all v1.Node objects to determine if we should
lookup and use an Acorn DNS provisioned domain. We do this even if
Acorn DNS is disabled, and other conditions where the v1.Node lookup is
not required. This change makes it such that if Acorn DNS is specifically
disabled then don't lookup v1.Node objects.

Signed-off-by: Darren Shepherd <darren@acorn.io>
