### PR TITLE
Don't create the directory ".dockerignore" during builds

### DIFF
--- a/pkg/buildclient/filesyncclient.go
+++ b/pkg/buildclient/filesyncclient.go
@@ -14,6 +14,12 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+var (
+	ignoreLocalFiles = map[string]bool{
+		".dockerignore": true,
+	}
+)
+
 type fileSyncClient struct {
 	sessionID string
 	messages  Messages
@@ -114,6 +120,9 @@ func prepareSyncedDirs(localDirs map[string]string, dirNames []string, followPat
 		for _, dirName := range dirNames {
 			if dirName == "context" && localDirName == dirName {
 				for _, followPath := range followPaths {
+					if ignoreLocalFiles[followPath] {
+						continue
+					}
 					f := filepath.Join(d, followPath)
 					if _, err := os.Stat(f); os.IsNotExist(err) {
 						err := os.MkdirAll(f, 0755)

--- a/pkg/dev/sync.go
+++ b/pkg/dev/sync.go
@@ -93,10 +93,12 @@ func invokeStartSyncForPath(ctx context.Context, client client.Client, con *apiv
 		if err == nil {
 			exclude = lines
 		} else {
-			return nil, nil, err
+			logrus.Warnf("failed to read %s for syncing: %v", filepath.Join(cwd, ".dockerignore"), err)
+			exclude = nil
 		}
 	} else if !os.IsNotExist(err) {
-		return nil, nil, err
+		logrus.Warnf("failed to open %s for syncing: %v", filepath.Join(cwd, ".dockerignore"), err)
+		exclude = nil
 	}
 	s, err := sync.NewSync(ctx, source, sync.Options{
 		DownstreamDisabled: !bidirectional,


### PR DESCRIPTION
.dockerignore is sent as a follow path and we incorrectly treat that as
a directory. We now ignore that file but also the sync code will no
longer abort if it can't read the .dockerignore file.

Signed-off-by: Darren Shepherd <darren@acorn.io>
