### PR TITLE
Refactor and test auto-upgrade functionality

### DIFF
--- a/pkg/autoupgrade/client.go
+++ b/pkg/autoupgrade/client.go
@@ -1,0 +1,58 @@
+package autoupgrade
+
+import (
+	"context"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/acorn/pkg/images"
+	tags2 "github.com/acorn-io/acorn/pkg/tags"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type daemonClient interface {
+	getConfig(context.Context) (*apiv1.Config, error)
+	listAppInstances(context.Context) ([]v1.AppInstance, error)
+	updateAppStatus(context.Context, *v1.AppInstance) error
+	listTags(context.Context, string, string, ...remote.Option) ([]string, error)
+	getTagsMatchingRepo(context.Context, name.Reference, string, string) ([]string, error)
+	imageDigest(context.Context, string, string, ...remote.Option) (string, error)
+	resolveLocalTag(context.Context, string, string) (string, bool, error)
+}
+
+type client struct {
+	client kclient.Client
+}
+
+func (c *client) getConfig(ctx context.Context) (*apiv1.Config, error) {
+	return config.Get(ctx, c.client)
+}
+
+func (c *client) listAppInstances(ctx context.Context) ([]v1.AppInstance, error) {
+	var appInstanceList v1.AppInstanceList
+	return appInstanceList.Items, c.client.List(ctx, &appInstanceList)
+}
+
+func (c *client) updateAppStatus(ctx context.Context, app *v1.AppInstance) error {
+	return c.client.Status().Update(ctx, app)
+}
+
+func (c *client) listTags(ctx context.Context, namespace, name string, opts ...remote.Option) ([]string, error) {
+	_, tags, pullErr := images.ListTags(ctx, c.client, namespace, name, opts...)
+	return tags, pullErr
+}
+
+func (c *client) getTagsMatchingRepo(ctx context.Context, current name.Reference, namespace, defaultReg string) ([]string, error) {
+	return tags2.GetTagsMatchingRepository(ctx, current, c.client, namespace, defaultReg)
+}
+
+func (c *client) imageDigest(ctx context.Context, namespace, name string, opts ...remote.Option) (string, error) {
+	return images.ImageDigest(ctx, c.client, namespace, name, opts...)
+}
+
+func (c *client) resolveLocalTag(ctx context.Context, namespace, name string) (string, bool, error) {
+	return tags2.ResolveLocal(ctx, c.client, namespace, name)
+}

--- a/pkg/autoupgrade/daemon_test.go
+++ b/pkg/autoupgrade/daemon_test.go
@@ -1,0 +1,508 @@
+package autoupgrade
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
+	"github.com/acorn-io/baaah/pkg/router"
+	"github.com/acorn-io/baaah/pkg/typed"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mockDaemonClient struct {
+	apps                                []v1.AppInstance
+	defaultAutoUpgradeInterval          string
+	appUpdates                          map[string]string
+	localTags, remoteTags               []string
+	remoteImageDigest, resolvedLocalTag string
+	localTagFound                       bool
+}
+
+func (m *mockDaemonClient) getConfig(_ context.Context) (*apiv1.Config, error) {
+	return &apiv1.Config{AutoUpgradeInterval: &m.defaultAutoUpgradeInterval}, nil
+}
+
+func (m *mockDaemonClient) listAppInstances(_ context.Context) ([]v1.AppInstance, error) {
+	return m.apps, nil
+}
+
+func (m *mockDaemonClient) updateAppStatus(_ context.Context, instance *v1.AppInstance) error {
+	if m.appUpdates == nil {
+		m.appUpdates = make(map[string]string)
+	}
+	// Use the concatenation of these values because one will be empty and the other will have the new image.
+	m.appUpdates[instance.Name] = instance.Status.AvailableAppImage + instance.Status.ConfirmUpgradeAppImage
+	return nil
+}
+
+func (m *mockDaemonClient) listTags(context.Context, string, string, ...remote.Option) ([]string, error) {
+	return m.remoteTags, nil
+}
+
+func (m *mockDaemonClient) getTagsMatchingRepo(context.Context, name.Reference, string, string) ([]string, error) {
+	return m.localTags, nil
+}
+
+func (m *mockDaemonClient) imageDigest(_ context.Context, namespace, name string, _ ...remote.Option) (string, error) {
+	if m.remoteImageDigest != "" {
+		return m.remoteImageDigest, nil
+	}
+	return fmt.Sprintf("sha256:%s1234%sabcd", namespace, name), nil
+}
+
+func (m *mockDaemonClient) resolveLocalTag(context.Context, string, string) (string, bool, error) {
+	return m.resolvedLocalTag, m.localTagFound, nil
+}
+
+func TestDetermineAppsToRefresh(t *testing.T) {
+	defaultNextCheckInterval := time.Minute
+	now := time.Now()
+	thirtySecondsAgo := now.Add(-30 * time.Second)
+	oneMinuteAgo := now.Add(-time.Minute)
+	ptrTrue := &[]bool{true}[0]
+	appImages := map[string]string{
+		"test-1":          "acorn/test-1:v#.*.**",
+		"acorn-1":         "acorn/acorn-1:v1.1.1-*",
+		"test-2":          "other/test-2:v1.2.3-**",
+		"no-auto-upgrade": "acorn/no-auto-upgrade:latest",
+		"brand-new":       "acorn/brand-new:v#.#.#",
+		"other-test-1":    "acorn/test-1:v#.#.#",
+		"enabled-app":     "acorn/enabled:latest",
+		"notify-app":      "acorn/notify:latest",
+	}
+	apps := make(map[kclient.ObjectKey]v1.AppInstance, len(appImages))
+	for _, entry := range typed.Sorted(appImages) {
+		app := v1.AppInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: entry.Key, Namespace: "acorn"},
+			Spec:       v1.AppInstanceSpec{Image: entry.Value},
+		}
+		switch entry.Key {
+		case "brand-new":
+			app.CreationTimestamp = metav1.Now()
+		case "enabled-app":
+			app.Spec.AutoUpgrade = ptrTrue
+		case "notify-app":
+			app.Spec.NotifyUpgrade = ptrTrue
+		}
+		apps[router.Key(app.Namespace, app.Name)] = app
+	}
+
+	tests := []struct {
+		name                                          string
+		appKeysPrevCheckBefore, appKeysPrevCheckAfter map[kclient.ObjectKey]time.Time
+		want                                          map[imageAndNamespaceKey][]kclient.ObjectKey
+	}{
+		{
+			name:                   "No auto-upgrade apps",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{},
+			want:                   make(map[imageAndNamespaceKey][]kclient.ObjectKey),
+		},
+		{
+			name:                   "App doesn't exist",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn"): oneMinuteAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{},
+			want:                   make(map[imageAndNamespaceKey][]kclient.ObjectKey),
+		},
+		{
+			name:                   "Auto upgrade was turned off",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "no-auto-upgrade"): oneMinuteAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{},
+			want:                   make(map[imageAndNamespaceKey][]kclient.ObjectKey),
+		},
+		{
+			name:                   "Not time to check",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
+			want:                   make(map[imageAndNamespaceKey][]kclient.ObjectKey),
+		},
+		{
+			name:                   "Time to check",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): oneMinuteAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): oneMinuteAgo},
+			want:                   map[imageAndNamespaceKey][]kclient.ObjectKey{{"acorn/test-1", "acorn"}: {router.Key("acorn", "test-1")}},
+		},
+		{
+			name:                   "App that was deleted and recreated, creation timestamp newer than last upgrade time",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "brand-new"): thirtySecondsAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "brand-new"): thirtySecondsAgo},
+			want:                   map[imageAndNamespaceKey][]kclient.ObjectKey{{"acorn/brand-new", "acorn"}: {router.Key("acorn", "brand-new")}},
+		},
+		{
+			name:                   "Two apps using the same image need to be updated",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): oneMinuteAgo, router.Key("acorn", "other-test-1"): oneMinuteAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): oneMinuteAgo, router.Key("acorn", "other-test-1"): oneMinuteAgo},
+			want:                   map[imageAndNamespaceKey][]kclient.ObjectKey{{"acorn/test-1", "acorn"}: {router.Key("acorn", "test-1"), router.Key("acorn", "other-test-1")}},
+		},
+		{
+			name:                   "Auto upgrade enabled with no tag pattern",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): oneMinuteAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): oneMinuteAgo},
+			want:                   map[imageAndNamespaceKey][]kclient.ObjectKey{{"acorn/enabled:latest", "acorn"}: {router.Key("acorn", "enabled-app")}},
+		},
+		{
+			name:                   "Notify upgrade enabled with no tag pattern",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): oneMinuteAgo},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): oneMinuteAgo},
+			want:                   map[imageAndNamespaceKey][]kclient.ObjectKey{{"acorn/notify:latest", "acorn"}: {router.Key("acorn", "notify-app")}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &daemon{
+				appKeysPrevCheck: tt.appKeysPrevCheckBefore,
+			}
+
+			got := d.determineAppsToRefresh(apps, defaultNextCheckInterval, time.Now())
+			assert.Equalf(t, len(got), len(tt.want), "length of maps don't match")
+			for key, value := range got {
+				assert.ElementsMatchf(t, tt.want[key], value, "determineAppsToRefresh(%v, %v)", apps, defaultNextCheckInterval)
+			}
+			assert.Equalf(t, tt.appKeysPrevCheckAfter, d.appKeysPrevCheck, "daemon state not as expected after call")
+		})
+	}
+}
+
+func TestRefreshImages(t *testing.T) {
+	now := time.Now()
+	thirtySecondsAgo := now.Add(-30 * time.Second)
+	ptrTrue := &[]bool{true}[0]
+	appImages := map[string]string{
+		"test-1":      "acorn/test-1:v#.#.#",
+		"acorn-1":     "docker.io/acorn/acorn-1:v1.1.1-*",
+		"enabled-app": "docker.io/acorn/enabled:latest",
+		"notify-app":  "docker.io/acorn/notify:latest",
+	}
+	apps := make(map[kclient.ObjectKey]v1.AppInstance, len(appImages))
+	for _, entry := range typed.Sorted(appImages) {
+		app := v1.AppInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: entry.Key, Namespace: "acorn"},
+			Spec:       v1.AppInstanceSpec{Image: entry.Value},
+			Status:     v1.AppInstanceStatus{AppImage: v1.AppImage{Digest: fmt.Sprintf("sha256:acorn1234%sabcd", strings.Split(entry.Value, ":")[0])}},
+		}
+		switch entry.Key {
+		case "enabled-app":
+			app.Spec.AutoUpgrade = ptrTrue
+		case "notify-app":
+			app.Spec.NotifyUpgrade = ptrTrue
+		}
+		apps[router.Key(app.Namespace, app.Name)] = app
+	}
+
+	tests := []struct {
+		name                                          string
+		client                                        *mockDaemonClient
+		appKeysPrevCheckBefore, appKeysPrevCheckAfter map[kclient.ObjectKey]time.Time
+		imagesToRefresh                               map[imageAndNamespaceKey][]kclient.ObjectKey
+		appsUpdated                                   map[string]string
+	}{
+		{
+			name:   "No images to refresh",
+			client: &mockDaemonClient{},
+		},
+		{
+			name:                   "Auto refresh tag with local update",
+			client:                 &mockDaemonClient{localTags: []string{"v1.1.1"}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "acorn/test-1", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
+			appsUpdated:            map[string]string{"test-1": "acorn/test-1:v1.1.1"},
+		},
+		{
+			name:                   "Auto refresh tag with multiple local updates",
+			client:                 &mockDaemonClient{localTags: []string{"v1.1.1", "v1.1.2"}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "acorn/test-1", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
+			appsUpdated:            map[string]string{"test-1": "acorn/test-1:v1.1.2"},
+		},
+		{
+			name:                   "Auto refresh tag with remote update",
+			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1-alpha"}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+			appsUpdated:            map[string]string{"acorn-1": "index.docker.io/acorn/acorn-1:v1.1.1-alpha"},
+		},
+		{
+			name:                   "Auto refresh tag with multiple remote updates",
+			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1-alpha", "v1.1.1-beta"}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+			appsUpdated:            map[string]string{"acorn-1": "index.docker.io/acorn/acorn-1:v1.1.1-beta"},
+		},
+		{
+			name:                   "Auto refresh tag with local and remote updates, local wins",
+			client:                 &mockDaemonClient{localTags: []string{"v1.1.1-beta"}, remoteTags: []string{"v1.1.1-alpha"}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+			appsUpdated:            map[string]string{"acorn-1": "index.docker.io/acorn/acorn-1:v1.1.1-beta"},
+		},
+		{
+			name:                   "Auto refresh tag with local and remote updates, remote wins",
+			client:                 &mockDaemonClient{localTags: []string{"v1.1.1-alpha"}, remoteTags: []string{"v1.1.1-beta"}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+			appsUpdated:            map[string]string{"acorn-1": "index.docker.io/acorn/acorn-1:v1.1.1-beta"},
+		},
+		{
+			name:                   "Auto refresh tag with local and remote tags, no updates",
+			client:                 &mockDaemonClient{localTags: []string{"v1.1.2-alpha"}, remoteTags: []string{"v1.1.2-beta"}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+		},
+		{
+			name:                   "Auto refresh tag with remote digest change",
+			client:                 &mockDaemonClient{remoteImageDigest: "sha256:acorn4321docker.io/acorn/acorn-1dcba"},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+			appsUpdated:            map[string]string{"acorn-1": "docker.io/acorn/acorn-1"},
+		},
+		{
+			name:                   "Auto refresh tag with local digest change",
+			client:                 &mockDaemonClient{resolvedLocalTag: "sha256:acorn4321docker.io/acorn/acorn-1dcba", localTagFound: true},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+			appsUpdated:            map[string]string{"acorn-1": "docker.io/acorn/acorn-1"},
+		},
+		{
+			name:                   "Auto refresh tag with no local digest found",
+			client:                 &mockDaemonClient{resolvedLocalTag: "sha256:acorn4321docker.io/acorn/acorn-1dcba"},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/acorn-1", namespace: "acorn"}: {router.Key("acorn", "acorn-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "acorn-1"): now},
+		},
+		{
+			name:                   "Auto refresh enabled with local digest change",
+			client:                 &mockDaemonClient{resolvedLocalTag: "sha256:acorn4321docker.io/acorn/enableddcba", localTagFound: true},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/enabled", namespace: "acorn"}: {router.Key("acorn", "enabled-app")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): now},
+			appsUpdated:            map[string]string{"enabled-app": "docker.io/acorn/enabled"},
+		},
+		{
+			name:                   "Auto refresh enabled with no local digest change",
+			client:                 &mockDaemonClient{localTagFound: true},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/enabled", namespace: "acorn"}: {router.Key("acorn", "enabled-app")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): now},
+		},
+		{
+			name:                   "Auto refresh enabled with remote digest change, no local",
+			client:                 &mockDaemonClient{remoteImageDigest: "sha256:acorn4321docker.io/acorn/enableddcba"},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/enabled", namespace: "acorn"}: {router.Key("acorn", "enabled-app")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "enabled-app"): now},
+			appsUpdated:            map[string]string{"enabled-app": "docker.io/acorn/enabled"},
+		},
+		{
+			name:                   "Auto refresh notify with local digest change",
+			client:                 &mockDaemonClient{resolvedLocalTag: "sha256:acorn4321docker.io/acorn/notifydcba", localTagFound: true},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/notify", namespace: "acorn"}: {router.Key("acorn", "notify-app")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): now},
+			appsUpdated:            map[string]string{"notify-app": "docker.io/acorn/notify"},
+		},
+		{
+			name:                   "Auto refresh notify with no local digest change",
+			client:                 &mockDaemonClient{localTagFound: true},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/notify", namespace: "acorn"}: {router.Key("acorn", "notify-app")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): now},
+		},
+		{
+			name:                   "Auto refresh notify with remote digest change, no local",
+			client:                 &mockDaemonClient{remoteImageDigest: "sha256:acorn4321docker.io/acorn/notifydcba"},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/notify", namespace: "acorn"}: {router.Key("acorn", "notify-app")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): now},
+			appsUpdated:            map[string]string{"notify-app": "docker.io/acorn/notify"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &daemon{
+				client:           tt.client,
+				appKeysPrevCheck: tt.appKeysPrevCheckBefore,
+			}
+
+			d.refreshImages(context.Background(), apps, tt.imagesToRefresh, now)
+			assert.Equalf(t, tt.appKeysPrevCheckAfter, d.appKeysPrevCheck, "daemon state not as expected after call")
+
+			assert.Equalf(t, len(tt.appsUpdated), len(tt.client.appUpdates), "different number of apps updated than expected")
+			for appName, image := range tt.appsUpdated {
+				assert.Equalf(t, image, tt.client.appUpdates[appName], "%s app doesn't have expected new version", appName)
+			}
+		})
+	}
+}
+func TestDaemonSync(t *testing.T) {
+	start := time.Now()
+	tenMinutesAgo := time.Now().Add(-10 * time.Minute)
+	fiftySecondsAgo := time.Now().Add(-50 * time.Second)
+	ptrTrue := &[]bool{true}[0]
+	appImages := map[string]string{
+		"test-1":          "30s",
+		"acorn-1":         "1m",
+		"enabled-app":     "5m",
+		"notify-app":      "3m",
+		"bad-interval":    "help",
+		"no-auto-upgrade": "1s",
+	}
+	apps := make([]v1.AppInstance, 0, len(appImages))
+	for _, entry := range typed.Sorted(appImages) {
+		app := v1.AppInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: entry.Key, Namespace: "acorn"},
+			Spec:       v1.AppInstanceSpec{AutoUpgradeInterval: entry.Value},
+		}
+		switch entry.Key {
+		case "enabled-app":
+			app.Spec.AutoUpgrade = ptrTrue
+			app.Spec.Image = "acorn/acorn-enabled:latest"
+		case "notify-app":
+			app.Spec.NotifyUpgrade = ptrTrue
+			app.Spec.Image = "acorn/acorn-notify:latest"
+		case "no-auto-upgrade":
+			app.Spec.Image = "acorn/acorn:latest"
+		default:
+			app.Spec.Image = "acorn/acorn:v#.*.**"
+		}
+		apps = append(apps, app)
+	}
+
+	tests := []struct {
+		name                                          string
+		apps                                          []v1.AppInstance
+		appKeysPrevCheckBefore, appKeysPrevCheckAfter map[kclient.ObjectKey]time.Time
+		defaultUpgradeInterval                        string
+		expectedNextCheckInterval                     time.Duration
+	}{
+		{
+			name:                      "No images to refresh",
+			defaultUpgradeInterval:    "1h",
+			expectedNextCheckInterval: time.Hour,
+		},
+		{
+			name:                   "All apps need refreshed because they are just added",
+			apps:                   apps,
+			defaultUpgradeInterval: "1h",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{},
+			appKeysPrevCheckAfter: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      start,
+				router.Key("acorn", "acorn-1"):     start,
+				router.Key("acorn", "enabled-app"): start,
+				router.Key("acorn", "notify-app"):  start,
+				// Not able to calculate refresh interval, so app is not updated.
+				router.Key("acorn", "bad-interval"): {},
+			},
+			expectedNextCheckInterval: 30 * time.Second,
+		},
+		{
+			name:                   "All apps need refreshed because they are just added, but default sync time is next refresh",
+			apps:                   apps,
+			defaultUpgradeInterval: "1s",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{},
+			appKeysPrevCheckAfter: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      start,
+				router.Key("acorn", "acorn-1"):     start,
+				router.Key("acorn", "enabled-app"): start,
+				router.Key("acorn", "notify-app"):  start,
+				// Not able to calculate refresh interval, so app is not updated.
+				router.Key("acorn", "bad-interval"): {},
+			},
+			expectedNextCheckInterval: time.Second,
+		},
+		{
+			name:                   "None of the apps need to be refreshed",
+			apps:                   apps,
+			defaultUpgradeInterval: "1h",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      start,
+				router.Key("acorn", "acorn-1"):     start,
+				router.Key("acorn", "enabled-app"): start,
+				router.Key("acorn", "notify-app"):  start,
+			},
+			appKeysPrevCheckAfter: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      start,
+				router.Key("acorn", "acorn-1"):     start,
+				router.Key("acorn", "enabled-app"): start,
+				router.Key("acorn", "notify-app"):  start,
+				// Not able to calculate refresh interval, so app is not updated.
+				router.Key("acorn", "bad-interval"): {},
+			},
+			expectedNextCheckInterval: 30 * time.Second,
+		},
+		{
+			name:                   "Apps need to be refreshed based on time",
+			apps:                   apps,
+			defaultUpgradeInterval: "1h",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      tenMinutesAgo,
+				router.Key("acorn", "acorn-1"):     tenMinutesAgo,
+				router.Key("acorn", "enabled-app"): tenMinutesAgo,
+				router.Key("acorn", "notify-app"):  tenMinutesAgo,
+			},
+			appKeysPrevCheckAfter: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      start,
+				router.Key("acorn", "acorn-1"):     start,
+				router.Key("acorn", "enabled-app"): start,
+				router.Key("acorn", "notify-app"):  start,
+				// Not able to calculate refresh interval, so app is not updated.
+				router.Key("acorn", "bad-interval"): {},
+			},
+			expectedNextCheckInterval: 30 * time.Second,
+		},
+		{
+			name:                   "Ensure a shorter next check is returned when an app is nearing update time",
+			apps:                   apps,
+			defaultUpgradeInterval: "1h",
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      start,
+				router.Key("acorn", "acorn-1"):     fiftySecondsAgo,
+				router.Key("acorn", "enabled-app"): start,
+				router.Key("acorn", "notify-app"):  start,
+			},
+			appKeysPrevCheckAfter: map[kclient.ObjectKey]time.Time{
+				router.Key("acorn", "test-1"):      start,
+				router.Key("acorn", "acorn-1"):     fiftySecondsAgo,
+				router.Key("acorn", "enabled-app"): start,
+				router.Key("acorn", "notify-app"):  start,
+				// Not able to calculate refresh interval, so app is not updated.
+				router.Key("acorn", "bad-interval"): {},
+			},
+			expectedNextCheckInterval: 10 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &daemon{
+				client:           &mockDaemonClient{apps: tt.apps, defaultAutoUpgradeInterval: tt.defaultUpgradeInterval},
+				appKeysPrevCheck: tt.appKeysPrevCheckBefore,
+			}
+
+			got, _ := d.sync(context.Background(), start)
+			// Calculate diff between start and now because that is how far off we would expect the "actual" and "expected" to be.
+			diff := time.Since(start)
+			assert.Equalf(t, tt.appKeysPrevCheckAfter, d.appKeysPrevCheck, "daemon state not as expected after call")
+
+			// The expected next check interval will be slightly smaller than expected because of the time it takes to run the test.
+			// Assert that it is within the expected diff.
+			assert.InDeltaf(t, tt.expectedNextCheckInterval, got, float64(diff), "Next check interval much different than expected")
+		})
+	}
+}

--- a/pkg/controller/config/autoupgrade.go
+++ b/pkg/controller/config/autoupgrade.go
@@ -2,21 +2,11 @@ package config
 
 import (
 	"github.com/acorn-io/acorn/pkg/autoupgrade"
-	"github.com/acorn-io/acorn/pkg/config"
 	"github.com/acorn-io/baaah/pkg/router"
 )
 
-// HandleAutoUpgradeInterval resets the ticker for auto-upgrade sync interval as it changes in the acorn config
-func HandleAutoUpgradeInterval(req router.Request, resp router.Response) error {
-	cfg, err := config.Get(req.Ctx, req.Client)
-	if err != nil {
-		return err
-	}
-
-	if cfg.AutoUpgradeInterval != nil {
-		err := autoupgrade.UpdateInterval(*cfg.AutoUpgradeInterval)
-		return err
-	}
-
+// HandleAutoUpgradeInterval resets the timer for auto-upgrade sync interval as it changes in the acorn config
+func HandleAutoUpgradeInterval(router.Request, router.Response) error {
+	autoupgrade.Sync()
 	return nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -16,7 +16,6 @@ import (
 	"github.com/acorn-io/baaah/pkg/apply"
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	"github.com/acorn-io/baaah/pkg/router"
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,10 +90,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		dnsInit := dns.NewDaemon(c.Router.Backend())
 		go wait.UntilWithContext(ctx, dnsInit.RenewAndSync, dnsRenewPeriodHours)
 
-		err := autoupgrade.StartSync(ctx, c.Router.Backend())
-		if err != nil {
-			logrus.Errorf("auto-upgrade daemon exited with error: %v", err)
-		}
+		autoupgrade.StartSync(ctx, c.Router.Backend())
 	}()
 
 	return c.Router.Start(ctx)

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -41,7 +41,7 @@ func Get(ctx context.Context, c client.Reader, namespace string) (apiv1.ImageLis
 // Note that the other functions in this package generally operate on the entire reference of an image as one opaque "tag"
 // but this function is only returning the portion that follows the final semicolon. For example, the "tags" returned by the
 // Get function are like "foo/bar:v1", but this function would just return "v1" for that image.
-func GetTagsMatchingRepository(reference name.Reference, ctx context.Context, c client.Reader, namespace, defaultReg string) ([]string, error) {
+func GetTagsMatchingRepository(ctx context.Context, reference name.Reference, c client.Reader, namespace, defaultReg string) ([]string, error) {
 	images, err := Get(ctx, c, namespace)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
These changes are broken up into ~3~ 4 commits for reviewability purposes. These changes should be squashed before merging.

The first commit is where most of the changes occur. There were three ways to kick-off an `sync` previously:
1. A ticker based on the default auto upgrade config value
2. An on-demand sync call
3. After the sync was over, a goroutine would wait until the nearest calculated next time to upgrade and call sync again. This step also took into account the default auto upgrade config value.

Since 1 and 3 were doing similar things, they were combined to simplify the package-level state and make the code more testable.

Additionally, if an auto-upgrade-enabed app was deleted and recreated before the auto-upgrade sync ran, the next upgrade time for that app would still exist for the old version of the app and a user would have to wait for the next interval before the app would completely deploy. Now we detect when an app is new and sync it immediately.

The second commit is ONLY separating the `sync` method into multiple functions. The code is copied and pasted and none of it is changed with the possible exception of variable names.

The third commit adds tests to the code. Some changes were also made to the implementation for testability and mockability purposes.

A fourth commit has been added to address acorn args validation. The ImageDetails api-server endpoint now supports auto-upgrade tags and will get the latest tag for the pattern and return the ImageDetails for that image.

Issues:
https://github.com/acorn-io/acorn/issues/1032
https://github.com/acorn-io/acorn/issues/1056