### PR TITLE
Add volume status to CLI

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -40,7 +40,8 @@ func TestVolume(t *testing.T) {
 	pv := helper.Wait(t, kclient.Watch, &corev1.PersistentVolumeList{}, func(obj *corev1.PersistentVolume) bool {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
-			obj.Labels[labels.AcornManaged] == "true"
+			obj.Labels[labels.AcornManaged] == "true" &&
+			obj.Labels[labels.AcornVolumeName] == "external"
 	})
 
 	_, err = c.AppDelete(ctx, app.Name)
@@ -64,11 +65,13 @@ func TestVolume(t *testing.T) {
 		return obj.Status.Phase == corev1.VolumeBound &&
 			obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
-			obj.Labels[labels.AcornManaged] == "true"
+			obj.Labels[labels.AcornManaged] == "true" &&
+			obj.Labels[labels.AcornVolumeName] == "external-bind"
 	})
 
 	helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
-		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success
+		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+			obj.Status.Condition(v1.AppInstanceConditionVolumes).Success
 	})
 }
 

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -19,6 +19,7 @@ var (
 	AppInstanceConditionJobs       = "jobs"
 	AppInstanceConditionReady      = "Ready"
 	AppInstanceConditionUpgrade    = "upgrade"
+	AppInstanceConditionVolumes    = "volumes"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/pvc.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/pvc.yaml
@@ -13,6 +13,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
     allowed-global.io: test-global
     allowed-scoped.io: test-volume
     allowed.io: test-allowed-app-spec-label

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/pvc.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/pvc.yaml
@@ -12,6 +12,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
     appSpecLabel: test-app-spec-label
     global-scoped-label: test-global
     named-scoped-label: test-named

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/pvc.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/pvc.yaml
@@ -7,6 +7,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
 spec:
   resources:
     requests:

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
@@ -54,6 +54,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
 spec:
   resources:
     requests:

--- a/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
@@ -54,6 +54,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
 spec:
   resources:
     requests:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
@@ -51,6 +51,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
 spec:
   volumeName: "existing-foo"
   resources:

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
@@ -54,6 +54,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
 spec:
   volumeName: "existing-foo"
   resources:

--- a/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
@@ -54,6 +54,7 @@ metadata:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
+    "acorn.io/volume-name": "foo"
 spec:
   resources:
     requests:

--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -156,6 +156,7 @@ func volumeLabels(appInstance *v1.AppInstance, volume string, volumeRequest v1.V
 		labels.AcornAppName:      appInstance.Name,
 		labels.AcornAppNamespace: appInstance.Namespace,
 		labels.AcornManaged:      "true",
+		labels.AcornVolumeName:   volume,
 	}
 	return labels.Merge(labelMap, labels.GatherScoped(volume, v1.LabelTypeVolume, appInstance.Status.AppSpec.Labels,
 		volumeRequest.Labels, appInstance.Spec.Labels))

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -45,6 +45,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	appRouter.HandlerFunc(appdefinition.AppStatus)
 	appRouter.HandlerFunc(appdefinition.AppEndpointsStatus)
 	appRouter.HandlerFunc(appdefinition.JobStatus)
+	appRouter.HandlerFunc(appdefinition.VolumeStatus)
 	appRouter.HandlerFunc(appdefinition.ReadyStatus)
 	appRouter.HandlerFunc(appdefinition.CLIStatus)
 	appRouter.HandlerFunc(appdefinition.UpdateGeneration)


### PR DESCRIPTION
By default, the CLI will show the status of different objects in an app until the app is ready. The status of volumes/PVCs is not shown. If there is an issue, the status will only show information about the container.

With this change, the CLI will show status for PVCs as volumes.

Signed-off-by: Donnie Adams <donnie@acorn.io>

### Checklist
- [x] All relevant issues are referenced in this PR
- [x] The title of this PR would make a good line in the Release Note's Changelog
- [x] Commits are signed-off using `git commit -s`
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section.


#### Proposed Changes
Add the status of volumes/PVCs in the CLI status.

#### User-Facing Change? ####
_Does this PR introduce a user-facing change in functionality, the API or the CLI?_
It shows the status of volumes in the CLI. For example, when using `acorn run`

_How will this change affect upgrades?_
A label is added all the Kubernetes objects related to volumes i.e. `acorn.io/volume-name: my-volume`

#### Verification and Testing ####

_How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes._
Use `acorn run` to deploy an app that has a volume. The status of the volume should appear in the statuses printed as the app is being deployed.

_Are there automated tests to cover your changes?_
The tests have been updated to include the label mentioned above and the new condition added to the AppInstance for the volume status.

#### Linked Issues ####
https://github.com/acorn-io/acorn/issues/415

