### PR TITLE
Allow volumes with sizes less than 10G in Acornfile (#1232)

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -43,6 +43,12 @@ func TestVolume(t *testing.T) {
 			obj.Labels[labels.AcornManaged] == "true"
 	})
 
+	app, err = c.AppGet(ctx, app.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, "1G", app.Status.AppSpec.Volumes["my-data"].Size, "volume my-data has size different than expected")
+
 	_, err = c.AppDelete(ctx, app.Name)
 	if err != nil {
 		t.Fatal(err)

--- a/integration/run/testdata/volume/Acornfile
+++ b/integration/run/testdata/volume/Acornfile
@@ -3,5 +3,12 @@ containers: {
 		build: "."
 		dirs: "/test": "./files"
 		dirs: "/external": "external"
+		dirs: "/tmp": "volume://my-data"
+	}
+}
+
+volumes: {
+	"my-data": {
+		size: "1G"
 	}
 }

--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -257,13 +257,15 @@ func impliedVolumesForContainer(app *AppSpec, containerName, sideCarName string,
 					// ignore error
 					continue
 				}
-				vSize, err := resource.ParseQuantity((string)(v.Size))
-				if err != nil {
-					// ignore error
-					continue
-				}
-				if existingSize.Cmp(vSize) < 0 {
-					existing.Size = v.Size
+				if v.Size != "" {
+					vSize, err := resource.ParseQuantity((string)(v.Size))
+					if err != nil {
+						// ignore error
+						continue
+					}
+					if existingSize.Cmp(vSize) < 0 {
+						existing.Size = v.Size
+					}
 				}
 				for _, accessMode := range v.AccessModes {
 					found := false
@@ -282,6 +284,9 @@ func impliedVolumesForContainer(app *AppSpec, containerName, sideCarName string,
 				})
 				app.Volumes[mount.Volume] = existing
 			} else {
+				if v.Size == "" {
+					v.Size = DefaultSizeQuantity
+				}
 				app.Volumes[mount.Volume] = VolumeRequest{
 					Size:        v.Size,
 					AccessModes: v.AccessModes,
@@ -1098,8 +1103,6 @@ func parseVolumeDefinition(anonName, s string) (VolumeBinding, error) {
 		if result.Volume == "" {
 			result.Volume = anonName
 		}
-	} else if result.Size == "" {
-		result.Size = DefaultSizeQuantity
 	}
 
 	for _, accessMode := range u.Query()["accessMode"] {


### PR DESCRIPTION
If a volume is defined in an Acornfile with a size less than 10G, then the size would be overwritten by the parser to be 10G. This was because it mistakenly thought there was a volume binding with size 10G. After this change, volumes defined in an Acornfile with size less than 10G will not be accidentally overwritten.

Issue: https://github.com/acorn-io/acorn/issues/1232

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

