### PR TITLE
ensure service-accounts are applied before deployments

### DIFF
--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -664,7 +664,7 @@ func ToDeployments(req router.Request, appInstance *v1.AppInstance, tag name.Ref
 		if perms := v1.FindPermission(dep.GetName(), appInstance.Spec.Permissions); perms.HasRules() {
 			result = append(result, toPermissions(perms, dep.GetLabels(), dep.GetAnnotations(), appInstance)...)
 		}
-		result = append(result, dep, sa, expose.ToPodDisruptionBudget(dep))
+		result = append(result, sa, dep, expose.ToPodDisruptionBudget(dep))
 	}
 	return result, nil
 }

--- a/pkg/controller/appdefinition/deploy_test.go
+++ b/pkg/controller/appdefinition/deploy_test.go
@@ -95,7 +95,7 @@ func TestEntrypointCommand(t *testing.T) {
 				},
 			},
 		},
-	}, testTag, nil)[0].(*appsv1.Deployment)
+	}, testTag, nil)[1].(*appsv1.Deployment)
 	assert.Equal(t, []string{"hi", "bye"}, dep.Spec.Template.Spec.Containers[0].Command)
 	assert.Equal(t, []string{"hi2", "bye2"}, dep.Spec.Template.Spec.Containers[0].Args)
 }
@@ -119,7 +119,7 @@ func TestEnvironment(t *testing.T) {
 				},
 			},
 		},
-	}, testTag, nil)[0].(*appsv1.Deployment)
+	}, testTag, nil)[1].(*appsv1.Deployment)
 	assert.Equal(t, []corev1.EnvVar{
 		{
 			Name:  "hi",
@@ -143,7 +143,7 @@ func TestWorkdir(t *testing.T) {
 				},
 			},
 		},
-	}, testTag, nil)[0].(*appsv1.Deployment)
+	}, testTag, nil)[1].(*appsv1.Deployment)
 	assert.Equal(t, "something", dep.Spec.Template.Spec.Containers[0].WorkingDir)
 }
 
@@ -158,7 +158,7 @@ func TestInteractive(t *testing.T) {
 				},
 			},
 		},
-	}, testTag, nil)[0].(*appsv1.Deployment)
+	}, testTag, nil)[1].(*appsv1.Deployment)
 	assert.True(t, dep.Spec.Template.Spec.Containers[0].TTY)
 	assert.True(t, dep.Spec.Template.Spec.Containers[0].Stdin)
 }
@@ -183,7 +183,7 @@ func TestSidecar(t *testing.T) {
 				},
 			},
 		},
-	}, testTag, nil)[0].(*appsv1.Deployment)
+	}, testTag, nil)[1].(*appsv1.Deployment)
 	assert.Equal(t, "sidecar", dep.Spec.Template.Spec.InitContainers[0].Image)
 	assert.Equal(t, "sidecar2", dep.Spec.Template.Spec.Containers[1].Image)
 }
@@ -217,7 +217,7 @@ func TestPorts(t *testing.T) {
 				},
 			},
 		},
-	}, testTag, nil)[0].(*appsv1.Deployment)
+	}, testTag, nil)[1].(*appsv1.Deployment)
 	assert.Equal(t, int32(81), dep.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 	assert.Equal(t, corev1.ProtocolTCP, dep.Spec.Template.Spec.Containers[0].Ports[0].Protocol)
 	assert.Equal(t, int32(91), dep.Spec.Template.Spec.Containers[1].Ports[0].ContainerPort)
@@ -273,7 +273,7 @@ func TestFiles(t *testing.T) {
 		},
 	}
 
-	dep := ToDeploymentsTest(t, app, testTag, nil)[0].(*appsv1.Deployment)
+	dep := ToDeploymentsTest(t, app, testTag, nil)[1].(*appsv1.Deployment)
 
 	assert.Equal(t, "files", dep.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
 	assert.Equal(t, "/a1/b/c", dep.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)

--- a/pkg/controller/appdefinition/jobs.go
+++ b/pkg/controller/appdefinition/jobs.go
@@ -33,7 +33,7 @@ func toJobs(req router.Request, appInstance *v1.AppInstance, pullSecrets *PullSe
 		if perms := v1.FindPermission(job.GetName(), appInstance.Spec.Permissions); perms.HasRules() {
 			result = append(result, toPermissions(perms, job.GetLabels(), job.GetAnnotations(), appInstance)...)
 		}
-		result = append(result, job, sa)
+		result = append(result, sa, job)
 	}
 	return result, nil
 }

--- a/pkg/controller/appdefinition/secret_test.go
+++ b/pkg/controller/appdefinition/secret_test.go
@@ -54,7 +54,7 @@ func TestSecretDirsToMounts(t *testing.T) {
 		},
 	}
 
-	dep := ToDeploymentsTest(t, app, testTag, nil)[0].(*appsv1.Deployment)
+	dep := ToDeploymentsTest(t, app, testTag, nil)[1].(*appsv1.Deployment)
 	assert.Equal(t, "/dir", dep.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
 	assert.Equal(t, "secret--dir-secret", dep.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
 	assert.Equal(t, "/dir-side", dep.Spec.Template.Spec.Containers[1].VolumeMounts[0].MountPath)


### PR DESCRIPTION
### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

