### PR TITLE
Don't block handlers when LE registration fails

### DIFF
--- a/pkg/controller/config/dns.go
+++ b/pkg/controller/config/dns.go
@@ -102,7 +102,7 @@ func (h *configHandler) Handle(req router.Request, resp router.Response) error {
 	}
 
 	if !strings.EqualFold(*cfg.LetsEncrypt, "disabled") {
-		if err := tls.ProvisionWildcardCert(req, domain, token); err != nil {
+		if err := tls.ProvisionWildcardCert(req, resp, domain, token); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
If LE registration fails instead of returning an error we instead just
retry 15 seconds later. If the handler fails the problem is it blocks
updating/deploying the registry server so installation fails waiting
for the registry to be active.

Signed-off-by: Darren Shepherd <darren@acorn.io>
