### PR TITLE
fixes #1112: show error on app stop when not found

### DIFF
--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -433,9 +433,7 @@ func (c *DefaultClient) appStop(ctx context.Context, name string) error {
 		Name:      name,
 		Namespace: c.Namespace,
 	}, app)
-	if apierrors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
+	if err != nil {
 		return err
 	}
 	if app.Spec.Stop == nil || !*app.Spec.Stop {


### PR DESCRIPTION
Signed-off-by: Sterling Hanenkamp <sterling@hanenkamp.com>

Just removes the special case for ignore the erorr if the app `IsNotFound`