### PR TITLE
Support comma separated projects in -j

### DIFF
--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -130,7 +130,7 @@ func (a *Acorn) PersistentPre(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		_, err = project.Get(cmd.Context(), clientFactory.Options().WithCLIConfig(cfg), a.Project)
+		err = project.Exists(cmd.Context(), clientFactory.Options().WithCLIConfig(cfg), a.Project)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -48,7 +48,7 @@ func (a *Project) Run(cmd *cobra.Command, args []string) error {
 
 	var projectNames []string
 	if len(args) == 1 {
-		_, err := project.Get(cmd.Context(), a.client.Options().WithCLIConfig(cfg), args[0])
+		err := project.Exists(cmd.Context(), a.client.Options().WithCLIConfig(cfg), args[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/project_use.go
+++ b/pkg/cli/project_use.go
@@ -38,7 +38,7 @@ func (a *ProjectUse) Run(cmd *cobra.Command, args []string) error {
 		return cfg.Save()
 	}
 
-	_, err = project.Get(cmd.Context(), a.client.Options().WithCLIConfig(cfg), args[0])
+	err = project.Exists(cmd.Context(), a.client.Options().WithCLIConfig(cfg), args[0])
 	if err != nil {
 		return fmt.Errorf("failed to find project %s, use \"acorn projects\" to list valid project names: %w", args[0], err)
 	}


### PR DESCRIPTION
If project names are like foo,bar,acorn.io/user/foo then we should be
ensuring that all three projects exists.  Previously we were erroneously
looking for just the last project in the list using the client from the
first project in the list

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

