### PR TITLE
Fix errors displayed by kubectl (#1233)

### DIFF
--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -14,7 +14,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -28,6 +30,7 @@ var (
 
 func AddToScheme(scheme *runtime.Scheme) error {
 	var errs []error
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
 	errs = append(errs, acornv1.AddToScheme(scheme))
 	errs = append(errs, acornapiv1.AddToScheme(scheme))
 	errs = append(errs, corev1.AddToScheme(scheme))


### PR DESCRIPTION
This fixes an obscure issue where errors are not displayed properly when using kubectl and the api.acorn.io types.

Issue: https://github.com/acorn-io/acorn/issues/1232

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

