### PR TITLE
Change to HTTP readiness probe for build-server (#1323)

### DIFF
--- a/pkg/imagesystem/buildertemplate.go
+++ b/pkg/imagesystem/buildertemplate.go
@@ -25,9 +25,9 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 				{
 					Name:     system.BuildKitName,
 					Protocol: corev1.ProtocolTCP,
-					Port:     int32(system.BuildkitPort),
+					Port:     system.BuildkitPort,
 					TargetPort: intstr.IntOrString{
-						IntVal: int32(system.BuildkitPort),
+						IntVal: system.BuildkitPort,
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 							},
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: int32(system.BuildkitPort),
+									ContainerPort: system.BuildkitPort,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -164,10 +164,9 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.IntOrString{
-											IntVal: int32(system.BuildkitPort),
-										},
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/ping",
+										Port: intstr.IntOrString{IntVal: system.BuildkitPort},
 									},
 								},
 								InitialDelaySeconds: 2,
@@ -175,7 +174,7 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 							},
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: int32(system.BuildkitPort),
+									ContainerPort: system.BuildkitPort,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/pkg/system/constants.go
+++ b/pkg/system/constants.go
@@ -16,12 +16,12 @@ const (
 )
 
 var (
-	RegistryName             = "registry"
-	RegistryPort             = 5000
-	BuildKitName             = "buildkitd"
-	ControllerName           = "acorn-controller"
-	APIServerName            = "acorn-api"
-	BuildkitPort             = 8080
-	ContainerdConfigPathName = "containerd-config-path"
-	DefaultHubAddress        = "acorn.io"
+	RegistryName                   = "registry"
+	RegistryPort                   = 5000
+	BuildKitName                   = "buildkitd"
+	ControllerName                 = "acorn-controller"
+	APIServerName                  = "acorn-api"
+	BuildkitPort             int32 = 8080
+	ContainerdConfigPathName       = "containerd-config-path"
+	DefaultHubAddress              = "acorn.io"
 )


### PR DESCRIPTION
The TCP probe tends to have issues, especially when running with linkerd. This change switches the probe to an HTTP GET probe, which is already enabled in the build-server.

A special note about this change: since this is changing the deployment spec for the build-server, all currently running build-servers will be restarted once this fix is pushed out to users.

If redeploying all currently running build-servers is not acceptable, then altering these changes to take affect only when the `BuilderInstance` generation changes would be possible, however, would be more involved. I pushed it this way because of the simplicity, but am happy to implement the more involved logic.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

Issue: https://github.com/acorn-io/acorn/issues/1323