### PR TITLE
fix info's integration tests breaking on eks (#1244)

### DIFF
--- a/integration/helper/assertions.go
+++ b/integration/helper/assertions.go
@@ -1,0 +1,28 @@
+package helper
+
+import (
+	"testing"
+)
+
+// Subset returns true if the first array is completely
+// contained in the second array. There must be at least
+// the same number of duplicate values in second as there
+// are in first.
+func Subset[V, W any, Z comparable](t *testing.T, first []V, second []W, firstLookup func(V) Z, secondLookup func(W) Z) bool {
+	t.Helper()
+
+	set := make(map[Z]int)
+	for _, value := range second {
+		set[secondLookup(value)] += 1
+	}
+
+	for _, value := range first {
+		parsedValue := firstLookup(value)
+		if set[parsedValue] < 1 {
+			return false
+		}
+		set[parsedValue]--
+	}
+
+	return true
+}

--- a/integration/helper/namespace.go
+++ b/integration/helper/namespace.go
@@ -24,7 +24,24 @@ func TempNamespace(t *testing.T, client client.Client) *corev1.Namespace {
 		Spec:   corev1.NamespaceSpec{},
 		Status: corev1.NamespaceStatus{},
 	}
-	return namedTempCreate(t, client, ns)
+	return tempCreateHelper(t, client, ns)
+}
+
+func TempProject(t *testing.T, client client.Client) *corev1.Namespace {
+	t.Helper()
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// namespace ends up as "acorn-test-{random chars}"
+			GenerateName: "acorn-project-",
+			Labels: map[string]string{
+				"test.acorn.io/namespace": "true",
+				labels.AcornProject:       "true",
+			},
+		},
+		Spec:   corev1.NamespaceSpec{},
+		Status: corev1.NamespaceStatus{},
+	}
+	return tempCreateHelper(t, client, ns)
 }
 
 func NamedTempProject(t *testing.T, client client.Client, name string) *corev1.Namespace {
@@ -40,17 +57,19 @@ func NamedTempProject(t *testing.T, client client.Client, name string) *corev1.N
 		Spec:   corev1.NamespaceSpec{},
 		Status: corev1.NamespaceStatus{},
 	}
-	return namedTempCreate(t, client, ns)
+	return tempCreateHelper(t, client, ns)
 }
 
-func namedTempCreate(t *testing.T, client client.Client, namespaceObject corev1.Namespace) *corev1.Namespace {
+func tempCreateHelper(t *testing.T, client client.Client, namespaceObject corev1.Namespace) *corev1.Namespace {
 	t.Helper()
-	namespaceName := namespaceObject.GetNamespace()
+	namespaceName := namespaceObject.GetName()
 	ctx := GetCTX(t)
 	err := client.Create(ctx, &namespaceObject)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
 			// Namespace already exists.
+			// Will want to get the existing namespace object to return it
+			// and set a cleaning function to remove it after testing.
 			t.Logf("Namespace %s already exists, skipping creation.\n", namespaceName)
 
 			// construct blank object pointer
@@ -73,8 +92,9 @@ func namedTempCreate(t *testing.T, client client.Client, namespaceObject corev1.
 		t.Fatal(err)
 		return nil
 	}
+
 	t.Cleanup(func() {
-		namespaceDeleting := namespaceName
+		namespaceDeleting := namespaceObject.Name
 		err = client.Delete(ctx, &namespaceObject)
 		if err != nil {
 			t.Logf("Could not delete namespace %s.\n", namespaceDeleting)


### PR DESCRIPTION
Refactoring integration tests to use generateName when creating namespaces, as well as verifying namespace names, instead of the length of info's response. This allows it to be more flexible on what cluster it is running on, and allowing other namespaces to preexist.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Closes #1244 
