### PR TITLE
Add CLI completion for projects (#1073)

### DIFF
--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/acorn/pkg/project"
 	"github.com/acorn-io/baaah/pkg/typed"
 	"github.com/spf13/cobra"
 	"k8s.io/utils/strings/slices"
@@ -250,6 +252,27 @@ func secretsCompletion(ctx context.Context, c client.Client, toComplete string) 
 	for _, secret := range secrets {
 		if strings.HasPrefix(secret.Name, toComplete) {
 			result = append(result, secret.Name)
+		}
+	}
+
+	return result, nil
+}
+
+func projectsCompletion(ctx context.Context, c client.Client, toComplete string) ([]string, error) {
+	cfg, err := config.ReadCLIConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	projects, err := project.List(ctx, cfg, project.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, project := range projects {
+		if strings.HasPrefix(project, toComplete) {
+			result = append(result, project)
 		}
 	}
 

--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -19,9 +19,10 @@ func NewProject(c CommandContext) *cobra.Command {
 		Aliases: []string{"projects", "["},
 		Example: `
 acorn project`,
-		SilenceUsage: true,
-		Short:        "Manage projects",
-		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
+		Short:             "Manage projects",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
 	})
 	cmd.AddCommand(NewProjectUse(c))
 	return cmd

--- a/pkg/cli/project_use.go
+++ b/pkg/cli/project_use.go
@@ -15,9 +15,10 @@ func NewProjectUse(c CommandContext) *cobra.Command {
 		Use: "use [flags] PROJECT_NAME",
 		Example: `
 acorn project use acorn.io/my-user/acorn`,
-		SilenceUsage: true,
-		Short:        "Set current project",
-		Args:         cobra.ExactArgs(1),
+		SilenceUsage:      true,
+		Short:             "Set current project",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
 	})
 	return cmd
 }


### PR DESCRIPTION
These changes add dynamic completion to the CLI for `acorn project` and `acorn project use`
Issue: #1073
Signed-off-by: Joshua Silverio <joshua@acorn.io>