### PR TITLE
fix docs site typo having an extra quotation (#1250)

### DIFF
--- a/docs/docs/38-authoring/03-containers.md
+++ b/docs/docs/38-authoring/03-containers.md
@@ -299,7 +299,7 @@ containers: {
                 }
             },
             {
-                "type: "startup"
+                type: "startup"
                 failureThreshold: 10
                 periodSeconds: 6
                 tcp:{


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
Closes #1250 
