### PR TITLE
Add disable labels/annotations docs

### DIFF
--- a/docs/docs/30-installation/02-options.md
+++ b/docs/docs/30-installation/02-options.md
@@ -82,5 +82,11 @@ acorn install --workload-memory-maximum 1Gi
 
 This will set it so all Acorns on this cluster will be unable to install should they exceed `1Gi` of memory.
 
+## Ignoring user-defined labels and annotations
+There are situations where you may not want a user to be able to label or annotate the objects created by Acorn in the workload cluster. For such circumstances, the installation flag `--ignore-user-labels-and-annotations` exists. If this flag is passed to `acorn install`, then, except for the metadata scope, labels and annotations defined by users in their Acorns will be ignored when creating objects. No error nor warning will be produced.
+
+Note that in order to allow propagation of user-defined labels and annotations on an Acorn installation that previous disallowed it, one must pass `--ignore-user-labels-and-annotations=false` to `acorn install`.
+
+
 ## Changing install options
-If you want to change your install options after the initial installation, just rerun `acorn install` with the new options. This will update the existing install dynamically.
+If you want to change your installation options after the initial installation, just rerun `acorn install` with the new options. This will update the existing install dynamically.

--- a/docs/docs/38-authoring/20-labels.md
+++ b/docs/docs/38-authoring/20-labels.md
@@ -47,3 +47,9 @@ containers:{
 In the above examples, the core Kubernetes resources created for the acorn container called "frontend" will get the labels and annotations. This includes the deployment, pods, ingress, and services.
 
 You can also specify labels and annotations from the CLI when launching an acorn via the `run` command. See [here](/running/labels) for more details.
+
+:::note
+
+If the Acorn installation has [disabled user label and annotation propagation](installation/options#ignoring-user-defined-labels-and-annotations), then, except for the metadata scope, labels and annotations will be silently ignored.
+
+:::

--- a/docs/docs/50-running/20-labels.md
+++ b/docs/docs/50-running/20-labels.md
@@ -30,3 +30,9 @@ Valid resource types are:
 - secrets
 
 For all resource types except metadata, you can add a name to only apply the label/annotation to the resource matching that name and scope.
+
+:::note
+
+If the Acorn installation has [disabled user label and annotation propagation](installation/options#ignoring-user-defined-labels-and-annotations), then, except for the metadata scope, labels and annotations will be silently ignored.
+
+:::


### PR DESCRIPTION
The `:::note` callout I used here is formatted in this way. Please note that the link (disabled user label and annotation propagation) is formatted differently. I am happy to not use this "admonition" this if it is not acceptable.
![Screenshot 2023-01-24 at 11 33 31](https://user-images.githubusercontent.com/3682717/214352737-88c247dd-d915-4f31-9458-5229f1833ef5.png)
