### PR TITLE
refactor cli unit tests to specify app, credential, container, image, secret or volume to return in test (#868)

### DIFF
--- a/pkg/cli/acorn_test.go
+++ b/pkg/cli/acorn_test.go
@@ -53,20 +53,22 @@ func TestAcorn(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = New()
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			testOut, _ := os.ReadFile(tt.wantOut)
-			assert.Equal(t, string(testOut), string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = New()
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				testOut, _ := os.ReadFile(tt.wantOut)
+				assert.Equal(t, string(testOut), string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/all_test.go
+++ b/pkg/cli/all_test.go
@@ -6,12 +6,29 @@ import (
 	"strings"
 	"testing"
 
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/cli/testdata"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAll(t *testing.T) {
+	var DefaultImageList = []apiv1.Image{{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+		Tags:       []string{"testtag:latest"},
+		Digest:     "1234567890asdfghkl",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
+		Digest:     "lkjhgfdsa0987654321",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+		Tags:       []string{"testtag1:latest", "testtag2:v1"},
+		Digest:     "lkjhgfdsa1234567890",
+	}}
 	type fields struct {
 		Quiet  bool
 		Output string
@@ -38,7 +55,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -57,7 +74,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -76,7 +93,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -95,7 +112,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -109,20 +126,22 @@ func TestAll(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewAll(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			testOut, _ := os.ReadFile(tt.wantOut)
-			assert.Equal(t, string(testOut), string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewAll(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				testOut, _ := os.ReadFile(tt.wantOut)
+				assert.Equal(t, string(testOut), string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/all_test.go
+++ b/pkg/cli/all_test.go
@@ -6,29 +6,12 @@ import (
 	"strings"
 	"testing"
 
-	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/cli/testdata"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAll(t *testing.T) {
-	var DefaultImageList = []apiv1.Image{{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
-		Tags:       []string{"testtag:latest"},
-		Digest:     "1234567890asdfghkl",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
-		Digest:     "lkjhgfdsa0987654321",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-		Tags:       []string{"testtag1:latest", "testtag2:v1"},
-		Digest:     "lkjhgfdsa1234567890",
-	}}
 	type fields struct {
 		Quiet  bool
 		Output string
@@ -55,7 +38,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -74,7 +57,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -93,7 +76,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -112,7 +95,7 @@ func TestAll(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -90,19 +90,21 @@ func TestApp(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewApp(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewApp(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -129,13 +129,29 @@ func TestAppsThenContainersCompletion(t *testing.T) {
 }
 
 func TestAppsCompletion(t *testing.T) {
+	var DefaultImageList = []apiv1.Image{{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+		Tags:       []string{"testtag:latest"},
+		Digest:     "1234567890asdfghkl",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
+		Digest:     "lkjhgfdsa0987654321",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+		Tags:       []string{"testtag1:latest", "testtag2:v1"},
+		Digest:     "lkjhgfdsa1234567890",
+	}}
 	names := []string{"test-1", "acorn-1", "acorn-2", "hub", "test-2"}
 	apps := make([]apiv1.App, 0, len(names))
 	for _, name := range names {
 		apps = append(apps, apiv1.App{ObjectMeta: metav1.ObjectMeta{Name: name}})
 	}
 	mockClientFactory := &testdata.MockClientFactory{
-		AppList: apps,
+		AppList:   apps,
+		ImageList: DefaultImageList,
 	}
 	cmd := new(cobra.Command)
 	cmd.SetContext(context.Background())
@@ -601,7 +617,22 @@ func TestOnlyAppsWithAcornContainer(t *testing.T) {
 }
 
 func TestImagesCompletion(t *testing.T) {
-	mockClientFactory := &testdata.MockClientFactory{}
+	var DefaultImageList = []apiv1.Image{{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+		Tags:       []string{"testtag:latest"},
+		Digest:     "1234567890asdfghkl",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
+		Digest:     "lkjhgfdsa0987654321",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+		Tags:       []string{"testtag1:latest", "testtag2:v1"},
+		Digest:     "lkjhgfdsa1234567890",
+	}}
+	mockClientFactory := &testdata.MockClientFactory{ImageList: DefaultImageList}
 	cmd := new(cobra.Command)
 	cmd.SetContext(context.Background())
 

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -129,29 +129,13 @@ func TestAppsThenContainersCompletion(t *testing.T) {
 }
 
 func TestAppsCompletion(t *testing.T) {
-	var DefaultImageList = []apiv1.Image{{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
-		Tags:       []string{"testtag:latest"},
-		Digest:     "1234567890asdfghkl",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
-		Digest:     "lkjhgfdsa0987654321",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-		Tags:       []string{"testtag1:latest", "testtag2:v1"},
-		Digest:     "lkjhgfdsa1234567890",
-	}}
 	names := []string{"test-1", "acorn-1", "acorn-2", "hub", "test-2"}
 	apps := make([]apiv1.App, 0, len(names))
 	for _, name := range names {
 		apps = append(apps, apiv1.App{ObjectMeta: metav1.ObjectMeta{Name: name}})
 	}
 	mockClientFactory := &testdata.MockClientFactory{
-		AppList:   apps,
-		ImageList: DefaultImageList,
+		AppList: apps,
 	}
 	cmd := new(cobra.Command)
 	cmd.SetContext(context.Background())
@@ -617,22 +601,7 @@ func TestOnlyAppsWithAcornContainer(t *testing.T) {
 }
 
 func TestImagesCompletion(t *testing.T) {
-	var DefaultImageList = []apiv1.Image{{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
-		Tags:       []string{"testtag:latest"},
-		Digest:     "1234567890asdfghkl",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
-		Digest:     "lkjhgfdsa0987654321",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-		Tags:       []string{"testtag1:latest", "testtag2:v1"},
-		Digest:     "lkjhgfdsa1234567890",
-	}}
-	mockClientFactory := &testdata.MockClientFactory{ImageList: DefaultImageList}
+	mockClientFactory := &testdata.MockClientFactory{}
 	cmd := new(cobra.Command)
 	cmd.SetContext(context.Background())
 

--- a/pkg/cli/containers_test.go
+++ b/pkg/cli/containers_test.go
@@ -128,19 +128,21 @@ func TestContainer(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewContainer(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewContainer(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -6,12 +6,29 @@ import (
 	"strings"
 	"testing"
 
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/cli/testdata"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestImage(t *testing.T) {
+	var DefaultImageList = []apiv1.Image{{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+		Tags:       []string{"testtag:latest"},
+		Digest:     "1234567890asdfghkl",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
+		Digest:     "lkjhgfdsa0987654321",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+		Tags:       []string{"testtag1:latest", "testtag2:v1"},
+		Digest:     "lkjhgfdsa1234567890",
+	}}
 	type fields struct {
 		Quiet  bool
 		Output string
@@ -38,7 +55,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -57,7 +74,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -76,7 +93,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -95,7 +112,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -114,7 +131,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -133,7 +150,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -151,7 +168,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
+				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -170,10 +187,15 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+						Tags:       []string{"testtag:latest"},
+						Digest:     "1234567890asdfghkl"}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"testtag"},
@@ -189,10 +211,16 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+						Tags:       []string{"testtag1:latest", "testtag2:v1"},
+						Digest:     "lkjhgfdsa1234567890",
+					}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"testtag1"},
@@ -208,10 +236,15 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+						Tags:       []string{"testtag1:latest", "testtag2:v1"},
+						Digest:     "lkjhgfdsa1234567890"}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"lkjhgfdsa1234567890"},
@@ -227,10 +260,15 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
+						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
+						Digest:     "registry1234567"}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"index.docker.io/subdir/test:v1"},
@@ -246,29 +284,15 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
-			},
-			args: args{
-				args:   []string{"registry1234567"},
-				client: &testdata.MockClient{},
-			},
-			wantErr: false,
-			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\nindex.docker.io/subdir/test   v2        registy12345\n",
-		},
-		{
-			name: "acorn image digest multi tag", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
+						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
+						Digest:     "registry1234567"}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"registry1234567"},
@@ -284,10 +308,15 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
+						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
+						Digest:     "registry1234567"}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"-c", "registry1234567"},
@@ -303,10 +332,15 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
+						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
+						Digest:     "registry1234567"}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"-q", "registry1234567"},
@@ -322,10 +356,15 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
+						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
+						Digest:     "registry1234567"}},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"-q", "-c", "registry1234567"},
@@ -341,10 +380,12 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader("y\n"),
+				ClientFactory: &testdata.MockClientFactory{
+					ImageItem: &apiv1.Image{},
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
 				args:   []string{"rm", "found-image1234567"},

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -14,21 +14,6 @@ import (
 )
 
 func TestImage(t *testing.T) {
-	var DefaultImageList = []apiv1.Image{{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
-		Tags:       []string{"testtag:latest"},
-		Digest:     "1234567890asdfghkl",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
-		Digest:     "lkjhgfdsa0987654321",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-		Tags:       []string{"testtag1:latest", "testtag2:v1"},
-		Digest:     "lkjhgfdsa1234567890",
-	}}
 	type fields struct {
 		Quiet  bool
 		Output string
@@ -55,7 +40,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -74,7 +59,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -93,7 +78,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -112,7 +97,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -131,7 +116,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -150,7 +135,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -168,7 +153,7 @@ func TestImage(t *testing.T) {
 				Output: "",
 			},
 			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{ImageList: DefaultImageList},
+				ClientFactory: &testdata.MockClientFactory{},
 				StdOut:        w,
 				StdErr:        w,
 				StdIn:         strings.NewReader("y\n"),
@@ -189,7 +174,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
 						Tags:       []string{"testtag:latest"},
 						Digest:     "1234567890asdfghkl"}},
@@ -213,7 +197,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
 						Tags:       []string{"testtag1:latest", "testtag2:v1"},
 						Digest:     "lkjhgfdsa1234567890",
@@ -238,7 +221,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
 						Tags:       []string{"testtag1:latest", "testtag2:v1"},
 						Digest:     "lkjhgfdsa1234567890"}},
@@ -262,7 +244,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
 						Digest:     "registry1234567"}},
@@ -286,7 +267,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
 						Digest:     "registry1234567"}},
@@ -310,7 +290,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
 						Digest:     "registry1234567"}},
@@ -334,7 +313,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
 						Digest:     "registry1234567"}},
@@ -358,7 +336,6 @@ func TestImage(t *testing.T) {
 			commandContext: CommandContext{
 				ClientFactory: &testdata.MockClientFactory{
 					ImageItem: &apiv1.Image{
-						TypeMeta:   metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
 						Digest:     "registry1234567"}},

--- a/pkg/cli/info_test.go
+++ b/pkg/cli/info_test.go
@@ -90,20 +90,22 @@ func TestInfo(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewInfo(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			testOut, _ := os.ReadFile(tt.wantOut)
-			assert.Equal(t, string(testOut), string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewInfo(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				testOut, _ := os.ReadFile(tt.wantOut)
+				assert.Equal(t, string(testOut), string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/log_test.go
+++ b/pkg/cli/log_test.go
@@ -109,19 +109,21 @@ func TestLog(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewLogs(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewLogs(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/pull_test.go
+++ b/pkg/cli/pull_test.go
@@ -71,19 +71,21 @@ func TestPull(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewPull(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewPull(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/push_test.go
+++ b/pkg/cli/push_test.go
@@ -71,19 +71,21 @@ func TestPush(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewPush(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewPush(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/render_test.go
+++ b/pkg/cli/render_test.go
@@ -71,20 +71,22 @@ func TestRender(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewRender(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			testOut, _ := os.ReadFile(tt.wantOut)
-			assert.Equal(t, string(testOut), string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewRender(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				testOut, _ := os.ReadFile(tt.wantOut)
+				assert.Equal(t, string(testOut), string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/secret_test.go
+++ b/pkg/cli/secret_test.go
@@ -223,19 +223,21 @@ func TestSecret(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewSecret(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewSecret(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -71,19 +71,21 @@ func TestStart(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewStart(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewStart(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/stop_test.go
+++ b/pkg/cli/stop_test.go
@@ -71,19 +71,21 @@ func TestStop(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewStop(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewStop(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/tag_test.go
+++ b/pkg/cli/tag_test.go
@@ -71,19 +71,21 @@ func TestTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewTag(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewTag(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -16,10 +16,17 @@ import (
 
 type MockClientFactory struct {
 	AppList        []apiv1.App
+	AppItem        *apiv1.App
 	ContainerList  []apiv1.ContainerReplica
+	ContainerItem  *apiv1.ContainerReplica
 	CredentialList []apiv1.Credential
+	CredentialItem *apiv1.Credential
 	VolumeList     []apiv1.Volume
+	VolumeItem     *apiv1.Volume
 	SecretList     []apiv1.Secret
+	SecretItem     *apiv1.Secret
+	ImageList      []apiv1.Image
+	ImageItem      *apiv1.Image
 }
 
 func (dc *MockClientFactory) Options() project.Options {
@@ -28,20 +35,34 @@ func (dc *MockClientFactory) Options() project.Options {
 
 func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 	return &MockClient{
-		Apps:        dc.AppList,
-		Containers:  dc.ContainerList,
-		Credentials: dc.CredentialList,
-		Volumes:     dc.VolumeList,
-		Secrets:     dc.SecretList,
+		Apps:           dc.AppList,
+		Containers:     dc.ContainerList,
+		Credentials:    dc.CredentialList,
+		Volumes:        dc.VolumeList,
+		Secrets:        dc.SecretList,
+		Images:         dc.ImageList,
+		AppItem:        dc.AppItem,
+		ContainerItem:  dc.ContainerItem,
+		CredentialItem: dc.CredentialItem,
+		VolumeItem:     dc.VolumeItem,
+		SecretItem:     dc.SecretItem,
+		ImageItem:      dc.ImageItem,
 	}, nil
 }
 
 type MockClient struct {
-	Apps        []apiv1.App
-	Containers  []apiv1.ContainerReplica
-	Credentials []apiv1.Credential
-	Volumes     []apiv1.Volume
-	Secrets     []apiv1.Secret
+	Apps           []apiv1.App
+	AppItem        *apiv1.App
+	Containers     []apiv1.ContainerReplica
+	ContainerItem  *apiv1.ContainerReplica
+	Credentials    []apiv1.Credential
+	CredentialItem *apiv1.Credential
+	Volumes        []apiv1.Volume
+	VolumeItem     *apiv1.Volume
+	Secrets        []apiv1.Secret
+	SecretItem     *apiv1.Secret
+	Images         []apiv1.Image
+	ImageItem      *apiv1.Image
 }
 
 func (m *MockClient) AppPullImage(ctx context.Context, name string) error {
@@ -61,6 +82,9 @@ func (m *MockClient) AppList(ctx context.Context) ([]apiv1.App, error) {
 }
 
 func (m *MockClient) AppDelete(ctx context.Context, name string) (*apiv1.App, error) {
+	if m.AppItem != nil {
+		return m.AppItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: app %s does not exist", name)
@@ -73,6 +97,9 @@ func (m *MockClient) AppDelete(ctx context.Context, name string) (*apiv1.App, er
 }
 
 func (m *MockClient) AppGet(ctx context.Context, name string) (*apiv1.App, error) {
+	if m.AppItem != nil {
+		return m.AppItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: app %s does not exist", name)
@@ -119,6 +146,9 @@ func (m *MockClient) AppStart(ctx context.Context, name string) error {
 }
 
 func (m *MockClient) AppRun(ctx context.Context, image string, opts *client.AppRunOptions) (*apiv1.App, error) {
+	if m.AppItem != nil {
+		return m.AppItem, nil
+	}
 	switch image {
 	case "dne":
 		return nil, fmt.Errorf("error: app %s does not exist", image)
@@ -141,6 +171,9 @@ func (m *MockClient) AppRun(ctx context.Context, image string, opts *client.AppR
 }
 
 func (m *MockClient) AppUpdate(ctx context.Context, name string, opts *client.AppUpdateOptions) (*apiv1.App, error) {
+	if m.AppItem != nil {
+		return m.AppItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: app %s does not exist", name)
@@ -198,6 +231,9 @@ func (m *MockClient) CredentialList(ctx context.Context) ([]apiv1.Credential, er
 }
 
 func (m *MockClient) CredentialGet(ctx context.Context, serverAddress string) (*apiv1.Credential, error) {
+	if m.CredentialItem != nil {
+		return m.CredentialItem, nil
+	}
 	switch serverAddress {
 	case "dne":
 		return nil, fmt.Errorf("error: cred %s does not exist", serverAddress)
@@ -216,14 +252,23 @@ func (m *MockClient) CredentialGet(ctx context.Context, serverAddress string) (*
 }
 
 func (m *MockClient) CredentialUpdate(ctx context.Context, serverAddress, username, password string, skipChecks bool) (*apiv1.Credential, error) {
+	if m.CredentialItem != nil {
+		return m.CredentialItem, nil
+	}
 	return nil, nil
 }
 
 func (m *MockClient) CredentialDelete(ctx context.Context, serverAddress string) (*apiv1.Credential, error) {
+	if m.CredentialItem != nil {
+		return m.CredentialItem, nil
+	}
 	return nil, nil
 }
 
 func (m *MockClient) SecretCreate(ctx context.Context, name, secretType string, data map[string][]byte) (*apiv1.Secret, error) {
+	if m.SecretItem != nil {
+		return m.SecretItem, nil
+	}
 	return nil, nil
 }
 
@@ -241,6 +286,9 @@ func (m *MockClient) SecretList(ctx context.Context) ([]apiv1.Secret, error) {
 }
 
 func (m *MockClient) SecretGet(ctx context.Context, name string) (*apiv1.Secret, error) {
+	if m.SecretItem != nil {
+		return m.SecretItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: Secret %s does not exist", name)
@@ -257,6 +305,9 @@ func (m *MockClient) SecretGet(ctx context.Context, name string) (*apiv1.Secret,
 }
 
 func (m *MockClient) SecretReveal(ctx context.Context, name string) (*apiv1.Secret, error) {
+	if m.SecretItem != nil {
+		return m.SecretItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: Secret %s does not exist", name)
@@ -273,10 +324,16 @@ func (m *MockClient) SecretReveal(ctx context.Context, name string) (*apiv1.Secr
 }
 
 func (m *MockClient) SecretUpdate(ctx context.Context, name string, data map[string][]byte) (*apiv1.Secret, error) {
+	if m.SecretItem != nil {
+		return m.SecretItem, nil
+	}
 	return nil, nil
 }
 
 func (m *MockClient) SecretDelete(ctx context.Context, name string) (*apiv1.Secret, error) {
+	if m.SecretItem != nil {
+		return m.SecretItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, nil
@@ -309,6 +366,9 @@ func (m *MockClient) ContainerReplicaList(ctx context.Context, opts *client.Cont
 }
 
 func (m *MockClient) ContainerReplicaGet(ctx context.Context, name string) (*apiv1.ContainerReplica, error) {
+	if m.ContainerItem != nil {
+		return m.ContainerItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: container %s does not exist", name)
@@ -332,6 +392,9 @@ func (m *MockClient) ContainerReplicaGet(ctx context.Context, name string) (*api
 }
 
 func (m *MockClient) ContainerReplicaDelete(ctx context.Context, name string) (*apiv1.ContainerReplica, error) {
+	if m.ContainerItem != nil {
+		return m.ContainerItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, nil
@@ -358,6 +421,9 @@ func (m *MockClient) VolumeList(ctx context.Context) ([]apiv1.Volume, error) {
 }
 
 func (m *MockClient) VolumeGet(ctx context.Context, name string) (*apiv1.Volume, error) {
+	if m.VolumeItem != nil {
+		return m.VolumeItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: volume %s does not exist", name)
@@ -372,6 +438,9 @@ func (m *MockClient) VolumeGet(ctx context.Context, name string) (*apiv1.Volume,
 }
 
 func (m *MockClient) VolumeDelete(ctx context.Context, name string) (*apiv1.Volume, error) {
+	if m.VolumeItem != nil {
+		return m.VolumeItem, nil
+	}
 	switch name {
 	case "dne":
 		return nil, nil
@@ -382,76 +451,24 @@ func (m *MockClient) VolumeDelete(ctx context.Context, name string) (*apiv1.Volu
 }
 
 func (m *MockClient) ImageList(ctx context.Context) ([]apiv1.Image, error) {
-	return []apiv1.Image{{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
-		Tags:       []string{"testtag:latest"},
-		Digest:     "1234567890asdfghkl",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
-		Digest:     "lkjhgfdsa0987654321",
-	}, {
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-		Tags:       []string{"testtag1:latest", "testtag2:v1"},
-		Digest:     "lkjhgfdsa1234567890",
-	}}, nil
+	if m.Images != nil {
+		return m.Images, nil
+	}
+	return []apiv1.Image{}, nil
 }
 
 func (m *MockClient) ImageGet(ctx context.Context, name string) (*apiv1.Image, error) {
-	switch name {
-	case "dne":
-		return nil, nil
-	case "found.image":
-		return &apiv1.Image{}, nil
-	case "found.image-two-tags":
-		return &apiv1.Image{}, nil
-	case "testtag":
-		return &apiv1.Image{
-			TypeMeta:   metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
-			Tags:       []string{"testtag:latest"},
-			Digest:     "1234567890asdfghkl",
-		}, nil
-	case "testtag1":
-		return &apiv1.Image{
-			TypeMeta:   metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-			Tags:       []string{"testtag1:latest", "testtag2:v1"},
-			Digest:     "lkjhgfdsa1234567890",
-		}, nil
-	case "lkjhgfdsa1234567890":
-		return &apiv1.Image{
-			TypeMeta:   metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
-			Tags:       []string{"testtag1:latest", "testtag2:v1"},
-			Digest:     "lkjhgfdsa1234567890",
-		}, nil
-	case "index.docker.io/subdir/test:v1":
-		return &apiv1.Image{
-			TypeMeta:   metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
-			Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
-			Digest:     "registry1234567",
-		}, nil
-	case "registry1234567":
-		return &apiv1.Image{
-			TypeMeta:   metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
-			Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
-			Digest:     "registry1234567",
-		}, nil
+	if m.ImageItem != nil {
+		return m.ImageItem, nil
 	}
 	return nil, nil
 }
 
 func (m *MockClient) ImageDelete(ctx context.Context, name string, opts *client.ImageDeleteOptions) (*apiv1.Image, error) {
+	if m.ImageItem != nil {
+		return m.ImageItem, nil
+	}
 	switch name {
-	case "dne":
-		return nil, nil
-	case "found-image1234567":
-		return &apiv1.Image{}, nil
 	case "found-image-two-tags1234567":
 		if !opts.Force {
 			return nil, fmt.Errorf("unable to delete %s (must be forced) - image is referenced in multiple repositories", name)

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -454,7 +454,21 @@ func (m *MockClient) ImageList(ctx context.Context) ([]apiv1.Image, error) {
 	if m.Images != nil {
 		return m.Images, nil
 	}
-	return []apiv1.Image{}, nil
+	return []apiv1.Image{{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+		Tags:       []string{"testtag:latest"},
+		Digest:     "1234567890asdfghkl",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-no-tag"},
+		Digest:     "lkjhgfdsa0987654321",
+	}, {
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+		Tags:       []string{"testtag1:latest", "testtag2:v1"},
+		Digest:     "lkjhgfdsa1234567890",
+	}}, nil
 }
 
 func (m *MockClient) ImageGet(ctx context.Context, name string) (*apiv1.Image, error) {

--- a/pkg/cli/update_test.go
+++ b/pkg/cli/update_test.go
@@ -52,20 +52,22 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.commandContext.StdOut = w
-		tt.args.cmd = NewUpdate(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.commandContext.StdOut = w
+			tt.args.cmd = NewUpdate(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }

--- a/pkg/cli/volumes_test.go
+++ b/pkg/cli/volumes_test.go
@@ -166,19 +166,21 @@ func TestVolume(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-		tt.args.cmd = NewVolume(tt.commandContext)
-		tt.args.cmd.SetArgs(tt.args.args)
-		err := tt.args.cmd.Execute()
-		if err != nil && !tt.wantErr {
-			assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
-		} else if err != nil && tt.wantErr {
-			assert.Equal(t, tt.wantOut, err.Error())
-		} else {
-			w.Close()
-			out, _ := io.ReadAll(r)
-			assert.Equal(t, tt.wantOut, string(out))
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = NewVolume(tt.commandContext)
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				assert.Equal(t, tt.wantOut, string(out))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Per comments on PR #1046 this PR will allow devs to specify items to use in CLI unit tests. For more special cases, the switch statement can still be used however for general best practice defining the Item and adding to the MockClientFactory in your tests will allow for easier testing of CLI.

Issue: #868 