### PR TITLE
Ensure ComputeClasses and Apps created for ComputeClass tests are deleted before next test

### DIFF
--- a/integration/helper/wait.go
+++ b/integration/helper/wait.go
@@ -9,7 +9,6 @@ import (
 	hclient "github.com/acorn-io/acorn/pkg/client"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -125,7 +124,7 @@ func WaitForObject[T client.Object](t *testing.T, watchFunc WatchFunc, list clie
 	return last
 }
 
-func EnsureDoesNotExist(ctx context.Context, getter func() (runtime.Object, error)) error {
+func EnsureDoesNotExist(ctx context.Context, getter func() (client.Object, error)) error {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(WatchTimeoutSeconds)*time.Second)


### PR DESCRIPTION
We've been noticing some test flakes that occur as a result of some recent ComputeClass integration tests. This is because an app is created that already exists in the TestUsingComputeClasses test. In response, I am now ensuring that they are deleted between every test run.

Also, cleaning up any apps that are created between test case runs

#1309 

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

