### PR TITLE
Harden ComputeClass feature

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -22,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestVolume(t *testing.T) {
@@ -850,7 +852,7 @@ func TestDeployParam(t *testing.T) {
 	assert.Equal(t, "5", appInstance.Status.AppSpec.Containers["foo"].Environment[0].Value)
 }
 
-func TestDefaultClusterComputeClass(t *testing.T) {
+func TestUsingComputeClasses(t *testing.T) {
 	helper.StartController(t)
 	cfg := helper.StartAPI(t)
 	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))
@@ -862,378 +864,181 @@ func TestDefaultClusterComputeClass(t *testing.T) {
 
 	ctx := helper.GetCTX(t)
 
-	computeClass := adminv1.ClusterComputeClassInstance{
-		ObjectMeta: metav1.ObjectMeta{Name: "acorn-test-custom"},
-		Default:    true,
-		CPUScaler:  0.25,
-		Memory: adminv1.ComputeClassMemory{
-			Default: "512Mi",
-			Max:     "1Gi",
-			Min:     "512Mi",
+	checks := []struct {
+		name              string
+		noComputeClass    bool
+		testDataDirectory string
+		computeClass      adminv1.ProjectComputeClassInstance
+		expected          map[string]v1.Scheduling
+		waitFor           func(obj *apiv1.App) bool
+		fail              bool
+	}{
+		{
+			name:              "valid",
+			testDataDirectory: "./testdata/computeclass",
+			computeClass: adminv1.ProjectComputeClassInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "acorn-test-custom",
+					Namespace: c.GetNamespace(),
+				},
+				CPUScaler: 0.25,
+				Memory: adminv1.ComputeClassMemory{
+					Min: "512Mi",
+					Max: "1Gi",
+				},
+			},
+			expected: map[string]v1.Scheduling{"simple": {
+				Requirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi")},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+					},
+				}},
+			},
+			waitFor: func(obj *apiv1.App) bool {
+				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
+			},
+		},
+		{
+			name:              "unrestricted default gets maximum",
+			testDataDirectory: "./testdata/computeclass",
+			computeClass: adminv1.ProjectComputeClassInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "acorn-test-custom",
+					Namespace: c.GetNamespace(),
+				},
+				CPUScaler: 0.25,
+				Memory: adminv1.ComputeClassMemory{
+					Max: "1Gi",
+				},
+			},
+			expected: map[string]v1.Scheduling{"simple": {
+				Requirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi")},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+					},
+				}},
+			},
+			waitFor: func(obj *apiv1.App) bool {
+				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
+			},
+		},
+		{
+			name:              "with values",
+			testDataDirectory: "./testdata/computeclass",
+			computeClass: adminv1.ProjectComputeClassInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "acorn-test-custom",
+					Namespace: c.GetNamespace(),
+				},
+				CPUScaler: 0.25,
+				Memory: adminv1.ComputeClassMemory{
+					Default: "512Mi",
+					Values: []string{
+						"1G",
+						"2G",
+					},
+				},
+			},
+			expected: map[string]v1.Scheduling{"simple": {
+				Requirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi")},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("125m"),
+					},
+				}},
+			},
+			waitFor: func(obj *apiv1.App) bool {
+				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
+			},
+		},
+		{
+			name:              "default",
+			testDataDirectory: "./testdata/simple",
+			computeClass: adminv1.ProjectComputeClassInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "acorn-test-custom",
+					Namespace: c.GetNamespace(),
+				},
+				Default:   true,
+				CPUScaler: 0.25,
+				Memory: adminv1.ComputeClassMemory{
+					Default: "512Mi",
+					Max:     "1Gi",
+					Min:     "512Mi",
+				},
+			},
+			expected: map[string]v1.Scheduling{"simple": {
+				Requirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi")},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("125m"),
+					},
+				}},
+			},
+			waitFor: func(obj *apiv1.App) bool {
+				return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
+					obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
+			},
+		},
+		{
+			name:              "does not exist",
+			noComputeClass:    true,
+			testDataDirectory: "./testdata/computeclass",
+			fail:              true,
 		},
 	}
-	if err := kclient.Create(ctx, &computeClass); err != nil {
-		t.Fatal(err)
-	}
 
-	defer func() {
-		if err := kclient.Delete(context.Background(), &computeClass); err != nil && !apierrors.IsNotFound(err) {
-			t.Fatal(err)
+	for _, tt := range checks {
+		asClusterComputeClass := adminv1.ClusterComputeClassInstance(tt.computeClass)
+		for kind, computeClass := range map[string]runtimeclient.Object{"projectcomputeclass": &tt.computeClass, "clustercomputeclass": &asClusterComputeClass} {
+			t.Run(fmt.Sprintf("%v_%v", kind, tt.name), func(t *testing.T) {
+				if !tt.noComputeClass {
+					if err := kclient.Create(ctx, computeClass); err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() {
+						if err = kclient.Delete(context.Background(), computeClass); err != nil && !apierrors.IsNotFound(err) {
+							t.Fatal(err)
+						}
+					})
+				}
+
+				image, err := c.AcornImageBuild(ctx, tt.testDataDirectory+"/Acornfile", &client.AcornImageBuildOptions{
+					Cwd: tt.testDataDirectory,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				app, err := c.AppRun(ctx, image.ID, nil)
+				if err != nil {
+					if tt.fail {
+						return
+					}
+					t.Fatal(err)
+				}
+
+				app = helper.WaitForObject(t, helper.Watcher(t, c), new(apiv1.AppList), app, tt.waitFor)
+				assert.EqualValues(t, app.Status.Scheduling, tt.expected, "generated scheduling rules are incorrect")
+			})
 		}
-	}()
-
-	image, err := c.AcornImageBuild(ctx, "./testdata/simple/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/simple",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app, err := c.AppRun(ctx, image.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app = helper.WaitForObject(t, helper.Watcher(t, c), new(apiv1.AppList), app, func(obj *apiv1.App) bool {
-		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
-			obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
-	})
-
-	expected := map[string]v1.Scheduling{"simple": {
-		Requirements: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi")},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-				corev1.ResourceCPU:    resource.MustParse("125m"),
-			},
-		}}}
-
-	assert.EqualValues(t, app.Status.Scheduling, expected, "generated scheduling rules are incorrect")
-}
-
-func TestDefaultProjectComputeClass(t *testing.T) {
-	helper.StartController(t)
-	cfg := helper.StartAPI(t)
-	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))
-	kclient := helper.MustReturn(kclient.Default)
-	c, err := client.New(cfg, "", ns.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := helper.GetCTX(t)
-
-	computeClass := adminv1.ProjectComputeClassInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acorn-test-custom",
-			Namespace: c.GetNamespace(),
-		},
-		Default:   true,
-		CPUScaler: 0.25,
-		Memory: adminv1.ComputeClassMemory{
-			Default: "512Mi",
-			Max:     "1Gi",
-			Min:     "512Mi",
-		},
-	}
-	if err := kclient.Create(ctx, &computeClass); err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		if err := kclient.Delete(context.Background(), &computeClass); err != nil && !apierrors.IsNotFound(err) {
-			t.Fatal(err)
-		}
-	}()
-
-	image, err := c.AcornImageBuild(ctx, "./testdata/simple/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/simple",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app, err := c.AppRun(ctx, image.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app = helper.WaitForObject(t, helper.Watcher(t, c), new(apiv1.AppList), app, func(obj *apiv1.App) bool {
-		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
-			obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
-	})
-
-	expected := map[string]v1.Scheduling{"simple": {
-		Requirements: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi")},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-				corev1.ResourceCPU:    resource.MustParse("125m"),
-			},
-		}}}
-
-	assert.EqualValues(t, app.Status.Scheduling, expected, "generated scheduling rules are incorrect")
-}
-
-func TestComputeClass(t *testing.T) {
-	helper.StartController(t)
-	cfg := helper.StartAPI(t)
-	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))
-	kclient := helper.MustReturn(kclient.Default)
-	c, err := client.New(cfg, "", ns.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := helper.GetCTX(t)
-
-	computeClass := adminv1.ProjectComputeClassInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acorn-test-custom",
-			Namespace: c.GetNamespace(),
-		},
-		CPUScaler: 0.25,
-		Memory: adminv1.ComputeClassMemory{
-			Default: "512Mi",
-			Max:     "1Gi",
-			Min:     "512Mi",
-		},
-	}
-	if err := kclient.Create(ctx, &computeClass); err != nil {
-		t.Fatal(err)
-	}
-
-	image, err := c.AcornImageBuild(ctx, "./testdata/computeclass/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/computeclass",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app, err := c.AppRun(ctx, image.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app = helper.WaitForObject(t, helper.Watcher(t, c), new(apiv1.AppList), app, func(obj *apiv1.App) bool {
-		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
-			obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
-	})
-
-	expected := map[string]v1.Scheduling{"simple": {
-		Requirements: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi")},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-				corev1.ResourceCPU:    resource.MustParse("125m"),
-			},
-		}}}
-
-	assert.EqualValues(t, app.Status.Scheduling, expected, "generated scheduling rules are incorrect")
-}
-
-func TestAppUsingComputeClassWithValues(t *testing.T) {
-	helper.StartController(t)
-	cfg := helper.StartAPI(t)
-	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))
-	kclient := helper.MustReturn(kclient.Default)
-	c, err := client.New(cfg, "", ns.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := helper.GetCTX(t)
-
-	computeClass := adminv1.ProjectComputeClassInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acorn-test-custom",
-			Namespace: c.GetNamespace(),
-		},
-		CPUScaler: 0.25,
-		Memory: adminv1.ComputeClassMemory{
-			Default: "512Mi",
-			Values: []string{
-				"1G",
-				"2G",
-			},
-		},
-	}
-	if err := kclient.Create(ctx, &computeClass); err != nil {
-		t.Fatal(err)
-	}
-
-	image, err := c.AcornImageBuild(ctx, "./testdata/computeclass/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/computeclass",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app, err := c.AppRun(ctx, image.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app = helper.WaitForObject(t, helper.Watcher(t, c), new(apiv1.AppList), app, func(obj *apiv1.App) bool {
-		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
-			obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
-	})
-
-	expected := map[string]v1.Scheduling{"simple": {
-		Requirements: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi")},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-				corev1.ResourceCPU:    resource.MustParse("125m"),
-			},
-		}}}
-
-	assert.EqualValues(t, app.Status.Scheduling, expected, "generated scheduling rules are incorrect")
-}
-
-func TestUnrestrictedDefaultGetsMaximum(t *testing.T) {
-	helper.StartController(t)
-	cfg := helper.StartAPI(t)
-	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))
-	kclient := helper.MustReturn(kclient.Default)
-	c, err := client.New(cfg, "", ns.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := helper.GetCTX(t)
-
-	computeClass := adminv1.ProjectComputeClassInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acorn-test-custom",
-			Namespace: c.GetNamespace(),
-		},
-		CPUScaler: 0.25,
-		Memory: adminv1.ComputeClassMemory{
-			Max: "1Gi",
-		},
-	}
-	if err := kclient.Create(ctx, &computeClass); err != nil {
-		t.Fatal(err)
-	}
-
-	image, err := c.AcornImageBuild(ctx, "./testdata/computeclass/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/computeclass",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app, err := c.AppRun(ctx, image.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app = helper.WaitForObject(t, helper.Watcher(t, c), new(apiv1.AppList), app, func(obj *apiv1.App) bool {
-		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
-			obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
-	})
-
-	expected := map[string]v1.Scheduling{"simple": {
-		Requirements: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("1Gi")},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-				corev1.ResourceCPU:    resource.MustParse("250m"),
-			},
-		}}}
-
-	assert.EqualValues(t, app.Status.Scheduling, expected, "generated scheduling rules are incorrect")
-}
-
-func TestUnrestrictedDefaultGetsMaximumWithMinimum(t *testing.T) {
-	helper.StartController(t)
-	cfg := helper.StartAPI(t)
-	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))
-	kclient := helper.MustReturn(kclient.Default)
-	c, err := client.New(cfg, "", ns.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := helper.GetCTX(t)
-
-	computeClass := adminv1.ProjectComputeClassInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acorn-test-custom",
-			Namespace: c.GetNamespace(),
-		},
-		CPUScaler: 0.25,
-		Memory: adminv1.ComputeClassMemory{
-			Min: "512Mi",
-			Max: "1Gi",
-		},
-	}
-	if err := kclient.Create(ctx, &computeClass); err != nil {
-		t.Fatal(err)
-	}
-
-	image, err := c.AcornImageBuild(ctx, "./testdata/computeclass/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/computeclass",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app, err := c.AppRun(ctx, image.ID, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app = helper.WaitForObject(t, helper.Watcher(t, c), new(apiv1.AppList), app, func(obj *apiv1.App) bool {
-		return obj.Status.Condition(v1.AppInstanceConditionParsed).Success &&
-			obj.Status.Condition(v1.AppInstanceConditionScheduling).Success
-	})
-
-	expected := map[string]v1.Scheduling{"simple": {
-		Requirements: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("1Gi")},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-				corev1.ResourceCPU:    resource.MustParse("250m"),
-			},
-		}}}
-
-	assert.EqualValues(t, app.Status.Scheduling, expected, "generated scheduling rules are incorrect")
-}
-
-func TestNonExistantComputeClass(t *testing.T) {
-	helper.StartController(t)
-	cfg := helper.StartAPI(t)
-	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))
-	c, err := client.New(cfg, "", ns.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx := helper.GetCTX(t)
-
-	// Create acorn and intentionall do not create the ComputeClass it references
-	image, err := c.AcornImageBuild(ctx, "./testdata/computeclass/Acornfile", &client.AcornImageBuildOptions{
-		Cwd: "./testdata/computeclass",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = c.AppRun(ctx, image.ID, nil)
-	if err == nil {
-		t.Fatal("expected an error to occur when creating an acorn that references a non-existant ComputeClass")
 	}
 }
 
-func TestCreateComputeClass(t *testing.T) {
+func TestCreatingComputeClasses(t *testing.T) {
 	helper.StartController(t)
 	cfg := helper.StartAPI(t)
 	ns := helper.TempNamespace(t, helper.MustReturn(kclient.Default))

--- a/pkg/apis/internal.admin.acorn.io/v1/computeclass.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/computeclass.go
@@ -56,12 +56,12 @@ func ParseComputeClassMemory(memory ComputeClassMemory) (memoryQuantities, error
 	quantities.Def = &defInt
 
 	quantities.Values = make([]*resource.Quantity, len(memory.Values))
-	for _, value := range memory.Values {
+	for i, value := range memory.Values {
 		valueInt, err := parseQuantity(value)
 		if err != nil {
 			return memoryQuantities{}, err
 		}
-		quantities.Values = append(quantities.Values, &valueInt)
+		quantities.Values[i] = &valueInt
 	}
 
 	return quantities, nil
@@ -121,7 +121,7 @@ func ValidateComputeClass(wc ProjectComputeClassInstance, memory resource.Quanti
 func memoryInValues(parsedMemory memoryQuantities, memory resource.Quantity) bool {
 	value := memory.Value()
 	for _, allowedMemory := range parsedMemory.Values {
-		if value == allowedMemory.Value() {
+		if allowedMemory != nil && value == allowedMemory.Value() {
 			return true
 		}
 	}

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -106,11 +106,14 @@ func ResourceRequirements(req router.Request, app *v1.AppInstance, containerName
 
 	memMax := cfg.WorkloadMemoryMaximum
 	if computeClass != nil {
-		maxQuantity, err := resource.ParseQuantity(computeClass.Memory.Max)
-		if err != nil {
-			return nil, err
+		memMax = new(int64)
+		if computeClass.Memory.Max != "" && computeClass.Memory.Max != "0" {
+			maxQuantity, err := resource.ParseQuantity(computeClass.Memory.Max)
+			if err != nil {
+				return nil, err
+			}
+			memMax = &[]int64{maxQuantity.Value()}[0]
 		}
-		memMax = &[]int64{maxQuantity.Value()}[0]
 	}
 
 	memoryQuantity, err := v1.ValidateMemory(app.Spec.Memory, containerName, container, memDefault, memMax)

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -114,7 +114,7 @@ var (
 		{"Name", "Name"},
 		{"Default", "{{ boolToStar .Default }}"},
 		{"Memory Range", "{{ memoryToRange .Memory }}"},
-		{"Memort Default", "{{ defaultMemory .Memory }}"},
+		{"Memory Default", "{{ defaultMemory .Memory }}"},
 		{"Description", "Description"},
 	}
 	ComputeClassConverter = MustConverter(ComputeClass)


### PR DESCRIPTION
Fixes:
- Panic when setting values #1280
- Typo in header for ComputeClasses #1276
- Issue where Max not being set causes scheduling error

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

