### PR TITLE
Add missing permissions for project edit roles to do update

### DIFF
--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -82,6 +82,13 @@ var (
 				},
 			},
 			{
+				Verbs: []string{"update"},
+				Resources: []string{
+					"images/details",
+					"apps/pullimage",
+				},
+			},
+			{
 				Verbs: []string{"create"},
 				Resources: []string{
 					"images/tag",


### PR DESCRIPTION
Signed-off-by: Daishan Peng <daishan@acorn.io>

### Checklist
- [ ] All relevant issues are referenced in this PR
- [ ] The title of this PR would make a good line in the Release Note's Changelog
- [ ] Commits are signed-off using `git commit -s`
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section.


#### Proposed Changes

Adding missed permission to project edit role. The edit role should have permission to update image details, and pull images. Those apis are required when updating an acorn apps, as it needs to pull image and update specs(Acornfile) from CLI and then update the acorn image.

#### User-Facing Change? ####

No

#### Verification and Testing ####

The permission was clearly missing when testing update https://github.com/acorn-io/hub/issues/181.

#### Linked Issues ####

https://github.com/acorn-io/hub/issues/181

