### PR TITLE
add project label to namespace when used within an app (#1143)

### DIFF
--- a/pkg/controller/appdefinition/namespace_test.go
+++ b/pkg/controller/appdefinition/namespace_test.go
@@ -4,8 +4,12 @@ import (
 	"testing"
 
 	"github.com/acorn-io/acorn/pkg/controller/namespace"
+	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/scheme"
 	"github.com/acorn-io/baaah/pkg/router/tester"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestAssignNamespace(t *testing.T) {
@@ -22,4 +26,46 @@ func TestLabelsAnnotationsBasic(t *testing.T) {
 
 func TestLabelsAnnotationsNoConfigset(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/propagation_noconfig", namespace.AddNamespace)
+}
+
+func TestHandler_AddAcornProjectLabel(t *testing.T) {
+	harness, input, err := tester.FromDir(scheme.Scheme, "testdata/addacornprojectlabel")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := tester.NewRequest(t, harness.Scheme, input, harness.Existing...)
+
+	if err = AddAcornProjectLabel(req, nil); err != nil {
+		t.Fatal(err)
+	}
+	var projectNamespace v1.Namespace
+	if err = req.Client.Get(req.Ctx, kclient.ObjectKey{
+		Name: input.GetNamespace(),
+	}, &projectNamespace); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "true", projectNamespace.Labels[labels.AcornProject])
+}
+
+func TestHandler_AddAcornProjectLabelAlreadyExists(t *testing.T) {
+	harness, input, err := tester.FromDir(scheme.Scheme, "testdata/addacornprojectlabelalreadyexists")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := tester.NewRequest(t, harness.Scheme, input, harness.Existing...)
+
+	if err = AddAcornProjectLabel(req, nil); err != nil {
+		t.Fatal(err)
+	}
+	var projectNamespace v1.Namespace
+	if err = req.Client.Get(req.Ctx, kclient.ObjectKey{
+		Name: input.GetNamespace(),
+	}, &projectNamespace); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "true", projectNamespace.Labels[labels.AcornProject])
 }

--- a/pkg/controller/appdefinition/testdata/addacornprojectlabel/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/addacornprojectlabel/existing.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+spec:
+  finalizers:
+    - kubernetes
+---
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: test
+  uid: 1234567890abcdef
+---

--- a/pkg/controller/appdefinition/testdata/addacornprojectlabel/input.yaml
+++ b/pkg/controller/appdefinition/testdata/addacornprojectlabel/input.yaml
@@ -1,0 +1,6 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: test
+  uid: 1234567890abcdef

--- a/pkg/controller/appdefinition/testdata/addacornprojectlabelalreadyexists/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/addacornprojectlabelalreadyexists/existing.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+  labels:
+    acorn.io/project: "true"
+spec:
+  finalizers:
+    - kubernetes
+---
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: test
+  uid: 1234567890abcdef
+
+---

--- a/pkg/controller/appdefinition/testdata/addacornprojectlabelalreadyexists/input.yaml
+++ b/pkg/controller/appdefinition/testdata/addacornprojectlabelalreadyexists/input.yaml
@@ -1,0 +1,6 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: test
+  uid: 1234567890abcdef

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -48,6 +48,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	appRouter.HandlerFunc(appdefinition.ReadyStatus)
 	appRouter.HandlerFunc(appdefinition.CLIStatus)
 	appRouter.HandlerFunc(appdefinition.UpdateGeneration)
+	appRouter.HandlerFunc(appdefinition.AddAcornProjectLabel)
 
 	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.DeployBuilder)
 


### PR DESCRIPTION
Signed-off-by: Joshua Silverio <joshua@acorn.io>

### Checklist
- [x] All relevant issues are referenced in this PR
- [ ] The title of this PR would make a good line in the Release Note's Changelog
- [x] Commits are signed-off using `git commit -s`
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section.


#### Proposed Changes
_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request_
This PR allows users to use pre-created namespaces within the project ecosystem once an app is run within that namespace
#### User-Facing Change? ####
_Does this PR introduce a user-facing change in functionality, the API or the CLI?_
Users can now see the namespace as a project after app is ran
_How will this change affect upgrades?_

#### Verification and Testing ####

_How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes._
```
kubectl create namespace test
acorn run -j test .
acorn project
//should list test as a project and can do all things with test as a normal project (filter, use, rm, etc)
```
_Are there automated tests to cover your changes?_
yes
#### Linked Issues ####
#1143 
_Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/acorn-io/acorn/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features._

