### PR TITLE
Ensure acorn volumes command outputs volume class (#1261)

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -156,7 +156,8 @@ func TestVolumeBadClassInImageBoundToGoodClass(t *testing.T) {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
 			obj.Labels[labels.AcornManaged] == "true" &&
-			obj.Labels[labels.AcornVolumeName] == "my-data"
+			obj.Labels[labels.AcornVolumeName] == "my-data" &&
+			obj.Labels[labels.AcornVolumeClass] == volumeClass.Name
 	})
 
 	helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
@@ -372,7 +373,8 @@ func TestVolumeClassRemoved(t *testing.T) {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
 			obj.Labels[labels.AcornManaged] == "true" &&
-			obj.Labels[labels.AcornVolumeName] == "my-data"
+			obj.Labels[labels.AcornVolumeName] == "my-data" &&
+			obj.Labels[labels.AcornVolumeClass] == volumeClass.Name
 	})
 
 	helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
@@ -442,7 +444,8 @@ func TestClusterVolumeClass(t *testing.T) {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
 			obj.Labels[labels.AcornManaged] == "true" &&
-			obj.Labels[labels.AcornVolumeName] == "my-data"
+			obj.Labels[labels.AcornVolumeName] == "my-data" &&
+			obj.Labels[labels.AcornVolumeClass] == volumeClass.Name
 	})
 
 	assert.Equal(t, []corev1.PersistentVolumeAccessMode{"ReadWriteOnce"}, pv.Spec.AccessModes)
@@ -503,7 +506,8 @@ func TestClusterVolumeClassValuesInAcornfile(t *testing.T) {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
 			obj.Labels[labels.AcornManaged] == "true" &&
-			obj.Labels[labels.AcornVolumeName] == "my-data"
+			obj.Labels[labels.AcornVolumeName] == "my-data" &&
+			obj.Labels[labels.AcornVolumeClass] == volumeClass.Name
 	})
 
 	assert.Equal(t, []corev1.PersistentVolumeAccessMode{"ReadWriteMany"}, pvc.Spec.AccessModes)
@@ -560,7 +564,8 @@ func TestProjectVolumeClass(t *testing.T) {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
 			obj.Labels[labels.AcornManaged] == "true" &&
-			obj.Labels[labels.AcornVolumeName] == "my-data"
+			obj.Labels[labels.AcornVolumeName] == "my-data" &&
+			obj.Labels[labels.AcornVolumeClass] == volumeClass.Name
 	})
 
 	assert.Equal(t, []corev1.PersistentVolumeAccessMode{"ReadWriteOnce"}, pv.Spec.AccessModes)
@@ -586,9 +591,11 @@ func TestProjectVolumeClassDefaultSizeValidation(t *testing.T) {
 		return
 	}
 
+	storageClassName := getStorageClassName(t, storageClasses)
+
 	volumeClass := adminapiv1.ProjectVolumeClass{
 		ObjectMeta:         metav1.ObjectMeta{Namespace: c.GetNamespace(), Name: "acorn-test-custom"},
-		StorageClassName:   getStorageClassName(t, storageClasses),
+		StorageClassName:   storageClassName,
 		AllowedAccessModes: []v1.AccessMode{v1.AccessModeReadWriteOnce},
 		Size: adminv1.VolumeClassSize{
 			Default: v1.Quantity("5G"),
@@ -622,10 +629,11 @@ func TestProjectVolumeClassDefaultSizeValidation(t *testing.T) {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
 			obj.Labels[labels.AcornManaged] == "true" &&
-			obj.Labels[labels.AcornVolumeName] == "my-data"
+			obj.Labels[labels.AcornVolumeName] == "my-data" &&
+			obj.Labels[labels.AcornVolumeClass] == volumeClass.Name
 	})
 
-	assert.Equal(t, storageClasses.Items[0].Name, pv.Spec.StorageClassName)
+	assert.Equal(t, storageClassName, pv.Spec.StorageClassName)
 	assert.Equal(t, []corev1.PersistentVolumeAccessMode{"ReadWriteOnce"}, pv.Spec.AccessModes)
 	assert.Equal(t, "6G", pv.Spec.Capacity.Storage().String())
 
@@ -731,7 +739,8 @@ func TestProjectVolumeClassValuesInAcornfile(t *testing.T) {
 		return obj.Labels[labels.AcornAppName] == app.Name &&
 			obj.Labels[labels.AcornAppNamespace] == app.Namespace &&
 			obj.Labels[labels.AcornManaged] == "true" &&
-			obj.Labels[labels.AcornVolumeName] == "my-data"
+			obj.Labels[labels.AcornVolumeName] == "my-data" &&
+			obj.Labels[labels.AcornVolumeClass] == volumeClass.Name
 	})
 
 	assert.Equal(t, []corev1.PersistentVolumeAccessMode{"ReadWriteMany"}, pvc.Spec.AccessModes)

--- a/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.yaml
@@ -79,6 +79,7 @@ metadata:
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
     "acorn.io/volume-name": "foo"
+    acorn.io/volume-class: "test-custom-class"
 spec:
   resources:
     requests:
@@ -97,6 +98,7 @@ metadata:
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
     "acorn.io/volume-name": "bar"
+    acorn.io/volume-class: "test-custom-class"
 spec:
   resources:
     requests:

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
@@ -74,6 +74,7 @@ metadata:
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
     "acorn.io/volume-name": "foo"
+    acorn.io/volume-class: cli-class
 spec:
   accessModes:
     - ReadWriteOnce

--- a/pkg/controller/appdefinition/testdata/volumes/defaults/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/defaults/expected.yaml
@@ -74,6 +74,7 @@ metadata:
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
     "acorn.io/volume-name": "foo"
+    acorn.io/volume-class: "test-custom-class"
 spec:
   resources:
     requests:

--- a/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.yaml
@@ -74,6 +74,7 @@ metadata:
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
     "acorn.io/volume-name": "foo"
+    acorn.io/volume-class: "test-custom-class"
 spec:
   resources:
     requests:

--- a/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
@@ -74,6 +74,7 @@ metadata:
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
     "acorn.io/volume-name": "foo"
+    acorn.io/volume-class: "custom-class"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -131,6 +131,7 @@ func toPVCs(req router.Request, appInstance *v1.AppInstance) (result []kclient.O
 					return nil, fmt.Errorf("%s has an invalid volume class %s", vol, volumeBinding.Class)
 				} else {
 					pvc.Spec.StorageClassName = &volClass.StorageClassName
+					pvc.Labels[labels.AcornVolumeClass] = volClass.Name
 				}
 			}
 
@@ -144,6 +145,7 @@ func toPVCs(req router.Request, appInstance *v1.AppInstance) (result []kclient.O
 					return nil, fmt.Errorf("%s has an invalid volume class %s", vol, volumeRequest.Class)
 				} else {
 					pvc.Spec.StorageClassName = &volClass.StorageClassName
+					pvc.Labels[labels.AcornVolumeClass] = volClass.Name
 				}
 			}
 			pvName, err := lookupExistingPV(req, appInstance, vol)

--- a/pkg/controller/pvc/markandsave.go
+++ b/pkg/controller/pvc/markandsave.go
@@ -26,6 +26,7 @@ func MarkAndSave(req router.Request, resp router.Response) error {
 	if pv.Labels[labels.AcornAppName] != pvc.Labels[labels.AcornAppName] ||
 		pv.Labels[labels.AcornAppNamespace] != pvc.Labels[labels.AcornAppNamespace] ||
 		pv.Labels[labels.AcornVolumeName] != pvc.Name ||
+		pv.Labels[labels.AcornVolumeClass] != pvc.Labels[labels.AcornVolumeClass] ||
 		pv.Labels[labels.AcornManaged] != "true" ||
 		pv.Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimRetain {
 		if pv.Labels == nil {
@@ -33,6 +34,7 @@ func MarkAndSave(req router.Request, resp router.Response) error {
 		}
 
 		pv.Labels[labels.AcornVolumeName] = pvc.Name
+		pv.Labels[labels.AcornVolumeClass] = pvc.Labels[labels.AcornVolumeClass]
 		pv.Labels[labels.AcornAppName] = pvc.Labels[labels.AcornAppName]
 		pv.Labels[labels.AcornAppNamespace] = pvc.Labels[labels.AcornAppNamespace]
 		pv.Labels[labels.AcornManaged] = "true"

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -21,6 +21,7 @@ const (
 	AcornDepNames                = Prefix + "dep-names"
 	AcornAppUID                  = Prefix + "app-uid"
 	AcornVolumeName              = Prefix + "volume-name"
+	AcornVolumeClass             = Prefix + "volume-class"
 	AcornSecretName              = Prefix + "secret-name"
 	AcornSecretGenerated         = Prefix + "secret-generated"
 	AcornContainerName           = Prefix + "container-name"

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -1,5 +1,11 @@
 package tables
 
+import (
+	"fmt"
+
+	"github.com/acorn-io/acorn/pkg/labels"
+)
+
 var (
 	CheckResult = [][]string{
 		{"Name", "Name"},
@@ -23,7 +29,7 @@ var (
 		{"App-Name", "Status.AppName"},
 		{"Bound-Volume", "Status.VolumeName"},
 		{"Capacity", "Spec.Capacity"},
-		{"Volume-Class", "Spec.Class"},
+		{"Volume-Class", fmt.Sprintf("{{ index .Labels %q }}", labels.AcornVolumeClass)},
 		{"Status", "Status.Status"},
 		{"Access-Modes", "Status.Columns.AccessModes"},
 		{"Created", "{{ago .CreationTimestamp}}"},


### PR DESCRIPTION
The acorn volumes class currently outputs the storage class instead of the volume class as expected. This change addresses this.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Issue: https://github.com/acorn-io/acorn/issues/1261