### PR TITLE
Check if string array's length greater than zero before overriding

### DIFF
--- a/docs/docs/30-installation/02-options.md
+++ b/docs/docs/30-installation/02-options.md
@@ -92,3 +92,9 @@ Note that in order to allow propagation of user-defined labels and annotations o
 
 ## Changing install options
 If you want to change your installation options after the initial installation, just rerun `acorn install` with the new options. This will update the existing install dynamically.
+
+For strings array flags, you can reset the slice to empty by pass empty string "". For example:
+
+```bash
+acorn install --propagate-project-annotation ""
+```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -211,12 +211,20 @@ func merge(oldConfig, newConfig *apiv1.Config) *apiv1.Config {
 	if newConfig.IgnoreUserLabelsAndAnnotations != nil {
 		mergedConfig.IgnoreUserLabelsAndAnnotations = newConfig.IgnoreUserLabelsAndAnnotations
 	}
-	if newConfig.AllowUserAnnotations != nil {
+
+	// This is to provide a way to reset value to empty if user passes --flag "" as empty string
+	if len(newConfig.AllowUserAnnotations) > 0 && newConfig.AllowUserAnnotations[0] == "" {
+		mergedConfig.AllowUserAnnotations = nil
+	} else if len(newConfig.AllowUserAnnotations) > 0 {
 		mergedConfig.AllowUserAnnotations = newConfig.AllowUserAnnotations
 	}
-	if newConfig.AllowUserLabels != nil {
+
+	if len(newConfig.AllowUserLabels) > 0 && newConfig.AllowUserLabels[0] == "" {
+		mergedConfig.AllowUserLabels = nil
+	} else if len(newConfig.AllowUserLabels) > 0 {
 		mergedConfig.AllowUserLabels = newConfig.AllowUserLabels
 	}
+
 	if newConfig.IngressClassName != nil {
 		if *newConfig.IngressClassName == "" {
 			mergedConfig.IngressClassName = nil
@@ -290,11 +298,15 @@ func merge(oldConfig, newConfig *apiv1.Config) *apiv1.Config {
 		mergedConfig.UseCustomCABundle = newConfig.UseCustomCABundle
 	}
 
-	if newConfig.PropagateProjectAnnotations != nil {
+	if len(newConfig.PropagateProjectAnnotations) > 0 && newConfig.PropagateProjectAnnotations[0] == "" {
+		mergedConfig.PropagateProjectAnnotations = nil
+	} else if len(newConfig.PropagateProjectAnnotations) > 0 {
 		mergedConfig.PropagateProjectAnnotations = newConfig.PropagateProjectAnnotations
 	}
 
-	if newConfig.PropagateProjectLabels != nil {
+	if len(newConfig.PropagateProjectLabels) > 0 && newConfig.PropagateProjectLabels[0] == "" {
+		mergedConfig.PropagateProjectLabels = nil
+	} else if len(newConfig.PropagateProjectLabels) > 0 {
 		mergedConfig.PropagateProjectLabels = newConfig.PropagateProjectLabels
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAcornDNSDisabledNoLookupsHappen(t *testing.T) {
@@ -14,4 +15,104 @@ func TestAcornDNSDisabledNoLookupsHappen(t *testing.T) {
 		AcornDNS: &s,
 	}, nil)
 	// if a lookup is going to happen this method would panic as the getter is nil
+}
+
+func TestMergeConfigWithZeroLengthStringsArrayShouldNotOverride(t *testing.T) {
+	oldConfig := &apiv1.Config{
+		AllowUserAnnotations:        []string{"foo"},
+		AllowUserLabels:             []string{"foo"},
+		PropagateProjectLabels:      []string{"foo"},
+		PropagateProjectAnnotations: []string{"foo"},
+		ClusterDomains:              []string{".acorn.io"},
+	}
+
+	newConfig := &apiv1.Config{
+		AllowUserAnnotations:        []string{},
+		AllowUserLabels:             []string{},
+		PropagateProjectLabels:      []string{},
+		PropagateProjectAnnotations: []string{},
+		ClusterDomains:              []string{},
+	}
+
+	result := merge(oldConfig, newConfig)
+	assert.Equal(t, []string{"foo"}, result.AllowUserAnnotations)
+	assert.Equal(t, []string{"foo"}, result.AllowUserLabels)
+	assert.Equal(t, []string{"foo"}, result.PropagateProjectAnnotations)
+	assert.Equal(t, []string{"foo"}, result.PropagateProjectLabels)
+	assert.Equal(t, []string{".acorn.io"}, result.ClusterDomains)
+}
+
+func TestMergeConfigWithActualValueStringsArrayShouldOverride(t *testing.T) {
+	oldConfig := &apiv1.Config{
+		AllowUserAnnotations:        []string{"foo"},
+		AllowUserLabels:             []string{"foo"},
+		PropagateProjectLabels:      []string{"foo"},
+		PropagateProjectAnnotations: []string{"foo"},
+		ClusterDomains:              []string{".acorn.io"},
+	}
+
+	newConfig := &apiv1.Config{
+		AllowUserAnnotations:        []string{"bar"},
+		AllowUserLabels:             []string{"bar"},
+		PropagateProjectLabels:      []string{"bar"},
+		PropagateProjectAnnotations: []string{"bar", "brah"},
+		ClusterDomains:              []string{"bar.acorn.io"},
+	}
+
+	result := merge(oldConfig, newConfig)
+	assert.Equal(t, []string{"bar"}, result.AllowUserAnnotations)
+	assert.Equal(t, []string{"bar"}, result.AllowUserLabels)
+	assert.Equal(t, []string{"bar"}, result.PropagateProjectLabels)
+	assert.Equal(t, []string{"bar", "brah"}, result.PropagateProjectAnnotations)
+	assert.Equal(t, []string{".bar.acorn.io"}, result.ClusterDomains)
+}
+
+func TestMergeConfigWithNilStringsArrayShouldNotOverride(t *testing.T) {
+	oldConfig := &apiv1.Config{
+		AllowUserAnnotations:        []string{"foo"},
+		AllowUserLabels:             []string{"foo"},
+		PropagateProjectLabels:      []string{"foo"},
+		PropagateProjectAnnotations: []string{"foo"},
+		ClusterDomains:              []string{".acorn.io"},
+	}
+
+	newConfig := &apiv1.Config{
+		AllowUserAnnotations:        nil,
+		AllowUserLabels:             nil,
+		PropagateProjectLabels:      nil,
+		PropagateProjectAnnotations: nil,
+		ClusterDomains:              nil,
+	}
+
+	result := merge(oldConfig, newConfig)
+	assert.Equal(t, []string{"foo"}, result.AllowUserAnnotations)
+	assert.Equal(t, []string{"foo"}, result.AllowUserLabels)
+	assert.Equal(t, []string{"foo"}, result.PropagateProjectLabels)
+	assert.Equal(t, []string{"foo"}, result.PropagateProjectAnnotations)
+	assert.Equal(t, []string{".acorn.io"}, result.ClusterDomains)
+}
+
+func TestMergeConfigWithEmptyStringStringsArrayShouldOverrideToNil(t *testing.T) {
+	oldConfig := &apiv1.Config{
+		AllowUserAnnotations:        []string{"foo"},
+		AllowUserLabels:             []string{"foo"},
+		PropagateProjectLabels:      []string{"foo"},
+		PropagateProjectAnnotations: []string{"foo"},
+		ClusterDomains:              []string{".acorn.io"},
+	}
+
+	newConfig := &apiv1.Config{
+		AllowUserAnnotations:        []string{""},
+		AllowUserLabels:             []string{""},
+		PropagateProjectLabels:      []string{""},
+		PropagateProjectAnnotations: []string{""},
+		ClusterDomains:              []string{""},
+	}
+
+	result := merge(oldConfig, newConfig)
+	assert.Nil(t, result.AllowUserAnnotations)
+	assert.Nil(t, result.AllowUserLabels)
+	assert.Nil(t, result.PropagateProjectLabels)
+	assert.Nil(t, result.PropagateProjectAnnotations)
+	assert.Nil(t, result.ClusterDomains)
 }


### PR DESCRIPTION
Signed-off-by: Daishan Peng <daishan@acorn.io>

## Context

We noticed that in dev-cluster some setting was constantly being overriden. It turns out that when merging config values, we only check whether value is not nil before overriding, and CLI will always initialize the value as an empty string array. This will cause the field being overriden as nil if `acorn install` is rerun.

Instead, we should check the length of the field and only override when its length is greater than zero.(user has explictly set the values).