### PR TITLE
handle invalid container names in "-m" to acorn run (#1087)

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/memory.go
+++ b/pkg/apis/internal.acorn.io/v1/memory.go
@@ -52,7 +52,7 @@ var (
 	ErrInvalidAcornMemory   = errors.New("invalid memory from Acornfile")
 	ErrInvalidSetMemory     = errors.New("invalid memory set by user")
 	ErrInvalidDefaultMemory = errors.New("invalid memory default")
-	ErrInvalidWorkload      = errors.New("invalid workload name set by user")
+	ErrInvalidWorkload      = errors.New("workload name set by user does not exist")
 )
 
 func MemoryToRequirements(memSpec Memory, containerName string, container Container, specMemDefault, specMemMaximum *int64) (*corev1.ResourceRequirements, error) {

--- a/pkg/apis/internal.acorn.io/v1/memory.go
+++ b/pkg/apis/internal.acorn.io/v1/memory.go
@@ -52,6 +52,7 @@ var (
 	ErrInvalidAcornMemory   = errors.New("invalid memory from Acornfile")
 	ErrInvalidSetMemory     = errors.New("invalid memory set by user")
 	ErrInvalidDefaultMemory = errors.New("invalid memory default")
+	ErrInvalidWorkload      = errors.New("invalid workload name set by user")
 )
 
 func MemoryToRequirements(memSpec Memory, containerName string, container Container, specMemDefault, specMemMaximum *int64) (*corev1.ResourceRequirements, error) {


### PR DESCRIPTION
This PR handles when a user inputs a nonexistent container name in the `acorn run -m` flag it will now error out server side. 

Issue: #1087 
Signed-off-by: Joshua Silverio <joshua@acorn.io>