### PR TITLE
Add CLI completion for --project -j (#1073)

### DIFF
--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -64,6 +64,11 @@ func New() *cobra.Command {
 		NewVolume(cmdContext),
 		NewWait(cmdContext),
 	)
+	// This will produce an error if the project flag doesn't exist or a completion function has already
+	// been registered for this flag. Not returning the error since neither of these is likely occur.
+	if err := root.RegisterFlagCompletionFunc("project", newCompletion(cmdContext.ClientFactory, projectsCompletion).complete); err != nil {
+		root.Printf("Error registering completion function for -j flag: %v\n", err)
+	}
 	root.InitDefaultHelpCmd()
 	return root
 }

--- a/pkg/cli/project_create.go
+++ b/pkg/cli/project_create.go
@@ -18,9 +18,10 @@ acorn project create my-new-project
 # Create a project on remote service acorn.io
 acorn project create acorn.io/username/new-project
 `,
-		SilenceUsage: true,
-		Short:        "Create new project",
-		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage:      true,
+		Short:             "Create new project",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
 	})
 	return cmd
 }

--- a/pkg/cli/project_rm.go
+++ b/pkg/cli/project_rm.go
@@ -14,9 +14,10 @@ func NewProjectRm(c CommandContext) *cobra.Command {
 		Example: `
 acorn project rm my-project
 `,
-		SilenceUsage: true,
-		Short:        "Deletes projects",
-		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage:      true,
+		Short:             "Deletes projects",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, projectsCompletion).complete,
 	})
 	return cmd
 }


### PR DESCRIPTION
Extends autocomplete functionality to --project (-j) flag and project create/rm throughout Acorn cli

Issue: #1073 
Signed-off-by: Joshua Silverio <joshua@acorn.io>