### PR TITLE
Missing make setup-ci-env for CD workflows breaking release (#1238)

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19"
-      - run: make setup-ci-env
       - run: make validate-ci
       - run: make validate
       - run: make build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,6 @@ jobs:
       - uses: debianmaster/actions-k3s@v1.0.5
         with:
           version: 'v1.23.6-k3s1'
-      - run: make setup-ci-env
       - run: make validate-ci
       - run: make validate
       - run: make build

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ setup-ci-image:
 validate:
 	golangci-lint run
 
-validate-ci:
+validate-ci: setup-ci-env
 	go generate
 	go mod tidy
 	go run tools/gendocs/main.go
@@ -35,7 +35,10 @@ goreleaser:
 	goreleaser build --snapshot --single-target --rm-dist
 
 setup-ci-env:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.49.0
+	if ! command -v golangci-lint &> /dev/null; then \
+  		echo "Could not find golangci-lint, installing."; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.51.1; \
+	fi
 	go install github.com/golang/mock/mockgen
 
 


### PR DESCRIPTION
make validate-ci depends on make setup-ci-env. Make setup-ci-env now only installs golangci-lint if it is not already installed, to avoid reinstalling it or installing it twice if it was installed some other way such as brew.

One potential issue is that it doesn't keep golangci-lint up to date on a dev's system, but that isn't a huge deal.


### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Fixes: #1238