### PR TITLE
Add registry to acorn image print outs and fix query based off specific tag in acorn image (#1043 #1044)

### DIFF
--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -53,9 +53,7 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(image.Digest, args[0]) {
-			tagToMatch = ""
-		} else {
+		if !strings.Contains(image.Digest, args[0]) {
 			//normalize through ParseReference inorder to add :latest tag to input if necessary
 			imageParsedReference, err := name.ParseReference(args[0], name.WithDefaultRegistry(""))
 			if err != nil {
@@ -76,7 +74,7 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 
 	if a.Containers {
 		//only display first tag in -c <tag>
-		if image != nil && len(image.Tags) != 0 && tagToMatch == "" {
+		if image != nil && len(image.Tags) != 0 && tagToMatch == "" && len(args) != 0 {
 			args[0] = image.Tags[0]
 			tagToMatch = image.Tags[0]
 		}
@@ -181,7 +179,7 @@ func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Cl
 			for _, tag := range imageContainer.Tags {
 				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""))
 				if err != nil {
-					return err
+					continue
 				}
 				if tagToMatch == imageParsedTag.Name() || tagToMatch == "" {
 					imageContainerPrint.Tag = imageParsedTag.TagStr()

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -45,15 +45,24 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	var images []apiv1.Image
+	var image *apiv1.Image
+	tagToMatch := ""
+
 	if len(args) == 1 {
-		image, err := c.ImageGet(cmd.Context(), args[0])
+		image, err = c.ImageGet(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
-		if strings.Contains(image.Digest, args[0]) && len(image.Tags) != 0 {
-			args[0] = image.Tags[0]
+		if strings.Contains(image.Digest, args[0]) {
+			tagToMatch = ""
+		} else {
+			//normalize through ParseReference inorder to add :latest tag to input if necessary
+			imageParsedReference, err := name.ParseReference(args[0], name.WithDefaultRegistry(""))
+			if err != nil {
+				return err
+			}
+			tagToMatch = imageParsedReference.Name()
 		}
-
 		images = []apiv1.Image{*image}
 
 		// If an image was provided explicitly, then display it even if it doesn't have tags
@@ -66,7 +75,13 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if a.Containers {
-		return printContainerImages(images, cmd.Context(), c, a, args)
+		//only display first tag in -c <tag>
+		if image != nil && len(image.Tags) != 0 && tagToMatch == "" {
+			args[0] = image.Tags[0]
+			tagToMatch = image.Tags[0]
+		}
+
+		return printContainerImages(images, cmd.Context(), c, a, args, tagToMatch)
 	}
 
 	out := table.NewWriter(tables.ImageAcorn, false, a.Output)
@@ -89,26 +104,24 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 			Digest: image.Digest,
 			Tag:    "",
 		}
+		if len(image.Tags) == 0 && a.All {
+			out.Write(imagePrint)
+			continue
+		}
 		for _, tag := range image.Tags {
 			imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""))
 			if err != nil {
 				return err
 			}
-			if tag == "" && !a.All {
-				continue
-			}
-			if tag == "" {
-				out.Write(imagePrint)
-				continue
-			} else {
+			if tagToMatch == imageParsedTag.Name() || tagToMatch == "" {
 				imagePrint.Tag = imageParsedTag.TagStr()
+				if imageParsedTag.RegistryStr() != "" {
+					imagePrint.Repository = imageParsedTag.RegistryStr() + "/"
+				}
+				imagePrint.Repository += imageParsedTag.RepositoryStr()
+				out.Write(imagePrint)
+				imagePrint.Repository = ""
 			}
-
-			imagePrint.Repository = imageParsedTag.RepositoryStr()
-			out.Write(imagePrint)
-		}
-		if len(image.Tags) == 0 && a.All {
-			out.Write(imagePrint)
 		}
 	}
 
@@ -138,11 +151,7 @@ type imageContainerPrint struct {
 	ImageID   string
 }
 
-func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Client, a *Image, args []string) error {
-	tagToMatch := ""
-	if len(args) == 1 {
-		tagToMatch = args[0]
-	}
+func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Client, a *Image, args []string, tagToMatch string) error {
 	out := table.NewWriter(tables.ImageContainer, a.Quiet, a.Output)
 
 	if a.Quiet {
@@ -163,23 +172,26 @@ func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Cl
 				Digest:    imageContainer.Digest,
 				ImageID:   imageContainer.ImageID,
 			}
-			for _, tag := range imageContainer.Tags {
-				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""))
-				if err != nil {
-					continue
-				}
-				if tagToMatch == "" || tagToMatch == tag {
-					if a.All || tag != "" {
-						imageContainerPrint.Tag = imageParsedTag.TagStr()
-						imageContainerPrint.Repo = imageParsedTag.RepositoryStr()
-						out.Write(imageContainerPrint)
-					}
-				}
-			}
 			if len(imageContainer.Tags) == 0 && a.All {
 				imageContainerPrint.Tag = "<none>"
 				imageContainerPrint.Repo = "<none>"
 				out.Write(imageContainerPrint)
+				continue
+			}
+			for _, tag := range imageContainer.Tags {
+				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""))
+				if err != nil {
+					return err
+				}
+				if tagToMatch == imageParsedTag.Name() || tagToMatch == "" {
+					imageContainerPrint.Tag = imageParsedTag.TagStr()
+					if imageParsedTag.RegistryStr() != "" {
+						imageContainerPrint.Repo = imageParsedTag.RegistryStr() + "/"
+					}
+					imageContainerPrint.Repo += imageParsedTag.RepositoryStr()
+					out.Write(imageContainerPrint)
+					imageContainerPrint.Repo = ""
+				}
 			}
 		}
 	}

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -164,6 +164,177 @@ func TestImage(t *testing.T) {
 			wantOut: "found-image1234567\nfound-image-no-tag\nfound-image-two-tags1234567\nfound-image-two-tags1234567\n",
 		},
 		{
+			name: "acorn image testtag", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"testtag"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\n",
+		},
+		{
+			name: "acorn image testtag1", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"testtag1"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag1     latest    found-image-\n",
+		},
+		{
+			name: "acorn image digest", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"lkjhgfdsa1234567890"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
+		},
+		{
+			name: "acorn image registry specific tag", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"index.docker.io/subdir/test:v1"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\n",
+		},
+		{
+			name: "acorn image digest multi tag", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"registry1234567"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\nindex.docker.io/subdir/test   v2        registy12345\n",
+		},
+		{
+			name: "acorn image digest multi tag", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"registry1234567"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\nindex.docker.io/subdir/test   v2        registy12345\n",
+		},
+		{
+			name: "acorn image -c digest multi tag", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"-c", "registry1234567"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID                  CONTAINER                      DIGEST\nindex.docker.io/subdir/test   v1        registy1234567-two-tags   test-image-running-container   test-image-running-container\n",
+		},
+		{
+			name: "acorn image -q digest multi tag", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"-q", "registry1234567"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "registy1234567-two-tags\nregisty1234567-two-tags\n",
+		},
+		{
+			name: "acorn image -q -c digest multi tag", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"-q", "-c", "registry1234567"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "index.docker.io/subdir/test:v1@test-image-running-container\n",
+		},
+		{
 			name: "acorn image rm found-image1234567", fields: fields{
 				All:    false,
 				Quiet:  false,
@@ -240,20 +411,23 @@ func TestImage(t *testing.T) {
 			wantOut: "found-image-two-tags1234567\n",
 		},
 	}
+
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewImage(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewImage(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -407,6 +407,41 @@ func (m *MockClient) ImageGet(ctx context.Context, name string) (*apiv1.Image, e
 		return &apiv1.Image{}, nil
 	case "found.image-two-tags":
 		return &apiv1.Image{}, nil
+	case "testtag":
+		return &apiv1.Image{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+			Tags:       []string{"testtag:latest"},
+			Digest:     "1234567890asdfghkl",
+		}, nil
+	case "testtag1":
+		return &apiv1.Image{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+			Tags:       []string{"testtag1:latest", "testtag2:v1"},
+			Digest:     "lkjhgfdsa1234567890",
+		}, nil
+	case "lkjhgfdsa1234567890":
+		return &apiv1.Image{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+			Tags:       []string{"testtag1:latest", "testtag2:v1"},
+			Digest:     "lkjhgfdsa1234567890",
+		}, nil
+	case "index.docker.io/subdir/test:v1":
+		return &apiv1.Image{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
+			Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
+			Digest:     "registry1234567",
+		}, nil
+	case "registry1234567":
+		return &apiv1.Image{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
+			Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
+			Digest:     "registry1234567",
+		}, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
This PR  helps provide clarity to `acorn image` outputs by including the registry to console. It also address a bug that would occur when running `acorn image <tag>` where all tags attached to that image would be outputted. The expected behavior of only displaying the queried tag should be achieved now.

Issues #1043 #1044 
Signed-off-by: Joshua Silverio <joshua@acorn.io>