### PR TITLE
Fix project UX issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693
-	github.com/acorn-io/baaah v0.0.0-20230209024313-042ca60f7909
+	github.com/acorn-io/baaah v0.0.0-20230210045136-282f5388cca5
 	github.com/acorn-io/mink v0.0.0-20230206230657-e1bd552f1bd4
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693 h1:5uxUFWpREhhKllLkan
 github.com/acorn-io/aml v0.0.0-20220717003025-bc8cb1214693/go.mod h1:uiNpPSAYWhEBfbGWKpN185+EP+hZr2M/U8Ckr/Jo3Kk=
 github.com/acorn-io/apiserver v0.25.2-ot-1 h1:91Q7+Jd9BeYZhzt0C+38w2sMn8aHFOxfTdlE6MCH9UI=
 github.com/acorn-io/apiserver v0.25.2-ot-1/go.mod h1:8cynBL5SR6CIKypk9nWtZXHzEiJhLVQxeMVZ5CGzkFo=
-github.com/acorn-io/baaah v0.0.0-20230209024313-042ca60f7909 h1:rSOlRuznStAN99KZ1MDcOiiXPUKcalNOn48WOtz6Zto=
-github.com/acorn-io/baaah v0.0.0-20230209024313-042ca60f7909/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
+github.com/acorn-io/baaah v0.0.0-20230210045136-282f5388cca5 h1:nK0zoe9Ce0xSTHkfk6KpRHUpf7SzZ8yHG8suqTxSvbY=
+github.com/acorn-io/baaah v0.0.0-20230210045136-282f5388cca5/go.mod h1:HVIZ8vDXjY2y045giWUAcoX1fIAkmqABQgKgdgo3/og=
 github.com/acorn-io/component-base v0.25.2-ot-1 h1:xinqJUNbpW2/zsvm8mDv6Q7riLhvXup9x7Kz9eIPM1M=
 github.com/acorn-io/component-base v0.25.2-ot-1/go.mod h1:/5qYr5BXGNPs+cRd6+WL1NfOYtzOstJlm1CMK06cm7s=
 github.com/acorn-io/etcd/server/v3 v3.5.4-ot-1 h1:sQMBy/UImb1923toh9U0oIxlpO7crLrD7eKE/orB/pQ=

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -264,7 +264,7 @@ func projectsCompletion(ctx context.Context, c client.Client, toComplete string)
 		return nil, err
 	}
 
-	projects, err := project.List(ctx, project.Options{
+	projects, _, err := project.List(ctx, project.Options{
 		CLIConfig: cfg,
 	})
 	if err != nil {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -28,12 +28,10 @@ type CommandClientFactory struct {
 
 func (c *CommandClientFactory) Options() project.Options {
 	return project.Options{
-		Project:       c.acorn.Project,
-		Kubeconfig:    c.acorn.Kubeconfig,
-		KubeconfigEnv: os.Getenv("KUBECONFIG"),
-		ContextEnv:    os.Getenv("CONTEXT"),
-		NamespaceEnv:  os.Getenv("NAMESPACE"),
-		AllProjects:   c.acorn.AllProjects,
+		Project:     c.acorn.Project,
+		Kubeconfig:  c.acorn.Kubeconfig,
+		ContextEnv:  os.Getenv("CONTEXT"),
+		AllProjects: c.acorn.AllProjects,
 	}
 }
 

--- a/pkg/cli/project_use.go
+++ b/pkg/cli/project_use.go
@@ -7,7 +7,6 @@ import (
 	"github.com/acorn-io/acorn/pkg/config"
 	"github.com/acorn-io/acorn/pkg/project"
 	"github.com/spf13/cobra"
-	"k8s.io/utils/strings/slices"
 )
 
 func NewProjectUse(c CommandContext) *cobra.Command {
@@ -33,21 +32,15 @@ func (a *ProjectUse) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// They want to clear the default, ok....
+	// They want to clear the default
 	if args[0] == "" {
 		cfg.CurrentProject = ""
 		return cfg.Save()
 	}
 
-	if cfg.ProjectAliases[args[0]] == "" {
-		projects, err := project.List(cmd.Context(), a.client.Options().WithCLIConfig(cfg))
-		if err != nil {
-			return err
-		}
-
-		if !slices.Contains(projects, args[0]) {
-			return fmt.Errorf("failed to find project %s, use \"acorn projects\" to list valid project names", args[0])
-		}
+	_, err = project.Get(cmd.Context(), a.client.Options().WithCLIConfig(cfg), args[0])
+	if err != nil {
+		return fmt.Errorf("failed to find project %s, use \"acorn projects\" to list valid project names: %w", args[0], err)
 	}
 
 	cfg.CurrentProject = args[0]

--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -28,6 +28,10 @@ type Store struct {
 	c   client.Client
 }
 
+func NewLocalOnlyStore(cfg *config.CLIConfig) (*Store, error) {
+	return NewStore(cfg, nil)
+}
+
 func NewStore(cfg *config.CLIConfig, c client.Client) (*Store, error) {
 	return &Store{
 		cfg: cfg,

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -120,16 +120,12 @@ func Login(ctx context.Context, password, address string) (user string, pass str
 }
 
 func DefaultProject(ctx context.Context, address, user, token string) (string, error) {
-	desiredDefault := address + "/" + user + "/acorn"
 	projects, err := Projects(ctx, address, token)
 	if err != nil {
 		return "", err
 	}
 	if len(projects) == 0 {
 		return "", err
-	}
-	if slices.Contains(projects, desiredDefault) {
-		return desiredDefault, nil
 	}
 	return projects[0], nil
 }

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -2,10 +2,7 @@ package project
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -15,40 +12,19 @@ import (
 	"github.com/acorn-io/acorn/pkg/hub"
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/baaah/pkg/restconfig"
-	"github.com/adrg/xdg"
 	"k8s.io/client-go/rest"
 )
 
 var (
-	csvSplit              = regexp.MustCompile(`\s*,\s*`)
-	ErrNoKubernetesConfig = errors.New("no kubeconfig file found try creating one at $HOME/.kube/config")
-	NoProjectMessageNoHub = "\n" +
-		"\nA valid Acorn client configuration can not be found." +
-		"\n" +
-		"\nPlease run one of the following commands:" +
-		"\n" +
-		"\n  \"acorn install\"              Install acorn into a Kubernetes cluster." +
-		"\n  \"acorn project use PROJECT\"  You already have a project but it's not set for some reason." +
-		"\n                               Use \"acorn projects\" to find your project name."
-	NoProjectMessage = "\n" +
-		"\nAcorn CLI has not been initialized." +
-		"\n" +
-		"\nPlease run one of the following commands:" +
-		"\n" +
-		"\n  \"acorn login\"               (Easy mode:     Configure acorn to use cloud based resources. Fast and easy.)" +
-		"\n  \"acorn install\"             (Hard mode:     Install acorn into a Kubernetes cluster. There be dragons.)" +
-		"\n  \"acorn project use PROJECT\" (Confused mode: You already have a project but it's not set for some reason." +
-		"\n                                              Use \"acorn projects\" to find your project name.)"
+	csvSplit = regexp.MustCompile(`\s*,\s*`)
 )
 
 type Options struct {
-	Project       string
-	Kubeconfig    string
-	KubeconfigEnv string
-	ContextEnv    string
-	NamespaceEnv  string
-	AllProjects   bool
-	CLIConfig     *config.CLIConfig
+	Project     string
+	Kubeconfig  string
+	ContextEnv  string
+	AllProjects bool
+	CLIConfig   *config.CLIConfig
 }
 
 func (o Options) WithCLIConfig(cfg *config.CLIConfig) Options {
@@ -58,36 +34,6 @@ func (o Options) WithCLIConfig(cfg *config.CLIConfig) Options {
 
 func Client(ctx context.Context, opts Options) (client.Client, error) {
 	return lookup(ctx, opts)
-}
-
-func localProjectToNamespace(project string) (string, error) {
-	parts := strings.Split(project, "/")
-	if len(parts) > 1 {
-		return "", fmt.Errorf("failed to determine target project, / is not allowed in project [%s] name when using local kubeconfig", project)
-	}
-	return parts[0], nil
-}
-
-func lookupNamespaceForLocal(opts Options, fromKubeconfig string) (string, error) {
-	if opts.AllProjects {
-		return "", nil
-	}
-	if opts.Project != "" {
-		return localProjectToNamespace(opts.Project)
-	}
-	if opts.CLIConfig.CurrentProject != "" {
-		if strings.Contains(opts.CLIConfig.CurrentProject, "/") {
-			return system.DefaultUserNamespace, nil
-		}
-		return opts.CLIConfig.CurrentProject, nil
-	}
-	if opts.NamespaceEnv != "" {
-		return localProjectToNamespace(opts.NamespaceEnv)
-	}
-	if fromKubeconfig != "" {
-		return fromKubeconfig, nil
-	}
-	return system.DefaultUserNamespace, nil
 }
 
 func lookup(ctx context.Context, opts Options) (client.Client, error) {
@@ -104,30 +50,12 @@ func lookup(ctx context.Context, opts Options) (client.Client, error) {
 		opts.CLIConfig = cfg
 	}
 
-	// If user specifies --kubeconfig them always read from it regardless of project config.  If the current
-	// project contains a "/" then fail
-	if opts.Kubeconfig != "" {
-		return clientFromFile(opts.Kubeconfig, opts)
-	}
-
 	projects, err := getDesiredProjects(ctx, cfg, opts)
 	if err != nil {
 		return nil, err
 	}
 	if len(projects) == 0 {
-		c, err := noConfigClient(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		defaultProject := c.GetProject()
-		if opts.AllProjects {
-			defaultProject = ""
-		}
-		return client.NewMultiClient(defaultProject, c.GetNamespace(), &projectClientFactory{
-			defaultProject: defaultProject,
-			clients:        []client.Client{c},
-			cfg:            cfg,
-		}), nil
+		projects = []string{system.DefaultUserNamespace}
 	}
 
 	var clients []client.Client
@@ -180,110 +108,65 @@ func (p *projectClientFactory) DefaultProject() string {
 	return p.defaultProject
 }
 
-func lookupKubeconfig(opts Options) (string, bool) {
-	if opts.Kubeconfig != "" {
-		return opts.Kubeconfig, true
-	}
-	if opts.KubeconfigEnv != "" {
-		return opts.KubeconfigEnv, true
-	}
-	homeConfig := filepath.Join(xdg.Home, ".kube", "config")
-	if _, err := os.Stat(homeConfig); err == nil {
-		return homeConfig, true
-	}
-	return "", false
-}
-
-func clientFromFile(kubeconfig string, opts Options) (client.Client, error) {
-	clientConfig := restconfig.ClientConfigFromFile(kubeconfig, opts.ContextEnv)
-	cfg, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	def, _, err := clientConfig.Namespace()
-	if err != nil {
-		return nil, err
-	}
-	// assume if the result is "default" the user didn't set one
-	if def == "default" {
-		def = ""
-	}
-	ns, err := lookupNamespaceForLocal(opts, def)
+func clientFromFile(kubeconfig string, ns string, context string) (client.Client, error) {
+	cfg, err := restconfig.FromFile(kubeconfig, context)
 	if err != nil {
 		return nil, err
 	}
 	return client.New(cfg, ns, ns)
 }
 
-// noConfigClient will try to find acorn locally installed in a local k8s, if it fails in anyway,
-// ignore it and continue
-func noConfigClient(ctx context.Context, opts Options) (client.Client, error) {
-	result, found := lookupKubeconfig(opts)
-	if !found {
-		return nil, ErrNoKubernetesConfig
-	}
-	return clientFromFile(result, opts)
-}
-
-func ParseProject(project string, kubeconfigs map[string]string) (server, account, namespace string, err error) {
+func ParseProject(project string, kubeconfigs map[string]string) (serverOrKubeconfig, account, namespace string, isKubeconfig bool, err error) {
 	parts := strings.Split(project, "/")
 	if len(parts) == 0 || len(parts) > 3 {
-		return "", "", "", fmt.Errorf("invalid project name [%s]: must contain zero, one or two slashes [/]", project)
+		return "", "", "", false, fmt.Errorf("invalid project name [%s]: must contain zero, one or two slashes [/]", project)
 	}
 	switch len(parts) {
 	case 1:
 		if strings.Contains(parts[0], ".") {
-			return "", "", "", fmt.Errorf("invalid project name [%s]: can not contain \".\"", project)
+			return "", "", "", false, fmt.Errorf("invalid project name [%s]: can not contain \".\"", project)
 		}
 		if strings.Contains(parts[0], ":") {
-			return "", "", "", fmt.Errorf("invalid project name [%s]: can not contain \":\"", project)
+			return "", "", "", false, fmt.Errorf("invalid project name [%s]: can not contain \":\"", project)
 		}
-		return "", "", parts[0], nil
+		return "", "", parts[0], true, nil
 	case 2:
 		if strings.Contains(parts[0], ".") {
-			return "", "", "", fmt.Errorf("invalid project name [%s]: part before / can not contain \".\" unless there are three parts (ex: acorn.io/account/name)", project)
+			return "", "", "", false, fmt.Errorf("invalid project name [%s]: part before / can not contain \".\" unless there are three parts (ex: acorn.io/account/name)", project)
 		}
 		if strings.Contains(parts[0], ":") {
-			return "", "", "", fmt.Errorf("invalid project name [%s]: part before / can not contain \":\" unless there are three parts (ex: acorn.io/account/name)", project)
+			return "", "", "", false, fmt.Errorf("invalid project name [%s]: part before / can not contain \":\" unless there are three parts (ex: acorn.io/account/name)", project)
 		}
 		if kubeconfig := kubeconfigs[parts[0]]; kubeconfig != "" {
-			return "", parts[0], parts[1], nil
+			return kubeconfig, parts[0], parts[1], true, nil
 		}
-		return system.DefaultHubAddress, parts[0], parts[1], nil
+		return system.DefaultHubAddress, parts[0], parts[1], false, nil
 	case 3:
-		return parts[0], parts[1], parts[2], nil
+		return parts[0], parts[1], parts[2], false, nil
 	}
 	panic(fmt.Sprintf("unreachable: parts len of %d not handled in %s", len(parts), project))
 }
 
 func getClient(ctx context.Context, cfg *config.CLIConfig, opts Options, project string) (client.Client, error) {
-	server, account, namespace, err := ParseProject(project, cfg.Kubeconfigs)
+	serverOrKubeconfig, account, namespace, isKubeconfig, err := ParseProject(project, cfg.Kubeconfigs)
 	if err != nil {
 		return nil, err
 	}
 
-	if server == "" {
-		if account != "" {
-			if kubeconfig := cfg.Kubeconfigs[account]; kubeconfig == "" {
-				return nil, fmt.Errorf("failed to find kubeconfig for %s", account)
-			} else {
-				config, err := restconfig.FromFile(kubeconfig, opts.ContextEnv)
-				if err != nil {
-					return nil, err
-				}
-				return client.New(config, project, namespace)
+	if isKubeconfig {
+		if serverOrKubeconfig == "" {
+			c, err := restconfig.FromFile(opts.Kubeconfig, opts.ContextEnv)
+			if err != nil {
+				return nil, err
 			}
+			return client.New(c, project, namespace)
 		}
 
-		cfgFile, ok := lookupKubeconfig(opts)
-		if !ok {
-			return nil, ErrNoKubernetesConfig
-		}
-		c, err := restconfig.FromFile(cfgFile, opts.ContextEnv)
+		config, err := restconfig.FromFile(serverOrKubeconfig, opts.ContextEnv)
 		if err != nil {
 			return nil, err
 		}
-		return client.New(c, project, namespace)
+		return client.New(config, project, namespace)
 	}
 
 	credStore, err := credentials.NewStore(cfg, nil)
@@ -291,21 +174,21 @@ func getClient(ctx context.Context, cfg *config.CLIConfig, opts Options, project
 		return nil, err
 	}
 
-	cred, ok, err := credStore.Get(ctx, server)
+	cred, ok, err := credStore.Get(ctx, serverOrKubeconfig)
 	if err != nil {
 		return nil, err
 	} else if !ok {
 		return nil, fmt.Errorf("failed to find authentication token for server %s,"+
-			" please run 'acorn login %s' first", server, server)
+			" please run 'acorn login %s' first", serverOrKubeconfig, serverOrKubeconfig)
 	}
 
 	return &client.DeferredClient{
 		Project:   project,
 		Namespace: namespace,
 		New: func() (client.Client, error) {
-			url := cfg.TestProjectURLs[server+"/"+account]
+			url := cfg.TestProjectURLs[serverOrKubeconfig+"/"+account]
 			if url == "" {
-				url, err = hub.ProjectURL(ctx, server, account, cred.Password)
+				url, err = hub.ProjectURL(ctx, serverOrKubeconfig, account, cred.Password)
 				if err != nil {
 					return nil, err
 				}
@@ -320,7 +203,8 @@ func getClient(ctx context.Context, cfg *config.CLIConfig, opts Options, project
 
 func getDesiredProjects(ctx context.Context, cfg *config.CLIConfig, opts Options) (result []string, err error) {
 	if opts.AllProjects {
-		return List(ctx, opts.WithCLIConfig(cfg))
+		projects, _, err := List(ctx, opts.WithCLIConfig(cfg))
+		return projects, err
 	}
 	p := strings.TrimSpace(opts.Project)
 	if p == "" {

--- a/pkg/project/client_test.go
+++ b/pkg/project/client_test.go
@@ -74,7 +74,7 @@ func TestParseProject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotServer, gotAccount, gotNamespace, err := ParseProject(tt.args.project, nil)
+			gotServer, gotAccount, gotNamespace, _, err := ParseProject(tt.args.project, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseProject() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -113,7 +113,6 @@ var (
 	ProjectClient = [][]string{
 		{"Name", "Name"},
 		{"Default", "{{ boolToStar .Default }}"},
-		{"Description", "Description"},
 	}
 
 	RuleRequests = [][]string{


### PR DESCRIPTION
Previously using -j with a value containing "/" and calling
"acorn project" would cause an error.

Setting KUBECONFIG to a separated list would fail

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] All relevant issues are referenced in this PR
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits).
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

