### PR TITLE
Continue checking dependencies after finding a linked one

### DIFF
--- a/pkg/controller/appdefinition/depends.go
+++ b/pkg/controller/appdefinition/depends.go
@@ -176,7 +176,7 @@ outer:
 	for _, depName := range deps {
 		for _, link := range d.app.Spec.Links {
 			if link.Target == depName {
-				return true
+				continue outer
 			}
 		}
 		for _, depCheck := range []depCheck{d.isDepReady, d.isJobReady, d.isCronJobReady} {


### PR DESCRIPTION
Once Acorn finds a linked dependency, it will stop probing the other dependencies. After this change, it will continue to probe other dependencies after finding a linked one.

Issue: https://github.com/acorn-io/acorn/issues/1191