### PR TITLE
Aggregate all validation needed into "make validate"

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -25,8 +25,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19"
-      - run: make validate-ci
-      - run: make validate
+      - run: make validate-code
       - run: make build
       - run: sudo install -o root -g root -m 0755 ./bin/acorn /usr/local/bin/acorn
 

--- a/.github/workflows/main-mac-smoke-test.yaml
+++ b/.github/workflows/main-mac-smoke-test.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "${COSIGN_KEY}" > "$GITHUB_WORKSPACE/cosign.key"
         env:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
-      - run: make validate-ci
+      - run: make validate-code
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -45,7 +45,7 @@ jobs:
           echo "${COSIGN_KEY}" > "$GITHUB_WORKSPACE/cosign.key"
         env:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
-      - run: make validate-ci
+      - run: make validate-code
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "${COSIGN_KEY}" > "$GITHUB_WORKSPACE/cosign.key"
         env:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
-      - run: make validate-ci
+      - run: make validate-code
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,8 +24,7 @@ jobs:
       - uses: debianmaster/actions-k3s@v1.0.5
         with:
           version: 'v1.23.6-k3s1'
-      - run: make validate-ci
-      - run: make validate
+      - run: make validate-code
       - run: make build
       - run: docker buildx install
       - run: make setup-ci-image


### PR DESCRIPTION
There are now two levels of validation:
- "make validate-code" - Called by test action
- "make validate-docs" - Called by docs action

These are both aggregated by "make validate" to make
preparing a commit for push easier. It will perform
all the necassary checks.

Additionally:
- Delete "make validate-ci"
- Update generate.go to use go run for mockgen
- Delete "make mocks" in favor of running "make generate"

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in paranthesis.
- [X] All relevant issues are referenced in the PR description.
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

