### PR TITLE
Correctly wait for app updates (#1265)

### DIFF
--- a/pkg/controller/appdefinition/cli_status.go
+++ b/pkg/controller/appdefinition/cli_status.go
@@ -36,18 +36,17 @@ func message(app *v1.AppInstance) string {
 		}
 	}
 
-	if buf.Len() == 0 {
-		if app.Status.ConfirmUpgradeAppImage != "" {
-			return "Upgrade available: " + app.Status.ConfirmUpgradeAppImage
-		}
-
-		if app.Status.Ready {
-			return "OK"
-		} else {
-			return "pending"
-		}
+	if buf.Len() != 0 {
+		return buf.String()
 	}
-	return buf.String()
+	if app.Status.ConfirmUpgradeAppImage != "" {
+		return "Upgrade available: " + app.Status.ConfirmUpgradeAppImage
+	}
+
+	if app.Status.Ready {
+		return "OK"
+	}
+	return "pending"
 }
 
 func uptodate(app *v1.AppInstance) string {

--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -120,6 +120,10 @@ func toPVCs(req router.Request, appInstance *v1.AppInstance) (result []kclient.O
 			},
 		}
 
+		if appInstance.Generation > 0 {
+			pvc.Annotations[labels.AcornAppGeneration] = strconv.FormatInt(appInstance.Generation, 10)
+		}
+
 		if bind {
 			pvc.Name = bindName(vol)
 			pvc.Spec.VolumeName = volumeBinding.Volume

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -48,7 +48,7 @@ func waitForApp(ctx context.Context, c client.Client, app *apiv1.App) (*apiv1.Ap
 	}
 	w := objwatcher.New[*apiv1.App](wc)
 	return w.ByObject(ctx, app, func(app *apiv1.App) (bool, error) {
-		if app.Status.Ready {
+		if app.Status.Ready && app.Generation == app.Status.ObservedGeneration {
 			return true, nil
 		}
 		for name, job := range app.Status.JobsStatus {


### PR DESCRIPTION
When doing an app update, the wait functionality didn't properly wait for the update. It would see that the app was "ready" and stop. This was incorrect because the app that was "ready" was the previous version. Now, the wait functionality will ensure that it is waiting for the correct version of the app before proceeding.

Additionally, there seems to be a flaky test. I am attempting to fix that here, too.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Issue: https://github.com/acorn-io/acorn/issues/1265