### PR TITLE
Add controller flag to run in dev-mode

### DIFF
--- a/integration/helper/controller.go
+++ b/integration/helper/controller.go
@@ -210,7 +210,7 @@ func StartController(t *testing.T) {
 	}
 
 	lock(context.Background(), k8s, func(ctx context.Context) {
-		c, err := controller.New()
+		c, err := controller.New(true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cli/controller.go
+++ b/pkg/cli/controller.go
@@ -17,11 +17,12 @@ func NewController(c CommandContext) *cobra.Command {
 }
 
 type Controller struct {
-	client ClientFactory
+	client  ClientFactory
+	DevMode bool `usage:"disable controller leader election"`
 }
 
-func (s *Controller) Run(cmd *cobra.Command, args []string) error {
-	c, err := controller.New()
+func (s *Controller) Run(cmd *cobra.Command, _ []string) error {
+	c, err := controller.New(s.DevMode)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,8 +33,15 @@ type Controller struct {
 	apply  apply.Apply
 }
 
-func New() (*Controller, error) {
-	router, err := baaah.DefaultRouter("acorn-controller", scheme.Scheme)
+func New(devMode bool) (*Controller, error) {
+	routerOpts, err := baaah.DefaultOptions("acorn-controller", scheme.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	if devMode {
+		routerOpts.ElectionConfig.TTL = time.Hour
+	}
+	router, err := baaah.NewRouter("acorn-controller", scheme.Scheme, routerOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, the only thing that dev-mode does is set the leader election
TTL to 1 hour.