### PR TITLE
Strict validation on volume class updates, including making the storage class name immutable (#1262)

### DIFF
--- a/integration/client/volumes/volumeclasses_test.go
+++ b/integration/client/volumes/volumeclasses_test.go
@@ -451,3 +451,200 @@ func TestCreateProjectDefaultWithExistingClusterDefault(t *testing.T) {
 
 	t.Fatal("project default not found")
 }
+
+func TestProjectVolumeClassUpdateValidation(t *testing.T) {
+	helper.StartController(t)
+
+	ctx := helper.GetCTX(t)
+	kclient := helper.MustReturn(kclient.Default)
+	ns := helper.TempNamespace(t, kclient)
+
+	volumeClass := adminv1.ProjectVolumeClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "acorn-test-default",
+			Namespace: ns.Name,
+		},
+		Default: true,
+	}
+	if err := kclient.Create(ctx, &volumeClass); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.Background(), &volumeClass); err != nil && !apierrors.IsNotFound(err) {
+			t.Fatal(err)
+		}
+	}()
+
+	tests := []struct {
+		name        string
+		volumeClass adminv1.ProjectVolumeClass
+		wantError   bool
+	}{
+		{
+			name: "Can change default",
+			volumeClass: adminv1.ProjectVolumeClass{
+				Default: false,
+			},
+		},
+		{
+			name: "Can update size constraints",
+			volumeClass: adminv1.ProjectVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "5G",
+					Min:     "2G",
+					Max:     "20G",
+				},
+			},
+		},
+		{
+			name:      "Can't update default size too small",
+			wantError: true,
+			volumeClass: adminv1.ProjectVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "5G",
+					Min:     "10G",
+					Max:     "20G",
+				},
+			},
+		},
+		{
+			name:      "Can't update default size too large",
+			wantError: true,
+			volumeClass: adminv1.ProjectVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "50G",
+					Min:     "10G",
+					Max:     "20G",
+				},
+			},
+		},
+		{
+			name:      "Can't update min/max size flipped",
+			wantError: true,
+			volumeClass: adminv1.ProjectVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "5G",
+					Min:     "20G",
+					Max:     "10G",
+				},
+			},
+		},
+		{
+			name:      "Can't update storage class name",
+			wantError: true,
+			volumeClass: adminv1.ProjectVolumeClass{
+				StorageClassName: "new-storage-class",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := kclient.Get(ctx, client.ObjectKey{Namespace: volumeClass.Namespace, Name: volumeClass.Name}, &volumeClass); err != nil {
+				t.Fatal(err)
+			}
+			tt.volumeClass.ObjectMeta = volumeClass.ObjectMeta
+			if err := kclient.Update(ctx, &tt.volumeClass); !tt.wantError && err != nil {
+				t.Fatal(err)
+			} else if tt.wantError && err == nil {
+				t.Fatal("expected error for test case")
+			}
+		})
+	}
+}
+
+func TestClusterVolumeClassUpdateValidation(t *testing.T) {
+	helper.StartController(t)
+
+	ctx := helper.GetCTX(t)
+	kclient := helper.MustReturn(kclient.Default)
+	ns := helper.TempNamespace(t, kclient)
+
+	className := "acorn-test-default"
+	volumeClass := adminv1.ClusterVolumeClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      className,
+			Namespace: ns.Name,
+		},
+	}
+	if err := kclient.Create(ctx, &volumeClass); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := kclient.Delete(context.Background(), &volumeClass); err != nil && !apierrors.IsNotFound(err) {
+			t.Fatal(err)
+		}
+	}()
+
+	tests := []struct {
+		name        string
+		volumeClass adminv1.ClusterVolumeClass
+		wantError   bool
+	}{
+		// Not testing changing default here because it is tested elsewhere
+		{
+			name: "Can update size constraints",
+			volumeClass: adminv1.ClusterVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "5G",
+					Min:     "2G",
+					Max:     "20G",
+				},
+			},
+		},
+		{
+			name:      "Can't update default size too small",
+			wantError: true,
+			volumeClass: adminv1.ClusterVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "5G",
+					Min:     "10G",
+					Max:     "20G",
+				},
+			},
+		},
+		{
+			name:      "Can't update default size too large",
+			wantError: true,
+			volumeClass: adminv1.ClusterVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "50G",
+					Min:     "10G",
+					Max:     "20G",
+				},
+			},
+		},
+		{
+			name:      "Can't update min/max size flipped",
+			wantError: true,
+			volumeClass: adminv1.ClusterVolumeClass{
+				Size: v1.VolumeClassSize{
+					Default: "5G",
+					Min:     "20G",
+					Max:     "10G",
+				},
+			},
+		},
+		{
+			name:      "Can't update storage class name",
+			wantError: true,
+			volumeClass: adminv1.ClusterVolumeClass{
+				StorageClassName: "new-storage-class",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := kclient.Get(ctx, client.ObjectKey{Namespace: volumeClass.Namespace, Name: volumeClass.Name}, &volumeClass); err != nil {
+				t.Fatal(err)
+			}
+			tt.volumeClass.ObjectMeta = volumeClass.ObjectMeta
+			if err := kclient.Update(ctx, &tt.volumeClass); !tt.wantError && err != nil {
+				t.Fatal(err)
+			} else if tt.wantError && err == nil {
+				t.Fatal("expected error for test case")
+			}
+		})
+	}
+}

--- a/pkg/server/registry/apigroups/admin/volumeclass/validator.go
+++ b/pkg/server/registry/apigroups/admin/volumeclass/validator.go
@@ -52,11 +52,12 @@ func (s *ProjectValidator) Validate(ctx context.Context, obj runtime.Object) (re
 }
 
 func (s *ProjectValidator) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
-	if newObj.(*adminv1.ProjectVolumeClass).Default != oldObj.(*adminv1.ProjectVolumeClass).Default {
-		return s.Validate(ctx, newObj)
+	newStorageClassName := newObj.(*adminv1.ProjectVolumeClass).StorageClassName
+	if newStorageClassName != oldObj.(*adminv1.ProjectVolumeClass).StorageClassName {
+		return []*field.Error{field.Invalid(field.NewPath("storageClassName"), newStorageClassName, "storageClassName cannot be changed")}
 	}
 
-	return nil
+	return s.Validate(ctx, newObj)
 }
 
 type ClusterValidator struct {
@@ -92,7 +93,11 @@ func (s *ClusterValidator) Validate(ctx context.Context, obj runtime.Object) (re
 	return
 }
 
-func (s *ClusterValidator) ValidateUpdate(ctx context.Context, newObj, _ runtime.Object) field.ErrorList {
+func (s *ClusterValidator) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+	newStorageClassName := newObj.(*adminv1.ClusterVolumeClass).StorageClassName
+	if newStorageClassName != oldObj.(*adminv1.ClusterVolumeClass).StorageClassName {
+		return []*field.Error{field.Invalid(field.NewPath("storageClassName"), newStorageClassName, "storageClassName cannot be changed")}
+	}
 	return s.Validate(ctx, newObj)
 }
 


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Issue: https://github.com/acorn-io/acorn/issues/1262