### PR TITLE
 Don't decrypted data when writing generated secret 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693
-	github.com/acorn-io/baaah v0.0.0-20230207131904-7917e522c261
+	github.com/acorn-io/baaah v0.0.0-20230209024313-042ca60f7909
 	github.com/acorn-io/mink v0.0.0-20230206230657-e1bd552f1bd4
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693 h1:5uxUFWpREhhKllLkan
 github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693/go.mod h1:uiNpPSAYWhEBfbGWKpN185+EP+hZr2M/U8Ckr/Jo3Kk=
 github.com/acorn-io/apiserver v0.25.2-ot-1 h1:91Q7+Jd9BeYZhzt0C+38w2sMn8aHFOxfTdlE6MCH9UI=
 github.com/acorn-io/apiserver v0.25.2-ot-1/go.mod h1:8cynBL5SR6CIKypk9nWtZXHzEiJhLVQxeMVZ5CGzkFo=
-github.com/acorn-io/baaah v0.0.0-20230207131904-7917e522c261 h1:Nb3Jic7TbiyfowAVrL+KdhE0y1FT0i8hdGAChtyHS+g=
-github.com/acorn-io/baaah v0.0.0-20230207131904-7917e522c261/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
+github.com/acorn-io/baaah v0.0.0-20230209024313-042ca60f7909 h1:rSOlRuznStAN99KZ1MDcOiiXPUKcalNOn48WOtz6Zto=
+github.com/acorn-io/baaah v0.0.0-20230209024313-042ca60f7909/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
 github.com/acorn-io/component-base v0.25.2-ot-1 h1:xinqJUNbpW2/zsvm8mDv6Q7riLhvXup9x7Kz9eIPM1M=
 github.com/acorn-io/component-base v0.25.2-ot-1/go.mod h1:/5qYr5BXGNPs+cRd6+WL1NfOYtzOstJlm1CMK06cm7s=
 github.com/acorn-io/etcd/server/v3 v3.5.4-ot-1 h1:sQMBy/UImb1923toh9U0oIxlpO7crLrD7eKE/orB/pQ=

--- a/pkg/controller/appdefinition/secret_test.go
+++ b/pkg/controller/appdefinition/secret_test.go
@@ -277,6 +277,16 @@ func TestSecretImageReference(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/secret-image", CreateSecrets)
 }
 
+func TestSecretEncrypted(t *testing.T) {
+	resp := tester.DefaultTest(t, scheme.Scheme, "testdata/secret-encrypted", CreateSecrets)
+	secret := resp.Client.Created[0].(*corev1.Secret)
+	assert.Equal(t, "foo-", secret.GenerateName)
+	assert.Equal(t, "app-namespace", secret.Namespace)
+	assert.Equal(t, "ACORNENC:eyJzNmc2QWx2V05ER09MUnVkMWo2eVdoNHVUQndVU2NPa0ZJLUluYktYTXpvIjoiaTZ"+
+		"DTl96TnpYM2wxYTVMaEdKTXpLalZnNlhPV2NZM0NYc21lQ2JETTNHWENySzBnSzVMdTg3bE45OGszcUdReGd6V1JSUHMifQ",
+		string(secret.Data["key"]))
+}
+
 func TestSecretLabelsAnnotations(t *testing.T) {
 	h := tester.Harness{
 		Scheme: scheme.Scheme,

--- a/pkg/controller/appdefinition/testdata/secret-encrypted/existing.yaml.d/namespace.yaml
+++ b/pkg/controller/appdefinition/testdata/secret-encrypted/existing.yaml.d/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-namespace
+  uid: a1234567890123

--- a/pkg/controller/appdefinition/testdata/secret-encrypted/existing.yaml.d/secret.yaml
+++ b/pkg/controller/appdefinition/testdata/secret-encrypted/existing.yaml.d/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  nacl-keys: eyJzNmc2QWx2V05ER09MUnVkMWo2eVdoNHVUQndVU2NPa0ZJLUluYktYTXpvIjp7ImFjb3JuTmFtZXNwYWNlIjoiYWNvcm4iLCJwcmltYXJ5Ijp0cnVlLCJhY29ybk5hbWVzcGFjZVVJRCI6ImI1ZjJjMTlkLTIxNTItNGMxYS1hOWViLTA5MjE1NDMzOTg5MCIsInByaXZhdGVLZXkiOlsyMCwyMzYsOTUsMjA1LDIyNSwxOTcsMjQ3LDI2LDM2LDkxLDExNSwxMjIsMTcwLDAsODksMjE1LDEwNywxNzMsMjE1LDExOCwyMTIsMTc0LDkxLDE5OCwxNDEsMTI0LDQsNzQsOTgsMTg2LDE1LDI0XSwicHVibGljS2V5IjpbMTc5LDE2OCw1OCwyLDkxLDIxNCw1Miw0OSwxNDIsNDUsMjcsMTU3LDIxNCw2MiwxNzgsOTAsMzAsNDYsNzYsMjgsMjAsNzMsMTk1LDE2NCwyMCwxNDMsMTM2LDE1NywxNzgsMTUxLDUxLDU4XX19
+  ns-uid: MTIzNDU2Nzg5MDEy
+kind: Secret
+metadata:
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/secret-generated: "true"
+  name: app-namespace-a12345678901-enc-keys
+  namespace: acorn-system

--- a/pkg/controller/appdefinition/testdata/secret-encrypted/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/secret-encrypted/expected.yaml.d/appinstance.yaml
@@ -1,0 +1,31 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  uid: 1234567890abcdef
+  name: app-name
+  namespace: app-namespace
+spec:
+  image: test
+  publishAllPorts: true
+  endpoints:
+    - target: oneimage
+      hostname: localhost
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+    imageData:
+      images:
+        foo:
+          image: asdf
+  appSpec:
+    secrets:
+      foo:
+        type: "template"
+        data:
+          key: "ACORNENC:eyJzNmc2QWx2V05ER09MUnVkMWo2eVdoNHVUQndVU2NPa0ZJLUluYktYTXpvIjoiaTZDTl96TnpYM2wxYTVMaEdKTXpLalZnNlhPV2NZM0NYc21lQ2JETTNHWENySzBnSzVMdTg3bE45OGszcUdReGd6V1JSUHMifQ"
+  conditions:
+    - type: secrets
+      reason: Success
+      status: "True"
+      success: true

--- a/pkg/controller/appdefinition/testdata/secret-encrypted/expected.yaml.d/secret.yaml
+++ b/pkg/controller/appdefinition/testdata/secret-encrypted/expected.yaml.d/secret.yaml
@@ -1,0 +1,12 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: foo
+  namespace: app-created-namespace
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+type: secrets.acorn.io/template
+data:
+  key: aGVsbG8=

--- a/pkg/controller/appdefinition/testdata/secret-encrypted/input.yaml
+++ b/pkg/controller/appdefinition/testdata/secret-encrypted/input.yaml
@@ -1,0 +1,26 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  uid: 1234567890abcdef
+  name: app-name
+  namespace: app-namespace
+spec:
+  image: test
+  publishAllPorts: true
+  endpoints:
+  - target: oneimage
+    hostname: localhost
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+    imageData:
+      images:
+        foo:
+          image: asdf
+  appSpec:
+    secrets:
+      foo:
+        type: "template"
+        data:
+          key: "ACORNENC:eyJzNmc2QWx2V05ER09MUnVkMWo2eVdoNHVUQndVU2NPa0ZJLUluYktYTXpvIjoiaTZDTl96TnpYM2wxYTVMaEdKTXpLalZnNlhPV2NZM0NYc21lQ2JETTNHWENySzBnSzVMdTg3bE45OGszcUdReGd6V1JSUHMifQ"


### PR DESCRIPTION
If the user puts an encrypted value a secret data field
in the Acornfile do not decrypt the value when creating the generated
secret in the app's source namespace. This causes an undesired side
effect  in that the user can now do "acorn secret reveal" to get the
clear text of an encrypted secret. This isn't a secret issue because
the users has already been granted "reveal", but we'd rather not
reveal the clear text value for a secret that was intentionally
encrypted by the user.

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [x] All relevant issues are referenced in this PR
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits).
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

