### PR TITLE
Normalize registry-1.docker.io to index.docker.io in buildkit

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -49,6 +49,7 @@ func ResolveAndParse(file, cwd string) (*appdefinition.AppDefinition, error) {
 
 func Build(ctx context.Context, messages buildclient.Messages, pushRepo string, opts *v1.AcornImageBuildInstanceSpec, keychain authn.Keychain, remoteOpts ...remote.Option) (*v1.AppImage, error) {
 	keychain = NewRemoteKeyChain(messages, keychain)
+	remoteOpts = append(remoteOpts, remote.WithAuthFromKeychain(keychain))
 
 	appDefinition, err := appdefinition.NewAppDefinition([]byte(opts.Acornfile))
 	if err != nil {

--- a/pkg/build/remotekeychain.go
+++ b/pkg/build/remotekeychain.go
@@ -1,12 +1,15 @@
 package build
 
 import (
+	"fmt"
 	"sync"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/buildclient"
 	images2 "github.com/acorn-io/acorn/pkg/images"
+	"github.com/acorn-io/acorn/pkg/imagesystem"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sirupsen/logrus"
 )
 
@@ -62,6 +65,14 @@ func (r *RemoteKeyChain) Resolve(resource authn.Resource) (authenticator authn.A
 			}
 		}
 	}()
+
+	address := imagesystem.NormalizeServerAddress(resource.RegistryStr())
+	if resource.RegistryStr() != address {
+		resource, err = name.NewRegistry(address)
+		if err != nil {
+			return nil, fmt.Errorf("failed to normalize registry from %s to %s", resource.RegistryStr(), address)
+		}
+	}
 
 	sent := false
 	for {

--- a/pkg/buildserver/server.go
+++ b/pkg/buildserver/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/acorn-io/acorn/pkg/build"
 	"github.com/acorn-io/acorn/pkg/buildclient"
 	"github.com/acorn-io/acorn/pkg/condition"
-	"github.com/acorn-io/acorn/pkg/images"
 	"github.com/acorn-io/acorn/pkg/imagesystem"
 	"github.com/acorn-io/acorn/pkg/k8schannel"
 	"github.com/acorn-io/acorn/pkg/pullsecret"
@@ -126,11 +125,7 @@ func (s *Server) build(ctx context.Context, messages buildclient.Messages, token
 	if err != nil {
 		return nil, err
 	}
-	opts, err := images.GetAuthenticationRemoteOptions(ctx, s.client, token.Build.Namespace)
-	if err != nil {
-		return nil, err
-	}
-	image, err := build.Build(ctx, messages, token.PushRepo, &token.Build.Spec, keychain, opts...)
+	image, err := build.Build(ctx, messages, token.PushRepo, &token.Build.Spec, keychain)
 	if err != nil {
 		_ = s.recordBuildError(ctx, &token.Build, err)
 		return nil, err

--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -6,6 +6,7 @@ import (
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/acorn/pkg/imagesystem"
 	credentials2 "github.com/acorn-io/acorn/pkg/server/registry/credentials"
 	"github.com/acorn-io/baaah/pkg/typed"
 	"github.com/docker/cli/cli/config/credentials"
@@ -42,19 +43,13 @@ func IsErrCredentialsNotFound(err error) bool {
 	return credentials3.IsErrCredentialsNotFound(err)
 }
 
-func normalizeServerAddress(address string) string {
-	if address == "docker.io" || address == "registry-1.docker.io" {
-		return "index.docker.io"
-	}
-	return address
-}
 func normalize(cred Credential) Credential {
-	cred.ServerAddress = normalizeServerAddress(cred.ServerAddress)
+	cred.ServerAddress = imagesystem.NormalizeServerAddress(cred.ServerAddress)
 	return cred
 }
 
 func (s *Store) Get(ctx context.Context, serverAddress string) (*apiv1.RegistryAuth, bool, error) {
-	serverAddress = normalizeServerAddress(serverAddress)
+	serverAddress = imagesystem.NormalizeServerAddress(serverAddress)
 	store, err := s.getStore(serverAddress)
 	if err != nil {
 		return nil, false, err

--- a/pkg/imagesystem/registry.go
+++ b/pkg/imagesystem/registry.go
@@ -17,6 +17,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func NormalizeServerAddress(address string) string {
+	if address == "docker.io" || address == "registry-1.docker.io" {
+		return "index.docker.io"
+	}
+	return address
+}
+
 func GetInternalRepoForNamespace(ctx context.Context, c client.Reader, namespace string) (name.Repository, error) {
 	cfg, err := config.Get(ctx, c)
 	if err != nil {

--- a/pkg/server/registry/credentials/strategy.go
+++ b/pkg/server/registry/credentials/strategy.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/imagesystem"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -21,7 +22,7 @@ func (s *Strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 
 func (s *Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	cred := obj.(*apiv1.Credential)
-	cred.ServerAddress = normalizeDockerIO(cred.ServerAddress)
+	cred.ServerAddress = imagesystem.NormalizeServerAddress(cred.ServerAddress)
 }
 
 func (s *Strategy) Validate(ctx context.Context, obj runtime.Object) (result field.ErrorList) {

--- a/pkg/server/registry/credentials/translator.go
+++ b/pkg/server/registry/credentials/translator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/imagesystem"
 	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/mink/pkg/types"
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +23,7 @@ type Translator struct {
 }
 
 func (t *Translator) FromPublicName(ctx context.Context, namespace, name string) (string, string, error) {
-	return namespace, strings.ReplaceAll(normalizeDockerIO(name), ":", "-"), nil
+	return namespace, strings.ReplaceAll(imagesystem.NormalizeServerAddress(name), ":", "-"), nil
 }
 
 func (t *Translator) ListOpts(ctx context.Context, namespace string, opts storage.ListOptions) (string, storage.ListOptions, error) {
@@ -108,11 +109,4 @@ func (t *Translator) NewPublicList() types.ObjectList {
 
 func (t *Translator) NewPublic() types.Object {
 	return &apiv1.Credential{}
-}
-
-func normalizeDockerIO(s string) string {
-	if s == "docker.io" {
-		return "index.docker.io"
-	}
-	return s
 }


### PR DESCRIPTION
When setting the internalRegistryPrefix to docker.io/username/ buildkit
will lookup a credential for registry-1.docker.io.  This code will
normalize registry-1.docker.io to index.docker.io which will match
the stored credentials.

Signed-off-by: Darren Shepherd <darren@acorn.io>
