### PR TITLE
Be less aggressive on namespace GC

### DIFF
--- a/pkg/controller/namespace/gc.go
+++ b/pkg/controller/namespace/gc.go
@@ -17,6 +17,10 @@ func DeleteOrphaned(req router.Request, resp router.Response) error {
 	appName := req.Object.GetLabels()[labels.AcornAppName]
 	appNamespace := req.Object.GetLabels()[labels.AcornAppNamespace]
 
+	if appName == "" || appNamespace == "" {
+		return nil
+	}
+
 	err := req.Client.Get(req.Ctx, router.Key(appNamespace, appName), &v1.AppInstance{})
 	if apierror.IsNotFound(err) {
 		return req.Client.Delete(req.Ctx, ns)


### PR DESCRIPTION
We delete created namespaces for which the acorn app doesn't exist
anymore. Currently we look for acorn.io/management labeled and if
it's found then look for the corresponding app. The lookup is
done by reading the acorn.io/app-name and acorn.io/app-namespace
labels. The issue is that if the labels aren't found we just lookup
""/"" which of course doesn't exist and then we delete the namespace.
This makes it suck that if you just put the label acorn.io/managed=true
on a namespace acorn will immediately delete it. So instead we now
require that the app-name/namespace labels actually exist on the
namespace.

Signed-off-by: Darren Shepherd <darren@acorn.io>
