### PR TITLE
Add recorded field to acornimagebuildinstance

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/build.go
+++ b/pkg/apis/internal.acorn.io/v1/build.go
@@ -65,6 +65,7 @@ type AcornImageBuildInstanceSpec struct {
 
 type AcornImageBuildInstanceStatus struct {
 	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
+	Recorded           bool        `json:"recorded,omitempty"`
 	BuildURL           string      `json:"buildURL,omitempty"`
 	Token              string      `json:"token,omitempty"`
 	AppImage           AppImage    `json:"appImage,omitempty"`

--- a/pkg/controller/acornimagebuildinstance/buildinstance.go
+++ b/pkg/controller/acornimagebuildinstance/buildinstance.go
@@ -1,0 +1,19 @@
+package acornimagebuildinstance
+
+import (
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/baaah/pkg/router"
+)
+
+func MarkRecorded(req router.Request, resp router.Response) error {
+	cfg, err := config.Get(req.Ctx, req.Client)
+	if err != nil {
+		return err
+	}
+	if !*cfg.RecordBuilds {
+		return nil
+	}
+	req.Object.(*v1.AcornImageBuildInstance).Status.Recorded = true
+	return nil
+}

--- a/pkg/controller/data.go
+++ b/pkg/controller/data.go
@@ -52,7 +52,7 @@ func (c *Controller) initData(ctx context.Context) error {
 				Resources: []string{"imageinstances"},
 			},
 			{
-				Verbs:     []string{"get"},
+				Verbs:     []string{"get", "list", "watch"},
 				APIGroups: []string{v1.SchemeGroupVersion.Group},
 				Resources: []string{"acornimagebuildinstances"},
 			},

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/controller/acornimagebuildinstance"
 	"github.com/acorn-io/acorn/pkg/controller/appdefinition"
 	"github.com/acorn-io/acorn/pkg/controller/builder"
 	"github.com/acorn-io/acorn/pkg/controller/config"
@@ -49,6 +50,8 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	appRouter.HandlerFunc(appdefinition.UpdateGeneration)
 
 	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.DeployBuilder)
+
+	router.Type(&v1.AcornImageBuildInstance{}).HandlerFunc(acornimagebuildinstance.MarkRecorded)
 
 	router.Type(&rbacv1.ClusterRole{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)
 	router.Type(&rbacv1.ClusterRoleBinding{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -2746,6 +2746,12 @@ func schema_pkg_apis_internalacornio_v1_AcornImageBuildInstanceStatus(ref common
 							Format: "int64",
 						},
 					},
+					"recorded": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"buildURL": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},


### PR DESCRIPTION
The build server saves the ImageInstance to acorn.  In a hub context
that is written to the downstream server which them must be synced up
to the account api server. This recorded field is here to enable hub to
notify the build server when the image has been synced and the build can
return.

Signed-off-by: Darren Shepherd <darren@acorn.io>
