### PR TITLE
Fix panic when using external auth provider

### DIFF
--- a/integration/projectconfig/projectconfig_test.go
+++ b/integration/projectconfig/projectconfig_test.go
@@ -43,6 +43,7 @@ func TestCLIConfig(t *testing.T) {
 		opt                project.Options
 		kubeconfigEnv      string
 		homeEnv            string
+		noEnv              bool
 		wantProject        string
 		wantNamespace      string
 		wantRestConfigHost string
@@ -130,9 +131,11 @@ func TestCLIConfig(t *testing.T) {
 			wantNamespace: "projectnamespace",
 		},
 		{
-			name:      "No config",
-			wantError: true,
-			homeEnv:   "garbage",
+			name:          "No config",
+			wantError:     true,
+			noEnv:         true,
+			kubeconfigEnv: "garbage",
+			homeEnv:       "garbage",
 		},
 		{
 			name: "No config, but user requested project",
@@ -200,8 +203,16 @@ func TestCLIConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			oldEnv := os.Environ()
 			oldHome := os.Getenv("HOME")
+			oldKubeconfig := os.Getenv("KUBECONFIG")
 			oldRecommendHomeFile := clientcmd.RecommendedHomeFile
+			if test.noEnv {
+				for _, env := range oldEnv {
+					k, _, _ := strings.Cut(env, "=")
+					os.Setenv(k, "")
+				}
+			}
 			if test.kubeconfigEnv != "" {
 				os.Setenv("KUBECONFIG", test.kubeconfigEnv)
 			}
@@ -211,7 +222,11 @@ func TestCLIConfig(t *testing.T) {
 			}
 			c, err := testCLIConfig(t, test.opt)
 			assert.Equal(t, test.wantError, err != nil, "should have error")
-			os.Setenv("KUBECONFIG", "")
+			for _, env := range oldEnv {
+				k, v, _ := strings.Cut(env, "=")
+				os.Setenv(k, v)
+			}
+			os.Setenv("KUBECONFIG", oldKubeconfig)
 			os.Setenv("HOME", oldHome)
 			clientcmd.RecommendedHomeFile = oldRecommendHomeFile
 			if test.wantErr != nil {

--- a/pkg/k8schannel/dialer.go
+++ b/pkg/k8schannel/dialer.go
@@ -65,7 +65,8 @@ func GetHeadersFor(cfg *rest.Config) (http.Header, error) {
 		return nil, err
 	}
 	_, err = rt.RoundTrip(&http.Request{
-		URL: &url.URL{},
+		Header: http.Header{},
+		URL:    &url.URL{},
 	})
 	return headerCapture.headers, err
 }


### PR DESCRIPTION
If your kubeconfig is using an external auth provider a panic
would happen. Cloud providers such as EKS use external auth providers.

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

