### PR TITLE
Avoid panic when login has no args

### DIFF
--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -55,7 +55,7 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && a.Password != "" {
 		// HubServer slice length is guaranteed to be >=1 by the ReadCLIConfig method
 		serverAddress = cfg.HubServers[0]
-	} else {
+	} else if len(args) > 0 {
 		serverAddress = args[0]
 	}
 


### PR DESCRIPTION
This is currently an in between state because zero args should
default to acorn.io but acorn.io is not ready yet.

Signed-off-by: Darren Shepherd <darren@acorn.io>
