### PR TITLE
Bump the baaah dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693
-	github.com/acorn-io/baaah v0.0.0-20230129022613-803520949ab8
+	github.com/acorn-io/baaah v0.0.0-20230201185337-4e2dc0c8952e
 	github.com/acorn-io/mink v0.0.0-20230119012606-799c4d32d238
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693 h1:5uxUFWpREhhKllLkan
 github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693/go.mod h1:uiNpPSAYWhEBfbGWKpN185+EP+hZr2M/U8Ckr/Jo3Kk=
 github.com/acorn-io/apiserver v0.25.2-ot-1 h1:91Q7+Jd9BeYZhzt0C+38w2sMn8aHFOxfTdlE6MCH9UI=
 github.com/acorn-io/apiserver v0.25.2-ot-1/go.mod h1:8cynBL5SR6CIKypk9nWtZXHzEiJhLVQxeMVZ5CGzkFo=
-github.com/acorn-io/baaah v0.0.0-20230129022613-803520949ab8 h1:WlEDlrth4rPRaqTn8aZGNAxGN8IlKmx69+92jIvSPf0=
-github.com/acorn-io/baaah v0.0.0-20230129022613-803520949ab8/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
+github.com/acorn-io/baaah v0.0.0-20230201185337-4e2dc0c8952e h1:yT2fwfbKcMimMnGI+JSVdzOPkNlmzQZsp0JMsP3eMjM=
+github.com/acorn-io/baaah v0.0.0-20230201185337-4e2dc0c8952e/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
 github.com/acorn-io/component-base v0.25.2-ot-1 h1:xinqJUNbpW2/zsvm8mDv6Q7riLhvXup9x7Kz9eIPM1M=
 github.com/acorn-io/component-base v0.25.2-ot-1/go.mod h1:/5qYr5BXGNPs+cRd6+WL1NfOYtzOstJlm1CMK06cm7s=
 github.com/acorn-io/etcd/server/v3 v3.5.4-ot-1 h1:sQMBy/UImb1923toh9U0oIxlpO7crLrD7eKE/orB/pQ=

--- a/integration/helper/controller.go
+++ b/integration/helper/controller.go
@@ -210,7 +210,7 @@ func StartController(t *testing.T) {
 	}
 
 	lock(context.Background(), k8s, func(ctx context.Context) {
-		c, err := controller.New(true)
+		c, err := controller.New()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cli/controller.go
+++ b/pkg/cli/controller.go
@@ -17,12 +17,11 @@ func NewController(c CommandContext) *cobra.Command {
 }
 
 type Controller struct {
-	client  ClientFactory
-	DevMode bool `usage:"disable controller leader election"`
+	client ClientFactory
 }
 
 func (s *Controller) Run(cmd *cobra.Command, _ []string) error {
-	c, err := controller.New(s.DevMode)
+	c, err := controller.New()
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,15 +33,8 @@ type Controller struct {
 	apply  apply.Apply
 }
 
-func New(devMode bool) (*Controller, error) {
-	routerOpts, err := baaah.DefaultOptions("acorn-controller", scheme.Scheme)
-	if err != nil {
-		return nil, err
-	}
-	if devMode {
-		routerOpts.ElectionConfig.TTL = time.Hour
-	}
-	router, err := baaah.NewRouter("acorn-controller", scheme.Scheme, routerOpts)
+func New() (*Controller, error) {
+	router, err := baaah.DefaultRouter("acorn-controller", scheme.Scheme)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A previous change was merged to set the leader election TTL on the controller to a high value for dev mode. That changed proved insufficient for all controllers that use baaah.

A new change was merged to baaah to allow the `BAAAH_DEV_MODE` environment variable to set the leader election TTL to a larger value. This change pulls in those baaah changes and uses them instead of the dev mode flag.