### PR TITLE
Include storage class details in cli acorn volumes (#1229)

### DIFF
--- a/pkg/cli/testdata/all/all_test.txt
+++ b/pkg/cli/testdata/all/all_test.txt
@@ -8,8 +8,8 @@ NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAG
 found.container                                 0              292y ago   
 
 VOLUMES:
-NAME           APP-NAME   BOUND-VOLUME   CAPACITY   STATUS    ACCESS-MODES   CREATED
-found.volume   found      found.volume   <nil>                               292y ago
+NAME           APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
+found.volume   found      found.volume   <nil>                                              292y ago
 
 SECRETS:
 ALIAS         NAME           TYPE      KEYS      CREATED

--- a/pkg/cli/testdata/all/all_test_i.txt
+++ b/pkg/cli/testdata/all/all_test_i.txt
@@ -8,8 +8,8 @@ NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAG
 found.container                                 0              292y ago   
 
 VOLUMES:
-NAME           APP-NAME   BOUND-VOLUME   CAPACITY   STATUS    ACCESS-MODES   CREATED
-found.volume   found      found.volume   <nil>                               292y ago
+NAME           APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
+found.volume   found      found.volume   <nil>                                              292y ago
 
 SECRETS:
 ALIAS         NAME           TYPE      KEYS      CREATED

--- a/pkg/cli/volumes_test.go
+++ b/pkg/cli/volumes_test.go
@@ -48,7 +48,7 @@ func TestVolume(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "NAME           APP-NAME   BOUND-VOLUME   CAPACITY   STATUS    ACCESS-MODES   CREATED\nfound.volume   found      found.volume   <nil>                               292y ago\n",
+			wantOut: "NAME           APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED\nfound.volume   found      found.volume   <nil>                                              292y ago\n",
 		},
 		{
 			name: "acorn volume -o json", fields: fields{
@@ -105,7 +105,7 @@ func TestVolume(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "NAME           APP-NAME   BOUND-VOLUME   CAPACITY   STATUS    ACCESS-MODES   CREATED\nfound.volume   found      found.volume   <nil>                               292y ago\n",
+			wantOut: "NAME           APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED\nfound.volume   found      found.volume   <nil>                                              292y ago\n",
 		},
 		{
 			name: "acorn volume dne", fields: fields{

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -23,6 +23,7 @@ var (
 		{"App-Name", "Status.AppName"},
 		{"Bound-Volume", "Status.VolumeName"},
 		{"Capacity", "Spec.Capacity"},
+		{"Volume-Class", "Spec.Class"},
 		{"Status", "Status.Status"},
 		{"Access-Modes", "Status.Columns.AccessModes"},
 		{"Created", "{{ago .CreationTimestamp}}"},


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Closes #1229