### PR TITLE
Don't return empty containers

### DIFF
--- a/pkg/server/registry/containers/translator.go
+++ b/pkg/server/registry/containers/translator.go
@@ -70,9 +70,6 @@ func (t *Translator) ToPublic(ctx context.Context, objs ...runtime.Object) (resu
 			result = append(result, &con)
 		}
 	}
-	if len(result) == 0 && len(objs) > 0 {
-		result = append(result, &apiv1.ContainerReplica{})
-	}
 	return
 }
 


### PR DESCRIPTION
Not sure why this was every done but it causes really bad errors for
watcher clients.

Signed-off-by: Darren Shepherd <darren@acorn.io>
