### PR TITLE
Run mockgen from go.mod, not PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ generate:
 	go generate
 
 mocks:
-	${GOPATH}/bin/mockgen --build_flags=--mod=mod -destination=pkg/mocks/mock_client.go -package=mocks github.com/acorn-io/acorn/pkg/client Client,ProjectClientFactory
+	go run github.com/golang/mock/mockgen --build_flags=--mod=mod -destination=./pkg/mocks/mock_client.go -package=mocks github.com/acorn-io/acorn/pkg/client Client,ProjectClientFactory
 
 image:
 	docker build .
@@ -39,7 +39,6 @@ setup-ci-env:
   		echo "Could not find golangci-lint, installing."; \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.51.1; \
 	fi
-	go install github.com/golang/mock/mockgen
 
 
 # This will initialize the node_modules needed to run the docs dev server. Run this before running serve-docs

--- a/generate.go
+++ b/generate.go
@@ -3,6 +3,6 @@
 //go:generate go run github.com/acorn-io/baaah/cmd/deepcopy ./pkg/apis/internal.admin.acorn.io/v1/
 //go:generate go run github.com/acorn-io/baaah/cmd/deepcopy ./pkg/apis/admin.acorn.io/v1/
 //go:generate go run k8s.io/kube-openapi/cmd/openapi-gen -i github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1,github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1,github.com/acorn-io/acorn/pkg/apis/internal.admin.acorn.io/v1,github.com/acorn-io/acorn/pkg/apis/admin.acorn.io/v1,k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/version,k8s.io/apimachinery/pkg/api/resource,k8s.io/api/core/v1,k8s.io/api/rbac/v1 -p ./pkg/openapi/generated -h tools/header.txt
-//go:generate $GOPATH/bin/mockgen --build_flags=--mod=mod -destination=./pkg/mocks/mock_client.go -package=mocks github.com/acorn-io/acorn/pkg/client Client,ProjectClientFactory
+//go:generate go run github.com/golang/mock/mockgen --build_flags=--mod=mod -destination=./pkg/mocks/mock_client.go -package=mocks github.com/acorn-io/acorn/pkg/client Client,ProjectClientFactory
 
 package main

--- a/tools/vendor.go
+++ b/tools/vendor.go
@@ -3,5 +3,6 @@ package tools
 import (
 	// Needed for go generate
 	_ "github.com/acorn-io/baaah/pkg/deepcopy"
+	_ "github.com/golang/mock/gomock"
 	_ "k8s.io/kube-openapi/cmd/openapi-gen/args"
 )


### PR DESCRIPTION
Internally use go run to run mockgen as opposed to running the binary
in the PATH.

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

