### PR TITLE
Add controlplane taints and node selector to acorn system components (#1231)

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -17,6 +17,7 @@ import (
 	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/run"
+	"github.com/acorn-io/acorn/pkg/tolerations"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -904,6 +905,12 @@ func TestUsingComputeClasses(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("250m"),
 					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      tolerations.WorkloadTolerationKey,
+						Operator: corev1.TolerationOpExists,
+					},
 				}},
 			},
 			waitFor: func(obj *apiv1.App) bool {
@@ -932,8 +939,13 @@ func TestUsingComputeClasses(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("250m"),
 					},
-				}},
-			},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      tolerations.WorkloadTolerationKey,
+						Operator: corev1.TolerationOpExists,
+					},
+				}}},
 			waitFor: func(obj *apiv1.App) bool {
 				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
 					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
@@ -963,6 +975,12 @@ func TestUsingComputeClasses(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("250m"),
+					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      tolerations.WorkloadTolerationKey,
+						Operator: corev1.TolerationOpExists,
 					},
 				}},
 			},
@@ -994,6 +1012,12 @@ func TestUsingComputeClasses(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
 						corev1.ResourceCPU:    resource.MustParse("125m"),
+					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      tolerations.WorkloadTolerationKey,
+						Operator: corev1.TolerationOpExists,
 					},
 				}},
 			},

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -3,6 +3,7 @@ package scheduling
 import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/condition"
+	tl "github.com/acorn-io/acorn/pkg/tolerations"
 
 	adminv1 "github.com/acorn-io/acorn/pkg/apis/internal.admin.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/config"
@@ -68,6 +69,13 @@ func addScheduling(req router.Request, appInstance *v1.AppInstance, workloads ma
 		if err != nil {
 			return err
 		}
+
+		// Add default toleration to taints.acorn.io/workload. This is so that when worker nodes are tainted
+		// with taints.acorn.io/workload, user app can still tolerate.
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      tl.WorkloadTolerationKey,
+			Operator: corev1.TolerationOpExists,
+		})
 
 		appInstance.Status.Scheduling[name] = v1.Scheduling{
 			Requirements: *requirements,

--- a/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml
@@ -21,6 +21,9 @@ status:
           memory: 2Mi
       computeClass: ""
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set/expected.yaml
@@ -15,6 +15,9 @@ status:
       oneimage: 1048576 # 1Mi
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/scheduling/testdata/computeclass/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/container/expected.yaml
@@ -19,6 +19,9 @@ status:
           cpu: 1m
           memory: 1Mi
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/scheduling/testdata/computeclass/different-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-computeclass/expected.yaml
@@ -13,6 +13,9 @@ status:
   observedGeneration: 1
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,6 +32,9 @@ status:
           cpu: 1m
           memory: 2Mi
     twoimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/scheduling/testdata/computeclass/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/job/expected.yaml
@@ -19,6 +19,9 @@ status:
           cpu: 1m
           memory: 1Mi
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml
@@ -19,6 +19,9 @@ status:
           cpu: 1m
           memory: 1Mi
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/scheduling/testdata/computeclass/sidecar/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/sidecar/expected.yaml
@@ -15,6 +15,11 @@ status:
   namespace: app-created-namespace
   appImage:
     id: test
+  scheduling:
+    oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-containers/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-containers/expected.yaml
@@ -12,6 +12,9 @@ status:
   observedGeneration: 1
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,6 +31,9 @@ status:
           cpu: 1m
           memory: 1Mi
     twoimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements: {}
   defaults:
     memory:

--- a/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/expected.yaml
@@ -17,6 +17,9 @@ status:
           cpu: 1m
           memory: 1Mi
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/controller/scheduling/testdata/memory/all-set-overwrite/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set-overwrite/expected.yaml
@@ -18,6 +18,9 @@ status:
       oneimage: 0
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements:
         limits:
           memory: 2Mi

--- a/pkg/controller/scheduling/testdata/memory/all-set/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set/expected.yaml
@@ -17,6 +17,9 @@ status:
       oneimage: 0
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements:
         limits:
           memory: 1Mi

--- a/pkg/controller/scheduling/testdata/memory/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/container/expected.yaml
@@ -17,6 +17,9 @@ status:
       oneimage: 0
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements:
         limits:
           memory: 1Mi

--- a/pkg/controller/scheduling/testdata/memory/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/job/expected.yaml
@@ -17,6 +17,9 @@ status:
       oneimage: 0
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements:
         limits:
           memory: 1Mi

--- a/pkg/controller/scheduling/testdata/memory/sidecar/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/sidecar/expected.yaml
@@ -18,6 +18,9 @@ status:
         requests:
           memory: 1Mi
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements: {}
   namespace: app-created-namespace
   appImage:

--- a/pkg/controller/scheduling/testdata/memory/two-containers/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/two-containers/expected.yaml
@@ -17,12 +17,18 @@ status:
       oneimage: 0
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements:
         limits:
           memory: 1Mi
         requests:
           memory: 1Mi
     twoimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements: {}
   namespace: app-created-namespace
   appImage:

--- a/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/expected.yaml
@@ -15,6 +15,9 @@ status:
       oneimage: 0
   scheduling:
     oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
       requirements:
         limits:
           memory: 1Mi

--- a/pkg/controller/scheduling/testdata/tolerations/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/container/expected.yaml
@@ -6,25 +6,13 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
-  memory:
-    oneimage: 1048576 # 1Mi
 status:
   observedGeneration: 1
-  defaults:
-    memory:
-      "": 0
-      left: 0
-      oneimage: 0
   scheduling:
     oneimage:
       tolerations:
-        - key: taints.acorn.io/workload
-          operator: "Exists"
-      requirements:
-        limits:
-          memory: 1Mi
-        requests:
-          memory: 1Mi
+      - key: taints.acorn.io/workload
+        operator: "Exists"
     left:
       requirements: {}
   namespace: app-created-namespace
@@ -48,9 +36,8 @@ status:
         build:
           dockerfile: "Dockerfile"
           context: "."
-        memory: 2097152 # 2Mi
   conditions:
     - type: scheduling
       reason: Success
       status: "True"
-      success: true    
+      success: true

--- a/pkg/controller/scheduling/testdata/tolerations/container/input.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/container/input.yaml
@@ -6,30 +6,12 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
-  memory:
-    oneimage: 1048576 # 1Mi
 status:
   observedGeneration: 1
-  defaults:
-    memory:
-      "": 0
-      left: 0
-      oneimage: 0
-  scheduling:
-    oneimage:
-      tolerations:
-        - key: taints.acorn.io/workload
-          operator: "Exists"
-      requirements:
-        limits:
-          memory: 1Mi
-        requests:
-          memory: 1Mi
-    left:
-      requirements: {}
   namespace: app-created-namespace
   appImage:
     id: test
+    defaults:
   appSpec:
     containers:
       oneimage:
@@ -48,9 +30,3 @@ status:
         build:
           dockerfile: "Dockerfile"
           context: "."
-        memory: 2097152 # 2Mi
-  conditions:
-    - type: scheduling
-      reason: Success
-      status: "True"
-      success: true    

--- a/pkg/controller/scheduling/testdata/tolerations/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/job/expected.yaml
@@ -6,32 +6,20 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
-  memory:
-    oneimage: 1048576 # 1Mi
 status:
   observedGeneration: 1
-  defaults:
-    memory:
-      "": 0
-      left: 0
-      oneimage: 0
   scheduling:
     oneimage:
       tolerations:
         - key: taints.acorn.io/workload
           operator: "Exists"
-      requirements:
-        limits:
-          memory: 1Mi
-        requests:
-          memory: 1Mi
     left:
       requirements: {}
   namespace: app-created-namespace
   appImage:
     id: test
   appSpec:
-    containers:
+    jobs:
       oneimage:
         sidecars:
           left:
@@ -48,9 +36,8 @@ status:
         build:
           dockerfile: "Dockerfile"
           context: "."
-        memory: 2097152 # 2Mi
   conditions:
     - type: scheduling
       reason: Success
       status: "True"
-      success: true    
+      success: true

--- a/pkg/controller/scheduling/testdata/tolerations/job/input.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/job/input.yaml
@@ -6,32 +6,14 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
-  memory:
-    oneimage: 1048576 # 1Mi
 status:
   observedGeneration: 1
-  defaults:
-    memory:
-      "": 0
-      left: 0
-      oneimage: 0
-  scheduling:
-    oneimage:
-      tolerations:
-        - key: taints.acorn.io/workload
-          operator: "Exists"
-      requirements:
-        limits:
-          memory: 1Mi
-        requests:
-          memory: 1Mi
-    left:
-      requirements: {}
   namespace: app-created-namespace
   appImage:
     id: test
+    defaults:
   appSpec:
-    containers:
+    jobs:
       oneimage:
         sidecars:
           left:
@@ -48,9 +30,3 @@ status:
         build:
           dockerfile: "Dockerfile"
           context: "."
-        memory: 2097152 # 2Mi
-  conditions:
-    - type: scheduling
-      reason: Success
-      status: "True"
-      success: true    

--- a/pkg/controller/scheduling/toleration_test.go
+++ b/pkg/controller/scheduling/toleration_test.go
@@ -1,0 +1,16 @@
+package scheduling
+
+import (
+	"testing"
+
+	"github.com/acorn-io/acorn/pkg/scheme"
+	"github.com/acorn-io/baaah/pkg/router/tester"
+)
+
+func TestContainerTolerations(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/tolerations/container", Calculate)
+}
+
+func TestJobTolerations(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/tolerations/job", Calculate)
+}

--- a/pkg/imagesystem/buildertemplate.go
+++ b/pkg/imagesystem/buildertemplate.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/acorn-io/acorn/pkg/system"
+	"github.com/acorn-io/acorn/pkg/tolerations"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -191,6 +192,12 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      tolerations.WorkloadTolerationKey,
+							Operator: corev1.TolerationOpExists,
 						},
 					},
 				},

--- a/pkg/imagesystem/registrytemplate.go
+++ b/pkg/imagesystem/registrytemplate.go
@@ -2,6 +2,7 @@ package imagesystem
 
 import (
 	"github.com/acorn-io/acorn/pkg/system"
+	"github.com/acorn-io/acorn/pkg/tolerations"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -117,6 +118,12 @@ func registryDeployment(namespace, registryImage string) []client.Object {
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 							Name: "registry",
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      tolerations.WorkloadTolerationKey,
+							Operator: corev1.TolerationOpExists,
 						},
 					},
 				},

--- a/pkg/install/apiserver.yaml
+++ b/pkg/install/apiserver.yaml
@@ -67,6 +67,9 @@ spec:
           securityContext:
             runAsUser: 1000
       serviceAccountName: acorn-system
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: "Exists"
 ---
 kind: PodDisruptionBudget
 apiVersion: policy/v1
@@ -78,3 +81,4 @@ spec:
   selector:
     matchLabels:
       app: acorn-api
+

--- a/pkg/install/check.go
+++ b/pkg/install/check.go
@@ -14,6 +14,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/scheme"
 	"github.com/acorn-io/acorn/pkg/streams"
 	"github.com/acorn-io/acorn/pkg/system"
+	"github.com/acorn-io/acorn/pkg/tolerations"
 	"github.com/acorn-io/baaah/pkg/randomtoken"
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	"github.com/acorn-io/baaah/pkg/watcher"
@@ -156,6 +157,12 @@ func CheckExec(ctx context.Context, opts CheckOptions) CheckResult {
 						"-f",
 						"/dev/null",
 					},
+				},
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      tolerations.WorkloadTolerationKey,
+					Operator: corev1.TolerationOpExists,
 				},
 			},
 		},

--- a/pkg/install/controller.yaml
+++ b/pkg/install/controller.yaml
@@ -28,6 +28,9 @@ spec:
           securityContext:
             runAsUser: 1000
       serviceAccountName: acorn-system
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: "Exists"
 ---
 kind: PodDisruptionBudget
 apiVersion: policy/v1

--- a/pkg/tolerations/tolerations.go
+++ b/pkg/tolerations/tolerations.go
@@ -1,0 +1,3 @@
+package tolerations
+
+const WorkloadTolerationKey = "taints.acorn.io/workload"


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

# Context

We need to figure Acorn system components to tolerate controlplane taints and only run it under cp nodes. 

The changes are 

1. Acorn-controll and acorn api and acorn-exec-check will be tolerating `node-role.kubernetes.io/control-plane`
2. Buildkitd, registry and user containers and jobs will be tolerating `taints.acorn.io/workload`

#1231 
