### PR TITLE
Add prompting to Lets-Encrypt enable if email or tos is not set (#1061)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
@@ -63,14 +62,6 @@ func complete(ctx context.Context, c *apiv1.Config, getter kclient.Reader) error
 	}
 	if c.LetsEncryptTOSAgree == nil {
 		c.LetsEncryptTOSAgree = new(bool)
-	}
-	if *c.LetsEncrypt == "enabled" {
-		if c.LetsEncryptEmail == "" {
-			return fmt.Errorf("letsencrypt email is required when Let's Encrypt is enabled")
-		}
-		if !*c.LetsEncryptTOSAgree {
-			return fmt.Errorf("letsencrypt TOS must be agreed to when Let's Encrypt is enabled")
-		}
 	}
 	if c.AutoUpgradeInterval == nil || *c.AutoUpgradeInterval == "" {
 		c.AutoUpgradeInterval = &DefaultImageCheckIntervalDefault


### PR DESCRIPTION
This PR fixes regression of not prompting for lets-encrypt-email and tos-agree when Let's Encrypt is enabled.

Issue: #1061 
Signed-off-by: Joshua Silverio <joshua@acorn.io>