### PR TITLE
Bump baaah dependency to add leader election to controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693
-	github.com/acorn-io/baaah v0.0.0-20230122153322-0c640322be9b
+	github.com/acorn-io/baaah v0.0.0-20230129022613-803520949ab8
 	github.com/acorn-io/mink v0.0.0-20230119012606-799c4d32d238
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693 h1:5uxUFWpREhhKllLkan
 github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693/go.mod h1:uiNpPSAYWhEBfbGWKpN185+EP+hZr2M/U8Ckr/Jo3Kk=
 github.com/acorn-io/apiserver v0.25.2-ot-1 h1:91Q7+Jd9BeYZhzt0C+38w2sMn8aHFOxfTdlE6MCH9UI=
 github.com/acorn-io/apiserver v0.25.2-ot-1/go.mod h1:8cynBL5SR6CIKypk9nWtZXHzEiJhLVQxeMVZ5CGzkFo=
-github.com/acorn-io/baaah v0.0.0-20230122153322-0c640322be9b h1:0KPwsPOCCBo6gIHmLqxVw/4NjyXOcmK0foirf9jU3IY=
-github.com/acorn-io/baaah v0.0.0-20230122153322-0c640322be9b/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
+github.com/acorn-io/baaah v0.0.0-20230129022613-803520949ab8 h1:WlEDlrth4rPRaqTn8aZGNAxGN8IlKmx69+92jIvSPf0=
+github.com/acorn-io/baaah v0.0.0-20230129022613-803520949ab8/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
 github.com/acorn-io/component-base v0.25.2-ot-1 h1:xinqJUNbpW2/zsvm8mDv6Q7riLhvXup9x7Kz9eIPM1M=
 github.com/acorn-io/component-base v0.25.2-ot-1/go.mod h1:/5qYr5BXGNPs+cRd6+WL1NfOYtzOstJlm1CMK06cm7s=
 github.com/acorn-io/etcd/server/v3 v3.5.4-ot-1 h1:sQMBy/UImb1923toh9U0oIxlpO7crLrD7eKE/orB/pQ=

--- a/pkg/install/role.yaml
+++ b/pkg/install/role.yaml
@@ -63,6 +63,9 @@ rules:
       - roles
       - clusterrolebindings
       - rolebindings
+  - verbs: ["*"]
+    apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
A new permission is also added to the acorn-system ClusterRole for leases in the coordination.k8s.io group for leader election support.

Issue: https://github.com/acorn-io/acorn/issues/241