### PR TITLE
Only notify about successful tagged releases to Acorn Users

### DIFF
--- a/.github/workflows/main-mac-smoke-test.yaml
+++ b/.github/workflows/main-mac-smoke-test.yaml
@@ -71,11 +71,3 @@ jobs:
           slack-message: "❌ Main-Mac-Release failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      - name: report success to slack
-        id: slack-success
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: '${{ secrets.SLACK_BOT_SUCCESS_CHANNEL }}'
-          slack-message: " ✅ Main-Mac-Release passed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: '${{ secrets.SLACK_BOT_TOKEN }}'

--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -86,11 +86,4 @@ jobs:
           slack-message: "❌ Main-Release failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      - name: report success to slack
-        id: slack-success
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: '${{ secrets.SLACK_BOT_SUCCESS_CHANNEL }}'
-          slack-message: " ✅ Main-Release passed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: '${{ secrets.SLACK_BOT_TOKEN }}'
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         id: slack-success
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: '${{ secrets.SLACK_BOT_SUCCESS_CHANNEL }}'
-          slack-message: " ✅ Release passed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          channel-id: '${{ secrets.USERS_SLACK_BOT_RELEASE_CHANNEL }}'
+          slack-message: " ✅ Release ${{ github.ref_name }} is now available: ${{ github.server_url }}/${{ github.repository }}/releases/${{ github.ref_name }}"
         env:
-          SLACK_BOT_TOKEN: '${{ secrets.SLACK_BOT_TOKEN }}'
+          SLACK_BOT_TOKEN: '${{ secrets.USERS_SLACK_BOT_TOKEN }}'


### PR DESCRIPTION
Once this merges, we will have to add two new secrets:

1. `USERS_SLACK_BOT_RELEASE_CHANNEL`
2. `USERS_SLACK_BOT_TOKEN`

In addition we will need to invite the bot to the channel we want it to notify to. I have already created the bot in the `Acorn Users` slack so this will be easy.