### PR TITLE
Cut generated app url hash suffix to 8 characters

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ var (
 	DefaultImageCheckIntervalDefault = "5m"
 
 	// Default HttpEndpointPattern set to enable Let's Encrypt
-	DefaultHttpEndpointPattern = "{{printf \"%s-%s-%s\" .Container .App .Hash | truncate}}.{{.ClusterDomain}}"
+	DefaultHttpEndpointPattern = "{{hashConcat 8 .Container .App .Namespace | truncate}}.{{.ClusterDomain}}"
 )
 
 func complete(ctx context.Context, c *apiv1.Config, getter kclient.Reader) error {

--- a/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     "acorn.io/service-name": "oneimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"ci1.acorn.not":{"port":81,"service":"oneimage"},"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade9cb9.local.on-acorn.io":{"port":81,"service":"oneimage"}}'
+    acorn.io/targets: '{"ci1.acorn.not":{"port":81,"service":"oneimage"},"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.on-acorn.io":{"port":81,"service":"oneimage"}}'
 spec:
   rules:
     - host: localhost
@@ -32,7 +32,7 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-    - host: oneimage-app-name-a5b0aade9cb9.local.on-acorn.io
+    - host: oneimage-app-name-a5b0aade.local.on-acorn.io
       http:
         paths:
           - backend:
@@ -58,10 +58,10 @@ metadata:
     "acorn.io/service-name": "buildimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"buildimage-app-name-40018221221c.local.on-acorn.io":{"port":81,"service":"buildimage"}}'
+    acorn.io/targets: '{"buildimage-app-name-40018221.local.on-acorn.io":{"port":81,"service":"buildimage"}}'
 spec:
   rules:
-    - host: buildimage-app-name-40018221221c.local.on-acorn.io
+    - host: buildimage-app-name-40018221.local.on-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     "globall1": "value"
     "globall2": "value"
   annotations:
-    "acorn.io/targets": '{"con1-app-name-2aaa22510108.local.on-acorn.io":{"port":81,"service":"con1"}}'
+    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.on-acorn.io":{"port":81,"service":"con1"}}'
     "allconsa1": "value"
     "cona1": "value"
     "cona3": "value"
@@ -22,7 +22,7 @@ metadata:
     "globala2": "value"
 spec:
   rules:
-    - host: con1-app-name-2aaa22510108.local.on-acorn.io
+    - host: con1-app-name-2aaa2251.local.on-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.yaml.d/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     "acorn.io/service-name": "app1"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"app1-app-name-04396c88dd5a.local.on-acorn.io":{"port":81,"service":"app1"},"ci1.acorn.not":{"port":81,"service":"app1"}}'
+    acorn.io/targets: '{"app1-app-name-04396c88.local.on-acorn.io":{"port":81,"service":"app1"},"ci1.acorn.not":{"port":81,"service":"app1"}}'
 spec:
   rules:
     - host: ci1.acorn.not
@@ -22,7 +22,7 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-    - host: app1-app-name-04396c88dd5a.local.on-acorn.io
+    - host: app1-app-name-04396c88.local.on-acorn.io
       http:
         paths:
           - backend:
@@ -48,7 +48,7 @@ metadata:
     "acorn.io/service-name": "app2"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"app2-app-name-5aa0a7481ff4.local.on-acorn.io":{"port":81,"service":"app2"},"ci1.acorn.not":{"port":81,"service":"app2"}}'
+    acorn.io/targets: '{"app2-app-name-5aa0a748.local.on-acorn.io":{"port":81,"service":"app2"},"ci1.acorn.not":{"port":81,"service":"app2"}}'
 spec:
   rules:
     - host: ci1.acorn.not
@@ -61,7 +61,7 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-    - host: app2-app-name-5aa0a7481ff4.local.on-acorn.io
+    - host: app2-app-name-5aa0a748.local.on-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     "globall1": "value"
     "globall2": "value"
   annotations:
-    "acorn.io/targets": '{"con1-app-name-2aaa22510108.local.on-acorn.io":{"port":81,"service":"con1"}}'
+    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.on-acorn.io":{"port":81,"service":"con1"}}'
     "allconsa1": "value"
     "cona1": "value"
     "cona3": "value"
@@ -22,7 +22,7 @@ metadata:
     "globala2": "value"
 spec:
   rules:
-    - host: con1-app-name-2aaa22510108.local.on-acorn.io
+    - host: con1-app-name-2aaa2251.local.on-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     "globall1": "value"
     "globall2": "value"
   annotations:
-    "acorn.io/targets": '{"con1-app-name-2aaa22510108.local.on-acorn.io":{"port":81,"service":"con1"}}'
+    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.on-acorn.io":{"port":81,"service":"con1"}}'
     "allconsa1": "value"
     "cona1": "value"
     "cona3": "value"
@@ -22,7 +22,7 @@ metadata:
     "globala2": "value"
 spec:
   rules:
-    - host: con1-app-name-2aaa22510108.local.on-acorn.io
+    - host: con1-app-name-2aaa2251.local.on-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/appdefinition/testdata/router/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/router/expected.yaml.d/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     acorn.io/managed: "true"
     acorn.io/service-name: router-name
   annotations:
-    acorn.io/targets: '{"router-name-app-name-3de5df498ac6.local.on-acorn.io":{"port":8080,"service":"router-name"}}'
+    acorn.io/targets: '{"router-name-app-name-3de5df49.local.on-acorn.io":{"port":8080,"service":"router-name"}}'
 spec:
   rules:
-    - host: router-name-app-name-3de5df498ac6.local.on-acorn.io
+    - host: router-name-app-name-3de5df49.local.on-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     "con2key": "value"
     "both": "con2val"
   annotations:
-    acorn.io/targets: '{"localhost":{"port":81,"service":"svc1"},"svc1-app-name-df05fde61781.local.on-acorn.io":{"port":81,"service":"svc1"}}'
+    acorn.io/targets: '{"localhost":{"port":81,"service":"svc1"},"svc1-app-name-df05fde6.local.on-acorn.io":{"port":81,"service":"svc1"}}'
     "con1": "value"
     "con2": "value"
     "both": "con2val"
@@ -28,7 +28,7 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-    - host: svc1-app-name-df05fde61781.local.on-acorn.io
+    - host: svc1-app-name-df05fde6.local.on-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     "acorn.io/service-name": "oneimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade9cb9.local.on-acorn.io":{"port":81,"service":"oneimage"}}'
+    acorn.io/targets: '{"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.on-acorn.io":{"port":81,"service":"oneimage"}}'
 spec:
   rules:
     - host: localhost
@@ -22,7 +22,7 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-    - host: oneimage-app-name-a5b0aade9cb9.local.on-acorn.io
+    - host: oneimage-app-name-a5b0aade.local.on-acorn.io
       http:
         paths:
           - backend:
@@ -44,10 +44,10 @@ metadata:
     "acorn.io/service-name": "buildimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"buildimage-app-name-40018221221c.local.on-acorn.io":{"port":81,"service":"buildimage"}}'
+    acorn.io/targets: '{"buildimage-app-name-40018221.local.on-acorn.io":{"port":81,"service":"buildimage"}}'
 spec:
   rules:
-    - host: buildimage-app-name-40018221221c.local.on-acorn.io
+    - host: buildimage-app-name-40018221.local.on-acorn.io
       http:
         paths:
           - backend:


### PR DESCRIPTION
The current generated url uses the first 12 characters of a hash of serviceName + appName + namespace, which is a bit longer and undesirable. Cut down to 8 to make url a little bit nicer.

This change will probably need to be made into changelog for the next release as it changes the format of user's app url. 