### PR TITLE
Add missing toleration for router deployments

### DIFF
--- a/pkg/controller/appdefinition/router.go
+++ b/pkg/controller/appdefinition/router.go
@@ -10,6 +10,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/pdb"
 	"github.com/acorn-io/acorn/pkg/ports"
 	"github.com/acorn-io/acorn/pkg/system"
+	"github.com/acorn-io/acorn/pkg/tolerations"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/acorn-io/baaah/pkg/typed"
 	name2 "github.com/rancher/wrangler/pkg/name"
@@ -118,6 +119,12 @@ func toRouter(appInstance *v1.AppInstance, routerName string, router v1.Router) 
 									},
 								},
 							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      tolerations.WorkloadTolerationKey,
+							Operator: corev1.TolerationOpExists,
 						},
 					},
 					ServiceAccountName: routerName,

--- a/pkg/controller/appdefinition/testdata/router/expected.yaml.d/deployment.yaml
+++ b/pkg/controller/appdefinition/testdata/router/expected.yaml.d/deployment.yaml
@@ -52,3 +52,6 @@ spec:
       - configMap:
           name: router-name-5f5b2f6b
         name: conf
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

# Context

Tolerations are missing for router deployments. 
