### PR TITLE
Fix typos in Compute Class documentation

### DIFF
--- a/docs/docs/100-reference/02-admin/03-computeclasses.md
+++ b/docs/docs/100-reference/02-admin/03-computeclasses.md
@@ -1,7 +1,7 @@
 ---
 title: Compute Classes
 ---
-Workload classes are a way of defining scheduling for the applications running on Acorn. They allow you to define Affinities, Tolerations, and Resource Requirements for the Pods that applications will run on.
+Compute classes are a way of defining scheduling for the applications running on Acorn. They allow you to define Affinities, Tolerations, and Resource Requirements for the Pods that applications will run on.
 
 ## Project Compute Classes
 A Project Compute Class is associated to a single project. Any apps in that project will have access to the compute class and its configurations. Project Compute Classes in different projects won't interfere with each other, so you can have a Project Compute Class in different projects with the same name and different parameters.

--- a/docs/docs/100-reference/03-acornfile.md
+++ b/docs/docs/100-reference/03-acornfile.md
@@ -466,7 +466,7 @@ containers: {
 ```
 
 ### class
-`class` allows you to specify what compute class the container should run on. If left unspecified, it will be defaulted to the project-level default. If there is no project-level default it will use the cluster-level default. If there is no cluster-level default the no compute class will be used. See the [reference documentation](06-compute-resources.md#compute-classes) for more information.
+`class` allows you to specify what compute class the container should run on. If left unspecified, it will be defaulted to the project-level default. If there is no project-level default it will use the cluster-level default. If there is no cluster-level default then no compute class will be used. See the [reference documentation](06-compute-resources.md#compute-classes) for more information.
 
 ```acorn
 containers: {

--- a/docs/docs/100-reference/06-compute-resources.md
+++ b/docs/docs/100-reference/06-compute-resources.md
@@ -48,18 +48,18 @@ This same interaction will occur if the `--workload-memory-default` is set to 0 
 ## Compute Classes
 You can configure Acorn apps to have a set compute class upon startup.
 
-Setting a compute class allows you to define what the infrastructure providing your Acorn workloads should look like. Things that workload classes control include:
+Setting a compute class allows you to define what the infrastructure providing your Acorn workloads should look like. Things that compute classes control include:
 
 - What OS/Architecure your workloads will run on
 - How much memory is minimal, maximal, default and allowed
 - How many vCPUs should be allocated
 
 :::info
-You are not able to set vCPUs directly. This is an intentional abstraction and instead vCPUs are calculated based on of the amount of memory for a workload.
+You are not able to set vCPUs directly. This is an intentional abstraction and instead vCPUs are calculated based on of the amount of memory specified for a workload.
 :::
 
 ### Using a Compute Class
-You can see the workload classes available in your current project using the CLI. 
+You can see the compute classes available in your current project using the CLI. 
 
 ```console
 $ acorn offerings computeclasses
@@ -70,10 +70,16 @@ unrestricted            Unrestricted      512Mi            Unrestricted ComputeC
 specific                128Mi,512Mi,1Gi   128Mi            Specific ComputeClass
 ```
 
-Breaking this down, `MEMORY_DEFAULT` tells us what memory we will get if we don't specify any. `MEMORY_RANGE` tells us what memory values are available to use. If it is a range, specified with a `-` then you can use any value in that range. If it has specific values, denoted by a comma seperated list, then you can only use those values. Specifying workload classes can be done in the Acornfile (using the `class` property for containers) or at runtime (using the `--compute-class` flag). 
+Breaking this down:
 
-If you do not specify a compute class, the default compute class for the project will be used. If there is no default for the project, the default for the cluster will be used. Finally, if there is no cluster default then no compute class will be used. Depending on the compute class that is used, the memory that you specify may be in contention with its requirements. Should that happen Acorn will provide a descriptive error message to ammend any issues.
+- `DEFAULT` says if a ComputeClass is the default and will be used if no ComputeClass is defined.
+- `MEMORY_DEFAULT` tells us what memory we will get if we don't specify any. 
+- `MEMORY_RANGE` tells us what memory values are available to use and can take two forms.
+    1. `-` denotes a range and any value within it can be used
+    2. `,` denotes specific values that are the only ones allowed.
+
+Specifying compute classes can be done in the Acornfile (using the `class` property for containers) or at runtime (using the `--compute-class` flag). If you do not specify a compute class, the default compute class for the project will be used. If there is no default for the project, the default for the cluster will be used. Finally, if there is no cluster default then no compute class will be used. Depending on the compute class that is used, the memory that you specify may be in contention with its requirements. Should that happen Acorn will provide a descriptive error message to ammend any issues.
 
 :::note
-Looking to manage a compute class? This should only be done if you are (or are in communication with) an administrator of Acorn. You can read more information about managing workload classes [here](02-admin/03-computeclasses.md)
+Looking to manage a compute class? This should only be done if you are (or are in communication with) an administrator of Acorn. You can read more information about managing compute classes [here](02-admin/03-computeclasses.md)
 :::

--- a/docs/docs/38-authoring/03-containers.md
+++ b/docs/docs/38-authoring/03-containers.md
@@ -363,7 +363,7 @@ The `memory` property can be abbreviated to `mem` in the file.
 
 ## Compute Classes
 
-When you want to specify what type of architecture your Acorn's workload will run on, you use Compute Classes. You can set the class of a workload by defining by the `class` property that is settable for all `workloads` (`containers` and `jobs`). Check out the [compute class documemtation](100-reference/06-compute-resources.md#compute-classes) for more information.
+When you want to specify what infrastructure your Acorn's workload will run on, you use Compute Classes. You can set the class of a workload by defining by the `class` property defineable on all workloads (`containers` and `jobs`). Check out the [compute class documemtation](100-reference/06-compute-resources.md#compute-classes) for more information.
 
 ```acorn
 containers: {
@@ -377,11 +377,6 @@ containers: {
     }
 }
 ```
-
-:::tip
-The `memory` property can be abbreviated to `mem` in the file.
-:::
-
 
 ## Additional Reading
 

--- a/docs/docs/50-running/55-compute-resources.md
+++ b/docs/docs/50-running/55-compute-resources.md
@@ -36,10 +36,12 @@ This sets all workloads in the `foo` acorn to have `256Mi` of memory except for 
 To set a compute class at run time, you can utilize the `--compute-class` flag.
 
 :::note
-Check out the [compute class reference documentation](100-reference/06-compute-resources.md#compute-classes) for more information about how workload classes work.
+Check out the [compute class reference documentation](100-reference/06-compute-resources.md#compute-classes) for more information about how compute classes work.
 :::
 
-When setting this value, you have two options - globally or per workload and you can do a combination of both. When setting the memory globally for that Acorn, you just define the compute class you would like to set.
+### --compute-class
+
+When setting this compute classes, you have two options - globally or per workload and you can do a combination of both. When setting the memory globally for that Acorn, you just define the compute class you would like to set.
 
 ```console
 acorn run --compute-class sample foo
@@ -52,7 +54,7 @@ This flag comes with auto completions! Hit tab to see workload classes that can 
 This will set all workloads in the `foo` acorn to use the `sample` compute class. Adjacently, you can set the memory of each individual workload in the Acorn using a `workload=class` pattern. 
 
 ```console
-acorn run -m nginx=sample foo
+acorn run --compute-class nginx=sample foo
 ```
 
 This will only update Acorn's `nginx` workload to use the `sample` compute class.
@@ -60,7 +62,7 @@ This will only update Acorn's `nginx` workload to use the `sample` compute class
 Finally, you can do a combination of both.
 
 ```console
-acorn run -m sample,nginx=different foo
+acorn run --compute-class sample,nginx=different foo
 ```
 
 This sets all workloads in the `foo` acorn to use the `sample` compute class except for the `nginx` workload which will have the `different` compute class.


### PR DESCRIPTION
### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

