### PR TITLE
Update quantity builder logic to not default to nil (#1089)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -44,8 +44,8 @@ acorn install
       --set-pod-security-enforce-profile      Set the PodSecurity profile on created namespaces (default true)
       --skip-checks                           Bypass installation checks
       --use-custom-ca-bundle                  Use CA bundle for admin supplied secret for all acorn control plane components. Defaults to false.
-  -m, --workload-memory-default string        Set the default memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and "." and "_" seperators (default "0")
-      --workload-memory-maximum string        Set the maximum memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and "." and "_" seperators (default "0")
+  -m, --workload-memory-default string        Set the default memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and "." and "_" seperators (default 0)
+      --workload-memory-maximum string        Set the maximum memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and "." and "_" seperators (default 0)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -333,8 +333,8 @@ type Config struct {
 	BuilderPerProject              *bool          `json:"builderPerProject" name:"builder-per-project" usage:"Create a dedicated builder per project"`
 	InternalRegistryPrefix         *string        `json:"internalRegistryPrefix" name:"internal-registry-prefix" usage:"The image prefix to use when pushing internal images (example ghcr.io/my-org/)"`
 	IgnoreUserLabelsAndAnnotations *bool          `json:"ignoreUserLabelsAndAnnotations" name:"ignore-user-labels-and-annotations" usage:"Don't propagate user-defined labels and annotations to dependent objects"`
-	WorkloadMemoryDefault          *int64         `json:"workloadMemoryDefault" name:"workload-memory-default" quantity:"true" usage:"Set the default memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and \".\" and \"_\" seperators" short:"m" default:"0"`
-	WorkloadMemoryMaximum          *int64         `json:"workloadMemoryMaximum" name:"workload-memory-maximum" quantity:"true" usage:"Set the maximum memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and \".\" and \"_\" seperators" default:"0"`
+	WorkloadMemoryDefault          *int64         `json:"workloadMemoryDefault" name:"workload-memory-default" quantity:"true" usage:"Set the default memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and \".\" and \"_\" seperators (default 0)" short:"m"`
+	WorkloadMemoryMaximum          *int64         `json:"workloadMemoryMaximum" name:"workload-memory-maximum" quantity:"true" usage:"Set the maximum memory for acorn workloads. Accepts binary suffixes (Ki, Mi, Gi, etc) and \".\" and \"_\" seperators (default 0)"`
 	UseCustomCABundle              *bool          `json:"useCustomCABundle" name:"use-custom-ca-bundle" usage:"Use CA bundle for admin supplied secret for all acorn control plane components. Defaults to false."`
 }
 

--- a/pkg/cli/builder/builder.go
+++ b/pkg/cli/builder/builder.go
@@ -228,10 +228,7 @@ func assignQuantities(app *cobra.Command, maps map[string]reflect.Value) error {
 		}
 
 		if i == "" {
-			i = "0"
-			if defValue := app.Flags().Lookup(k).DefValue; defValue != "" {
-				i = defValue
-			}
+			continue
 		}
 
 		quantity, err := v1.ParseQuantityString(i)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,12 @@ func complete(ctx context.Context, c *apiv1.Config, getter kclient.Reader) error
 	if c.HttpEndpointPattern == nil || *c.HttpEndpointPattern == "" {
 		c.HttpEndpointPattern = &DefaultHttpEndpointPattern
 	}
+	if c.WorkloadMemoryDefault == nil {
+		c.WorkloadMemoryDefault = new(int64)
+	}
+	if c.WorkloadMemoryMaximum == nil {
+		c.WorkloadMemoryMaximum = new(int64)
+	}
 	if c.InternalRegistryPrefix == nil {
 		c.InternalRegistryPrefix = new(string)
 	}


### PR DESCRIPTION
There was a bug with the quantity builder where if there was no value set by the user it would default the *int64 to be a new(int64). This would always overwrite whatever the server saved value was.

#1089 

Signed-off-by: tylerslaton <mtslaton1@gmail.com>