### PR TITLE
validate -j/--project inputs for acorn cli (#1212)

### DIFF
--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -8,6 +8,8 @@ import (
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client/term"
+	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/acorn/pkg/project"
 	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
@@ -117,6 +119,23 @@ func (a *Acorn) PersistentPre(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+
+	if a.Project != "" {
+		clientFactory := CommandClientFactory{
+			cmd:   cmd,
+			acorn: a,
+		}
+		cfg, err := config.ReadCLIConfig()
+		if err != nil {
+			return err
+		}
+
+		_, err = project.Get(cmd.Context(), clientFactory.Options().WithCLIConfig(cfg), a.Project)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cli/acorn_test.go
+++ b/pkg/cli/acorn_test.go
@@ -72,3 +72,105 @@ func TestAcorn(t *testing.T) {
 		})
 	}
 }
+
+func TestAcornProject(t *testing.T) {
+	type fields struct {
+		Quiet  bool
+		Output string
+		All    bool
+	}
+	type args struct {
+		cmd    *cobra.Command
+		args   []string
+		client *testdata.MockClient
+	}
+	var _, w, _ = os.Pipe()
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		wantOut        string
+		commandContext CommandContext
+	}{
+		{
+			name: "acorn image -j noproject",
+			fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader(""),
+			},
+			args: args{
+				args:   []string{"image", "-j", "noproject"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: true,
+			wantOut: "projects.api.acorn.io \"noproject\" not found",
+		},
+		{
+			name: "acorn image -j 12.badname",
+			fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader(""),
+			},
+			args: args{
+				args:   []string{"image", "-j", "12.badname"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: true,
+			wantOut: "invalid project name [12.badname]: can not contain \".\"",
+		},
+		{
+			name: "acorn image -j badname/projectname/here",
+			fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader(""),
+			},
+			args: args{
+				args:   []string{"image", "-j", "badname/projectname/here"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: true,
+			wantOut: "failed to find authentication token for server badname, please run 'acorn login badname' first",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			tt.args.cmd = New()
+			tt.args.cmd.SetArgs(tt.args.args)
+			err := tt.args.cmd.Execute()
+			if err != nil && !tt.wantErr {
+				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
+			} else if err != nil && tt.wantErr {
+				assert.Equal(t, tt.wantOut, err.Error())
+			} else {
+				w.Close()
+				out, _ := io.ReadAll(r)
+				testOut, _ := os.ReadFile(tt.wantOut)
+				assert.Equal(t, string(testOut), string(out))
+			}
+		})
+	}
+}

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -27,6 +27,8 @@ type MockClientFactory struct {
 	SecretItem     *apiv1.Secret
 	ImageList      []apiv1.Image
 	ImageItem      *apiv1.Image
+	ProjectList    []apiv1.Project
+	ProjectItem    *apiv1.Project
 }
 
 func (dc *MockClientFactory) Options() project.Options {
@@ -41,12 +43,14 @@ func (dc *MockClientFactory) CreateDefault() (client.Client, error) {
 		Volumes:        dc.VolumeList,
 		Secrets:        dc.SecretList,
 		Images:         dc.ImageList,
+		Projects:       dc.ProjectList,
 		AppItem:        dc.AppItem,
 		ContainerItem:  dc.ContainerItem,
 		CredentialItem: dc.CredentialItem,
 		VolumeItem:     dc.VolumeItem,
 		SecretItem:     dc.SecretItem,
 		ImageItem:      dc.ImageItem,
+		ProjectItem:    dc.ProjectItem,
 	}, nil
 }
 
@@ -63,6 +67,8 @@ type MockClient struct {
 	SecretItem     *apiv1.Secret
 	Images         []apiv1.Image
 	ImageItem      *apiv1.Image
+	Projects       []apiv1.Project
+	ProjectItem    *apiv1.Project
 }
 
 func (m *MockClient) AppPullImage(ctx context.Context, name string) error {
@@ -612,18 +618,27 @@ func (m *MockClient) AcornImageBuild(ctx context.Context, file string, opts *cli
 }
 
 func (m *MockClient) ProjectList(ctx context.Context) ([]apiv1.Project, error) {
-	//TODO implement me
-	panic("implement me")
+	if m.Projects != nil {
+		return m.Projects, nil
+	}
+	return []apiv1.Project{{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "project"},
+	}}, nil
 }
 
 func (m *MockClient) GetProject() string {
-	//TODO implement me
-	panic("implement me")
+	if m.ProjectItem != nil {
+		return m.ProjectItem.Name
+	}
+	return ""
 }
 
 func (m *MockClient) ProjectGet(ctx context.Context, name string) (*apiv1.Project, error) {
-	//TODO implement me
-	panic("implement me")
+	if m.ProjectItem != nil {
+		return m.ProjectItem, nil
+	}
+	return nil, nil
 }
 
 func (m *MockClient) ProjectCreate(ctx context.Context, name string) (*apiv1.Project, error) {


### PR DESCRIPTION
Signed-off-by: Joshua Silverio <joshua@acorn.io>

### Checklist
- [x] All relevant issues are referenced in this PR
#1212 #1069 
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits).
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
This PR introduces validation to -j/--project flags in Acorn CLI. Now instead of no response when a user uses a -j flag with a invalid project the cmd will error out with specific reason why that project can not be used.

