### PR TITLE
Handle default volume classes when cluster and project defaults exist (#1287)

### DIFF
--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/existing.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/existing.yaml
@@ -2,7 +2,7 @@
 kind: ClusterVolumeClassInstance
 apiVersion: internal.admin.acorn.io/v1
 metadata:
-  name: test-volume-class
+  name: test-cluster-volume-class
 description: Just a simple test volume class
 default: true
 storageClassName: test-storage-class

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -106,11 +106,11 @@ func GetVolumeClasses(ctx context.Context, c client.Client, namespace string) (m
 			continue
 		}
 		if cvc.Default {
-			// Ordering of the default volume class name ensure our error messages don't flop.
-			if !cvc.Inactive && (defaultVolumeClass == nil || cvc.Name < defaultVolumeClass.Name) {
-				defaultVolumeClass = (*adminv1.ProjectVolumeClassInstance)(cvc.DeepCopy())
-			} else if cvc.Inactive || projectDefaultFound {
+			if projectDefaultFound || cvc.Inactive {
 				cvc.Default = false
+			} else if defaultVolumeClass == nil || cvc.Name < defaultVolumeClass.Name {
+				// Ordering of the default volume class name ensure our error messages don't flop.
+				defaultVolumeClass = (*adminv1.ProjectVolumeClassInstance)(cvc.DeepCopy())
 			}
 		}
 		volumeClasses.Items = append(volumeClasses.Items, adminv1.ProjectVolumeClassInstance(cvc))


### PR DESCRIPTION
There was an error in logic when both a cluster and project volume class defaults existed. Specifically, when the cluster default was alphabetically smaller than the project default. This change addresses this by ensuring that if there is a project volume class default then the cluster volume class defaults are ignored.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Issue: https://github.com/acorn-io/acorn/issues/1287