### PR TITLE
Don't unset the env vars

### DIFF
--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -2,11 +2,8 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"os"
 
-	"github.com/acorn-io/acorn/pkg/project"
-	"github.com/pkg/errors"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -17,10 +14,7 @@ import (
 func RunAndHandleError(ctx context.Context, cmd *cobra.Command) {
 	cmd.SilenceErrors = true
 	err := cmd.ExecuteContext(ctx)
-	if !pterm.RawOutput && errors.Is(err, project.ErrNoCurrentProject) {
-		fmt.Println(project.NoProjectMessageNoHub)
-		os.Exit(1)
-	} else if err != nil {
+	if err != nil {
 		pterm.Error.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -105,11 +105,6 @@ func lookup(ctx context.Context, opts Options) (client.Client, error) {
 		err error
 	)
 
-	// Reset all env vars that might impact kubeconfig loading behavior
-	os.Setenv("KUBECONFIG", "")
-	os.Setenv("NAMESPACE", "")
-	os.Setenv("CONTEXT", "")
-
 	if cfg == nil {
 		cfg, err = config.ReadCLIConfig()
 		if err != nil {

--- a/pkg/project/operations.go
+++ b/pkg/project/operations.go
@@ -139,8 +139,8 @@ func List(ctx context.Context, opts Options) (result []string, err error) {
 		}
 	}
 
-	c := noConfigClient(ctx, opts)
-	if c != nil {
+	c, err := noConfigClient(ctx, opts)
+	if err == nil && c != nil {
 		projects, err := timeoutProjectList(ctx, c)
 		if err == nil {
 			result = append(result, typed.MapSlice(projects, func(project apiv1.Project) string {


### PR DESCRIPTION
If you call the DefaultClient() method twice from the client factory what happens is we read the ENV vars, then lookup unsets them, and then on the second call it reads the env vars and it's empty.

It was obviously a bad idea to unset the env vars in the first place, that was just a bad idea on my part.  So we just won't do that anymore.

https://github.com/acorn-io/acorn/issues/1138

Signed-off-by: Darren Shepherd <darren@acorn.io>
