### PR TITLE
Fix sidecar container exec (#1216)

### DIFF
--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -7,6 +7,19 @@ import (
 	"github.com/acorn-io/acorn/pkg/client"
 )
 
+func NewImageWithSidecar(t *testing.T, namespace string) string {
+	t.Helper()
+
+	c := helper.BuilderClient(t, namespace)
+	image, err := c.AcornImageBuild(helper.GetCTX(t), "../testdata/sidecar/Acornfile", &client.AcornImageBuildOptions{
+		Cwd: "../testdata/sidecar",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return image.ID
+}
+
 func NewImage2(t *testing.T, namespace string) string {
 	t.Helper()
 

--- a/integration/client/testdata/sidecar/Acornfile
+++ b/integration/client/testdata/sidecar/Acornfile
@@ -1,0 +1,12 @@
+containers: {
+	web: {
+		image: "public.ecr.aws/docker/library/nginx:latest"
+        files: "/tmp/file": "This is the web container"
+
+        sidecars: sidecar: {
+            image: "public.ecr.aws/docker/library/busybox:latest"
+            command: ["/bin/sh", "-c", "sleep 9999"]
+            files: "/tmp/file": "This is the sidecar"
+        }
+	}
+}

--- a/pkg/cli/exec.go
+++ b/pkg/cli/exec.go
@@ -87,6 +87,9 @@ func (s *Exec) filterContainers(containers []apiv1.ContainerReplica) (result []a
 		} else if c.Spec.ContainerName == s.Container {
 			result = append(result, c)
 			break
+		} else if c.Spec.ContainerName+"."+c.Spec.SidecarName == s.Container {
+			result = append(result, c)
+			break
 		}
 	}
 	return result

--- a/pkg/server/registry/apigroups/acorn/containers/exec.go
+++ b/pkg/server/registry/apigroups/acorn/containers/exec.go
@@ -105,12 +105,8 @@ func (c *ContainerExec) Connect(ctx context.Context, id string, options runtime.
 
 	container := &apiv1.ContainerReplica{}
 	ns, _ := request.NamespaceFrom(ctx)
-	ns, name, err := c.t.FromPublicName(ctx, ns, id)
-	if err != nil {
-		return nil, err
-	}
 
-	err = c.client.Get(ctx, k8sclient.ObjectKey{Namespace: ns, Name: name}, container)
+	err := c.client.Get(ctx, k8sclient.ObjectKey{Namespace: ns, Name: id}, container)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/registry/apigroups/acorn/containers/translator_test.go
+++ b/pkg/server/registry/apigroups/acorn/containers/translator_test.go
@@ -1,0 +1,105 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/scheme"
+	"github.com/acorn-io/baaah/pkg/router/tester"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFromPublicName(t *testing.T) {
+	app := &v1.AppInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: "appNs",
+		},
+		Status: v1.AppInstanceStatus{
+			Namespace: "podNs",
+		},
+	}
+
+	tests := []struct {
+		containerPublicName      string
+		containerPublicNamespace string
+
+		expectedPodName      string
+		expectedPodNamespace string
+		expectedErr          error
+	}{
+		{
+			containerPublicName:      "app.pod",
+			containerPublicNamespace: app.Namespace,
+
+			expectedPodName:      "pod",
+			expectedPodNamespace: app.Status.Namespace,
+			expectedErr:          nil,
+		},
+		{
+			containerPublicName:      "app.pod.container",
+			containerPublicNamespace: app.Namespace,
+
+			expectedPodName:      "pod",
+			expectedPodNamespace: app.Status.Namespace,
+			expectedErr:          nil,
+		},
+
+		{
+			containerPublicName:      "nonExistingApp.pod.container",
+			containerPublicNamespace: app.Namespace,
+
+			expectedPodName:      "nonExistingApp.pod.container",
+			expectedPodNamespace: app.Namespace,
+			expectedErr:          fmt.Errorf("\"nonExistingApp\" not found"),
+		},
+		{
+			containerPublicName:      "app.pod.container",
+			containerPublicNamespace: "nonExistingNamespace",
+
+			expectedPodName:      "app.pod.container",
+			expectedPodNamespace: "nonExistingNamespace",
+			expectedErr:          fmt.Errorf("\"app\" not found"),
+		},
+
+		{
+			containerPublicName:      "app", // incorrect format
+			containerPublicNamespace: app.Namespace,
+
+			expectedPodName:      "app",
+			expectedPodNamespace: app.Namespace,
+			expectedErr:          nil,
+		},
+		{
+			containerPublicName:      "", // incorrect format
+			containerPublicNamespace: app.Namespace,
+
+			expectedPodName:      "",
+			expectedPodNamespace: app.Namespace,
+			expectedErr:          nil,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+		tcName := tc.containerPublicNamespace + "/" + tc.containerPublicName
+		t.Run(tcName, func(t *testing.T) {
+			t.Parallel()
+
+			req := tester.NewRequest(t, scheme.Scheme, app)
+			translator := &Translator{req.Client}
+			podNs, podName, err := translator.FromPublicName(context.Background(), tc.containerPublicNamespace, tc.containerPublicName)
+
+			assert.Equal(t, tc.expectedPodName, podName)
+			assert.Equal(t, tc.expectedPodNamespace, podNs)
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedErr.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

### Description
Suppose there is an app named `app` with one container named `web` that has a sidecar named `sidecar`

Before the fix these worked:
a. `acorn exec -c web app` (Note that app is not entered twice)
b. `acorn exec app.web-5c979bdb7b-vzq7j` (the extra characters come from the actual pod running in Kubernetes)

With the fix the below mentioned variations work as well:
c. `acorn exec app.web-5c979bdb7b-vzq7j.web`
d. `acorn exec -c web.sidecar app`
e. `acorn exec app.web-5c979bdb7b-vzq7j.sidecar`

The -c flag accepts the container name as defined in the Acornfile and not the Kubernetes pod name.

For #1216 