### PR TITLE
Wait until digests are accessible

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -49,7 +49,7 @@ func ResolveAndParse(file, cwd string) (*appdefinition.AppDefinition, error) {
 
 func Build(ctx context.Context, messages buildclient.Messages, pushRepo string, opts *v1.AcornImageBuildInstanceSpec, keychain authn.Keychain, remoteOpts ...remote.Option) (*v1.AppImage, error) {
 	keychain = NewRemoteKeyChain(messages, keychain)
-	remoteOpts = append(remoteOpts, remote.WithAuthFromKeychain(keychain))
+	remoteOpts = append(remoteOpts, remote.WithAuthFromKeychain(keychain), remote.WithContext(ctx))
 
 	appDefinition, err := appdefinition.NewAppDefinition([]byte(opts.Acornfile))
 	if err != nil {

--- a/pkg/buildserver/token.go
+++ b/pkg/buildserver/token.go
@@ -18,7 +18,7 @@ import (
 var (
 	tokenCache = cache.NewTTLStore(func(obj interface{}) (string, error) {
 		return string(obj.([]byte)), nil
-	}, 30*time.Second)
+	}, 2*time.Minute)
 )
 
 func GetToken(req *http.Request, uuid string, pubKey, privKey *[32]byte) (*Token, error) {
@@ -55,7 +55,7 @@ func GetToken(req *http.Request, uuid string, pubKey, privKey *[32]byte) (*Token
 		return nil, fmt.Errorf("invalid builder UID %s!=%s", result.BuilderUUID, uuid)
 	}
 
-	if time.Since(result.Time.Time) > (30 * time.Second) {
+	if time.Since(result.Time.Time) > time.Minute {
 		return nil, fmt.Errorf("expired token")
 	}
 

--- a/pkg/client/builder.go
+++ b/pkg/client/builder.go
@@ -2,10 +2,10 @@ package client
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/buildclient"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/acorn-io/baaah/pkg/watcher"
 	"github.com/sirupsen/logrus"
@@ -58,20 +58,8 @@ func (c *client) getOrCreateBuilder(ctx context.Context, name string) (*apiv1.Bu
 		return nil, err
 	}
 
-	if builder.Status.Ready && builder.Status.Endpoint != "" {
-		for i := 0; i < 5; i++ {
-			resp, err := http.Get(builder.Status.Endpoint + "/ping")
-			if err != nil {
-				logrus.Debugf("builder ping failed: %v", err)
-			} else {
-				_ = resp.Body.Close()
-				logrus.Debugf("builder status code: %d", resp.StatusCode)
-				if resp.StatusCode == http.StatusOK {
-					return builder, nil
-				}
-			}
-			time.Sleep(time.Second)
-		}
+	if builder.Status.Endpoint != "" {
+		buildclient.PingBuilder(ctx, builder.Status.Endpoint)
 	}
 
 	return builder, nil


### PR DESCRIPTION
Due to storage backends that are eventually consistent it is possible
that a digest that was just written is not immediately available for
read or we get a 404 after a successful read.  For digests that we just
created we will retry for 5 seconds trying to get the result.


Signed-off-by: Darren Shepherd <darren@acorn.io>
