### PR TITLE
Add docs for help and security

### DIFF
--- a/docs/docs/10-home.md
+++ b/docs/docs/10-home.md
@@ -135,3 +135,4 @@ Next you can learn more about what you can do with Acorn in the [getting started
 * [Getting Started](/getting-started)
 * [Authoring Acornfiles](/authoring/overview)
 * [Running Acorn Apps](/running/args-and-secrets)
+* [Join our Slack channel](https://slack.acorn.io)

--- a/docs/docs/110-faq.md
+++ b/docs/docs/110-faq.md
@@ -2,6 +2,16 @@
 title: FAQ
 ---
 
+### Where can I get help?
+There are several ways you can get help from the community and Acorn's maintainers:
+
+- For bugs or feature requests, open an issue [here](https://github.com/acorn-io/acorn/issues/new)
+- For questions or discussions, visit our [forum](https://github.com/acorn-io/acorn/discussions)
+- To reach out to and interact with the rest of the community, [join our Slack](https://slack.acorn.io)
+
+### How can I report a security issue?
+Please see our [security docs](/architecture/security-considerations).
+
 #### Does Acorn support CustomResourceDefinitions (CRDs)?
 
 CRD support is a commonly requested feature and we are thinking hard about how and whether we can support this. We recognize CRDs' value and prominence in the Kubernetes ecosystem, but because every CRD has its own unique impact and lifecycle, Acorn cannot reliably and predictably manage CustomResources generically. We are investigating different approaches and solutions.

--- a/docs/docs/60-architecture/02-security-considerations.md
+++ b/docs/docs/60-architecture/02-security-considerations.md
@@ -2,6 +2,27 @@
 title: Security Considerations
 ---
 
+## Report a Vulnerability
+
+Please email security@acorn.io to report a security vulnerability.
+
+You may optionally use GPG key `ed25519/2B480FBF4589035A` to encrypt the message:
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEYumxgxYJKwYBBAHaRw8BAQdAOKLnuP8xUhoLv3W9Pt1dm9vHugQp6wfvAOXp
+fdsec6y0IkFjb3JuIFNlY3VyaXR5IDxzZWN1cml0eUBhY29ybi5pbz6IkwQTFgoA
+OxYhBA6PZhQ3ctoS4HilaitID79FiQNaBQJi6bGDAhsDBQsJCAcCAiICBhUKCQgL
+AgQWAgMBAh4HAheAAAoJECtID79FiQNasGcA/0iK+CvUt4WR4EJQCat+59kDga4W
+q93NusAccHpVmS2BAP91JcJ8OwZyV8IcW/dwcDFvBvH3A5R0BMejEYLeP+goBbg4
+BGLpsYMSCisGAQQBl1UBBQEBB0D+8r9ML4HBgrobV+rysJQ205UKIFmbgVTY5bmD
+ywWsRAMBCAeIeAQYFgoAIBYhBA6PZhQ3ctoS4HilaitID79FiQNaBQJi6bGDAhsM
+AAoJECtID79FiQNagEEA/2XN7UI70hZNVcm+kGTW04MQ1s57YVzwibGcB79AvIX+
+AP9aDhMMlbAOJTVFlBmkzQ6ERpCfakLvw+BM2hEv10uiAg==
+=B32Z
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
 ## Acorn System Access
 
 Acorn system components run with cluster admin privileges because it needs the ability to create namespaces and other objects on the user's behalf. End users have little required permissions.


### PR DESCRIPTION
- Direct users to slack, issues, and discussions to get help
- Give instructions for report security vulns

Signed-off-by: Craig Jellick <craig@acorn.io>
