### PR TITLE
fix: enable referencing images by repo digest/SHA256 (#1320)

### DIFF
--- a/integration/client/apps/update_test.go
+++ b/integration/client/apps/update_test.go
@@ -30,7 +30,7 @@ func TestUpdatePull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, "foo", &client.AppRunOptions{Name: "test"})
+	app, err := c.AppRun(ctx, "foo:latest", &client.AppRunOptions{Name: "test"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestUpdatePull(t *testing.T) {
 	assert.Equal(t, app.Status.AppImage.ID, imageID)
 
 	imageID2 := client2.NewImage2(t, ns.Name)
-	err = c.ImageTag(ctx, imageID2, "foo")
+	err = c.ImageTag(ctx, imageID2, "foo:latest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -408,5 +408,4 @@ func TestImageBadTag(t *testing.T) {
 
 	err = c.ImageTag(ctx, image.Name, "foo@@:badtag")
 	assert.Equal(t, "could not parse reference: foo@@:badtag", err.Error())
-
 }

--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -404,8 +404,9 @@ func TestImageBadTag(t *testing.T) {
 	assert.Equal(t, "sha256:"+image.Name, image.Digest)
 
 	err = c.ImageTag(ctx, image.Name, "foo:a@badtag")
-	assert.Equal(t, "tag can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`: a@badtag", err.Error())
+	assert.Equal(t, "could not parse reference: foo:a@badtag", err.Error())
 
 	err = c.ImageTag(ctx, image.Name, "foo@@:badtag")
-	assert.Equal(t, "repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: foo@@", err.Error())
+	assert.Equal(t, "could not parse reference: foo@@:badtag", err.Error())
+
 }

--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -119,17 +119,17 @@ func TestImageTag(t *testing.T) {
 
 	image := images[0]
 
-	err = c.ImageTag(ctx, image.Name, "foo")
+	err = c.ImageTag(ctx, image.Name, "foo:latest")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.ImageTag(ctx, "foo", "bar")
+	err = c.ImageTag(ctx, "foo:latest", "bar:latest")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.ImageTag(ctx, "foo", "ghcr.io/acorn-io/acorn/test:v0.0.0-abc")
+	err = c.ImageTag(ctx, "foo:latest", "ghcr.io/acorn-io/acorn/test:v0.0.0-abc")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -58,19 +58,14 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		// tag or digest was provided
-		if ref.Identifier() != "" {
+		// tag, digest or ID was provided
+		if ref.Identifier() != "" || !strings.Contains(ref.Name(), "/") {
 			image, err = c.ImageGet(cmd.Context(), args[0])
 			if err != nil {
 				return err
 			}
 			if !strings.Contains(image.Digest, args[0]) {
-				//normalize through ParseReference inorder to add :latest tag to input if necessary
-				imageParsedReference, err := name.ParseReference(args[0], name.WithDefaultRegistry(""))
-				if err != nil {
-					return err
-				}
-				tagToMatch = imageParsedReference.Name()
+				tagToMatch = ref.Name()
 			}
 			images = []apiv1.Image{*image}
 		} else {

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -52,7 +52,6 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	repoToMatch := ""
 
 	if len(args) == 1 {
-
 		ref, err := name.ParseReference(args[0], name.WithDefaultRegistry(""), name.WithDefaultTag(""))
 		if err != nil {
 			return err
@@ -73,7 +72,6 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 			}
 			images = []apiv1.Image{*image}
 		} else {
-
 			if tags.SHAPermissivePrefixPattern.MatchString(args[0]) {
 				// > search by ID or prefix
 				image, err = c.ImageGet(cmd.Context(), args[0])
@@ -193,7 +191,6 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 			imagePrint.Repository = ""
 			imagePrint.Tag = ""
 		}
-
 	}
 
 	return out.Err()

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -131,24 +131,29 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 			imagePrint.Repository += imageTagRef.Context().RepositoryStr()
 
 			if tagToMatch == imageTagRef.Name() {
-				ntag, ok := imageTagRef.(name.Tag)
-				if ok {
+				if ntag, ok := imageTagRef.(name.Tag); ok {
+					// it's a tag, so print it like usual
 					imagePrint.Tag = ntag.TagStr()
+					out.Write(imagePrint)
+				} else if _, ok := imageTagRef.(name.Digest); ok {
+					// it's a digest, so print without a tag
+					out.Write(imagePrint)
 				}
 			} else if tagToMatch == "" {
-				ntag, ok := imageTagRef.(name.Tag)
-				if ok {
+				if ntag, ok := imageTagRef.(name.Tag); ok {
+					// it's a tag, so print it like usual
 					imagePrint.Tag = ntag.TagStr()
-				} else {
-					if !allSetByUser {
-						continue
-					}
+					out.Write(imagePrint)
+				} else if allSetByUser {
+					// it's not a tag but user wants to see everything
+					out.Write(imagePrint)
 				}
 			}
-			out.Write(imagePrint)
+
 			imagePrint.Repository = ""
 			imagePrint.Tag = ""
 		}
+
 	}
 
 	return out.Err()

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -52,19 +52,8 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	allSetByUser := cmd.Flags().Changed("all")
 
 	if len(args) == 1 {
-		searchStr := args[0]
 
-		ref, err := name.ParseReference(searchStr, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
-		if err != nil {
-			return err
-		}
-
-		// If the image is a digest, then we need to get the image by digest
-		if dig, ok := ref.(name.Digest); ok {
-			searchStr = dig.DigestStr()
-		}
-
-		image, err = c.ImageGet(cmd.Context(), searchStr)
+		image, err = c.ImageGet(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -146,7 +135,6 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 				if ok {
 					imagePrint.Tag = ntag.TagStr()
 				}
-				out.Write(imagePrint)
 			} else if tagToMatch == "" {
 				ntag, ok := imageTagRef.(name.Tag)
 				if ok {
@@ -156,8 +144,10 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 						continue
 					}
 				}
-				out.Write(imagePrint)
 			}
+			out.Write(imagePrint)
+			imagePrint.Repository = ""
+			imagePrint.Tag = ""
 		}
 	}
 

--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -5,6 +5,7 @@ import (
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,12 @@ func (a *ImageDelete) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, image := range args {
-		deleted, err := c.ImageDelete(cmd.Context(), image, &client.ImageDeleteOptions{Force: a.Force})
+		// normalize image name (adding :latest if no tag is specified)
+		ref, err := name.ParseReference(image, name.WithDefaultRegistry(""))
+		if err != nil {
+			return err
+		}
+		deleted, err := c.ImageDelete(cmd.Context(), ref.Name(), &client.ImageDeleteOptions{Force: a.Force})
 
 		if err != nil {
 			return fmt.Errorf("deleting %s: %w", image, err)

--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/acorn/pkg/tags"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
@@ -32,13 +34,18 @@ func (a *ImageDelete) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, image := range args {
-		// normalize image name (adding :latest if no tag is specified)
-		ref, err := name.ParseReference(image, name.WithDefaultRegistry(""))
+		opts := []name.Option{name.WithDefaultRegistry("")}
+
+		if strings.HasPrefix("sha256:", image) || tags.SHAPermissivePrefixPattern.MatchString(image) {
+			opts = append(opts, name.WithDefaultTag(""))
+		}
+
+		// normalize image name (adding :latest if no tag is specified and it's not a digest or potential ID)
+		ref, err := name.ParseReference(image, opts...)
 		if err != nil {
 			return err
 		}
-		deleted, err := c.ImageDelete(cmd.Context(), ref.Name(), &client.ImageDeleteOptions{Force: a.Force})
-
+		deleted, err := c.ImageDelete(cmd.Context(), strings.TrimSuffix(ref.Name(), ":"), &client.ImageDeleteOptions{Force: a.Force})
 		if err != nil {
 			return fmt.Errorf("deleting %s: %w", image, err)
 		}

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -223,13 +223,13 @@ func TestImage(t *testing.T) {
 					ImageItem: &apiv1.Image{
 						ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
 						Tags:       []string{"testtag1:latest", "testtag2:v1"},
-						Digest:     "lkjhgfdsa1234567890"}},
+						Digest:     "sha256:abcdef1234567890"}},
 				StdOut: w,
 				StdErr: w,
 				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"lkjhgfdsa1234567890"},
+				args:   []string{"abcdef1234567890"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
@@ -246,7 +246,7 @@ func TestImage(t *testing.T) {
 					ImageItem: &apiv1.Image{
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
-						Digest:     "registry1234567"}},
+						Digest:     "sha256:abcdef1234567890"}},
 				StdOut: w,
 				StdErr: w,
 				StdIn:  strings.NewReader("y\n"),
@@ -269,13 +269,13 @@ func TestImage(t *testing.T) {
 					ImageItem: &apiv1.Image{
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
-						Digest:     "registry1234567"}},
+						Digest:     "sha256:abcdef1234567890"}},
 				StdOut: w,
 				StdErr: w,
 				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"registry1234567"},
+				args:   []string{"sha256:abcdef1234567890"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
@@ -292,13 +292,13 @@ func TestImage(t *testing.T) {
 					ImageItem: &apiv1.Image{
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
-						Digest:     "registry1234567"}},
+						Digest:     "sha256:abcdef1234567890"}},
 				StdOut: w,
 				StdErr: w,
 				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"-c", "registry1234567"},
+				args:   []string{"-c", "sha256:abcdef1234567890"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
@@ -315,13 +315,13 @@ func TestImage(t *testing.T) {
 					ImageItem: &apiv1.Image{
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
-						Digest:     "registry1234567"}},
+						Digest:     "sha256:abcdef1234567890"}},
 				StdOut: w,
 				StdErr: w,
 				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"-q", "registry1234567"},
+				args:   []string{"-q", "sha256:abcdef1234567890"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
@@ -338,13 +338,13 @@ func TestImage(t *testing.T) {
 					ImageItem: &apiv1.Image{
 						ObjectMeta: metav1.ObjectMeta{Name: "registy1234567-two-tags"},
 						Tags:       []string{"index.docker.io/subdir/test:v1", "index.docker.io/subdir/test:v2"},
-						Digest:     "registry1234567"}},
+						Digest:     "sha256:abcdef1234567890"}},
 				StdOut: w,
 				StdErr: w,
 				StdIn:  strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"-q", "-c", "registry1234567"},
+				args:   []string{"-q", "-c", "sha256:abcdef1234567890"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
@@ -391,7 +391,7 @@ func TestImage(t *testing.T) {
 			wantOut: "Error: No such image: dne-image\n",
 		},
 		{
-			name: "acorn image rm found-image-two-tags1234567", fields: fields{
+			name: "acorn image rm ff12345", fields: fields{
 				All:    false,
 				Quiet:  false,
 				Output: "",
@@ -403,14 +403,14 @@ func TestImage(t *testing.T) {
 				StdIn:         strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"rm", "found-image-two-tags1234567"},
+				args:   []string{"rm", "ff12345"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: true,
-			wantOut: "deleting found-image-two-tags1234567: unable to delete found-image-two-tags1234567 (must be forced) - image is referenced in multiple repositories",
+			wantOut: "deleting ff12345: unable to delete ff12345 (must be forced) - image is referenced in multiple repositories",
 		},
 		{
-			name: "acorn image rm found-image-two-tags1234567 -f", fields: fields{
+			name: "acorn image rm ff12345 -f", fields: fields{
 				All:    false,
 				Quiet:  false,
 				Output: "",
@@ -422,11 +422,11 @@ func TestImage(t *testing.T) {
 				StdIn:         strings.NewReader("y\n"),
 			},
 			args: args{
-				args:   []string{"rm", "found-image-two-tags1234567", "-f"},
+				args:   []string{"rm", "ff12345", "-f"},
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "found-image-two-tags1234567\n",
+			wantOut: "ff12345\n",
 		},
 	}
 

--- a/pkg/cli/pull.go
+++ b/pkg/cli/pull.go
@@ -29,7 +29,7 @@ func (s *Pull) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tag, err := name.NewTag(args[0])
+	ref, err := name.ParseReference(args[0])
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (s *Pull) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	auth, _, err := creds.Get(cmd.Context(), tag.RegistryStr())
+	auth, _, err := creds.Get(cmd.Context(), ref.Context().RegistryStr())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -536,12 +536,12 @@ func (m *MockClient) ImageDelete(ctx context.Context, name string, opts *client.
 		return m.ImageItem, nil
 	}
 	switch name {
-	case "found-image-two-tags1234567":
+	case "ff12345":
 		if !opts.Force {
 			return nil, fmt.Errorf("unable to delete %s (must be forced) - image is referenced in multiple repositories", name)
 		} else {
 			return &apiv1.Image{TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{Name: "found-image-two-tags1234567"},
+				ObjectMeta: metav1.ObjectMeta{Name: "ff12345"},
 				Tags:       []string{"testtag1:latest", "testtag2:latest"},
 			}, nil
 		}

--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -222,17 +222,6 @@ func (c *DefaultClient) ImageDelete(ctx context.Context, imageName string, opts 
 }
 
 func (c *DefaultClient) ImageGet(ctx context.Context, imageName string) (*apiv1.Image, error) {
-
-	ref, err := name.ParseReference(imageName, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
-	if err != nil {
-		return nil, err
-	}
-
-	// If the image is a digest, then we need to get the image by digest
-	if dig, ok := ref.(name.Digest); ok {
-		imageName = dig.DigestStr()
-	}
-
 	result := &apiv1.Image{}
 	return result, c.Client.Get(ctx, kclient.ObjectKey{
 		Name:      strings.ReplaceAll(imageName, "/", "+"),

--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -167,6 +167,7 @@ func (c *DefaultClient) ImagePush(ctx context.Context, imageName string, opts *I
 }
 
 func (c *DefaultClient) ImageDelete(ctx context.Context, imageName string, opts *ImageDeleteOptions) (*apiv1.Image, error) {
+
 	image, err := c.ImageGet(ctx, imageName)
 	if apierrors.IsNotFound(err) {
 		return nil, nil
@@ -204,6 +205,17 @@ func (c *DefaultClient) ImageDelete(ctx context.Context, imageName string, opts 
 }
 
 func (c *DefaultClient) ImageGet(ctx context.Context, imageName string) (*apiv1.Image, error) {
+
+	ref, err := name.ParseReference(imageName, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
+	if err != nil {
+		return nil, err
+	}
+
+	// If the image is a digest, then we need to get the image by digest
+	if dig, ok := ref.(name.Digest); ok {
+		imageName = dig.DigestStr()
+	}
+
 	result := &apiv1.Image{}
 	return result, c.Client.Get(ctx, kclient.ObjectKey{
 		Name:      strings.ReplaceAll(imageName, "/", "+"),

--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -169,7 +169,6 @@ func (c *DefaultClient) ImagePush(ctx context.Context, imageName string, opts *I
 }
 
 func (c *DefaultClient) ImageDelete(ctx context.Context, imageName string, opts *ImageDeleteOptions) (*apiv1.Image, error) {
-
 	image, err := c.ImageGet(ctx, imageName)
 	if apierrors.IsNotFound(err) {
 		return nil, nil

--- a/pkg/server/registry/apigroups/acorn/images/pull.go
+++ b/pkg/server/registry/apigroups/acorn/images/pull.go
@@ -114,6 +114,8 @@ func (i *ImagePull) ImagePull(ctx context.Context, namespace, imageName string, 
 		return nil, err
 	}
 
+	logrus.Infof("Pulling %s (%#v)", pullTag.String(), pullTag)
+
 	opts, err := images.GetAuthenticationRemoteOptionsWithLocalAuth(ctx, pullTag.Context(), auth, i.client, namespace, i.transportOpt)
 	if err != nil {
 		return nil, err

--- a/pkg/server/registry/apigroups/acorn/images/storage_test.go
+++ b/pkg/server/registry/apigroups/acorn/images/storage_test.go
@@ -18,6 +18,12 @@ func TestFindMatchingImage(t *testing.T) {
 		{
 			Digest: "sha256:123409876",
 		},
+		{
+			Digest: "sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb",
+			Tags: []string{
+				"foo/bar",
+			},
+		},
 	}
 	il := apiv1.ImageList{
 		Items: images,
@@ -32,6 +38,13 @@ func TestFindMatchingImage(t *testing.T) {
 
 	_, _, err = findImageMatch(il, "123")
 	assert.Error(t, err)
+
+	image, ref, err = findImageMatch(il, "foo/bar@sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb", image.Digest)
+	assert.Equal(t, "foo/bar", ref)
 
 	_, _, err = findImageMatch(il, "ghcr.io/acorn-io/library/hello-world@sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb")
 	assert.Error(t, err)

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -149,10 +149,14 @@ func (s *Strategy) findImage(ctx context.Context, namespace, imageName string) (
 }
 
 // findImageMatch matches images by digest, digest prefix, or tag name:
+//
 // - digest (raw): sha256:<digest> or <digest> (exactly 64 chars)
 // - digest (image): <registry>/<repo>@sha256:<digest> or <repo>@sha256:<digest>
 // - digest prefix: sha256:<digest prefix> (min. 3 chars)
 // - tag name: <registry>/<repo>:<tag> or <repo>:<tag>
+// - tag name (with default): <registry>/<repo> or <repo> -> Will be matched against the default tag (:latest)
+//   - Note: if we get some string here, that matches the SHAPermissivePrefixPattern, it could be both a digest or a name without a tag
+//     so we will try to match it against the default tag (:latest) first and if that fails, we treat it as a digest(-prefix)
 func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, string, error) {
 	var (
 		repoDigest     name.Digest

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -161,11 +161,11 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 	} else if tags2.SHAPermissivePrefixPattern.MatchString(imageName) {
 		digestPrefix = "sha256:" + imageName
 	} else {
-		tag, err := name.ParseReference(imageName, name.WithDefaultRegistry(""))
+		tag, err := name.ParseReference(imageName, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
 		if err != nil {
 			return nil, "", err
 		}
-		tagName = tag.Name()
+		tagName = strings.TrimSuffix(tag.Name(), ":")
 	}
 
 	var matchedImage apiv1.Image

--- a/pkg/server/registry/apigroups/acorn/images/tag.go
+++ b/pkg/server/registry/apigroups/acorn/images/tag.go
@@ -80,7 +80,7 @@ func (t *TagStrategy) ImageTag(ctx context.Context, namespace, imageName string,
 	}
 	set := sets.NewString(res...)
 
-	imageRef, err := name.ParseReference(tagToAdd)
+	imageRef, err := name.ParseReference(tagToAdd, name.WithDefaultRegistry(""))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- internally this will now be stored as a new image tag without the actual `:<tag>` part
  - this will also not be auto-normalized to `:latest` internally (we only do this on user input for consistency)

## Changes

- Looking up images works via
  - :one: Image ID or Image ID Prefix, e.g. `1234abcde...` or `123`
  - :two: digest or digest prefix, e.g. `sha256:1234abcde...` or `1234ab`
  - :arrow_forward: Since IDs are created from digests, the first two options work the same
  - :three: tag, e.g. `foo:latest` or `foo/bar:mytag` or just `foo` in which case we first try `foo:latest` and then `foo` as ID/Digest (Prefix) [Docker Style]
  - :arrow_forward: For all above options, the result **must** be a single image, otherwise we'll return an error
  - `acorn images` can return a list of tags belonging to a **single** image
  - alternatively, `acorn images myreg/myrepo` can return a list of tags belonging to **multiple** images as long as the tag has a prefix of `myreg/myrepo` -> :four: repo prefix search
  - :exclamation: When searching for an image where the user input **could** be a digest, we still first try to match it with `:latest` tag and only if that doesn't yield a result, we try to match it as an image ID/Digest (that's the Docker way)


## Ref

- #1320 

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description

## Tests

<details>
<summary> :heavy_check_mark:  <code>acorn run</code></summary>

```bash
$ acorn run ghcr.io/acorn-io/library/hello-world:latest
lingering-dust
STATUS: ENDPOINTS[] HEALTHY[] UPTODATE[] 
STATUS: ENDPOINTS[] HEALTHY[0] UPTODATE[0] pending
STATUS: ENDPOINTS[] HEALTHY[0/1] UPTODATE[1] [containers: webapp ContainerCreating]
STATUS: ENDPOINTS[http://webapp-lingering-dust-e9ae3a77.local.on-acorn.io => webapp:80] HEALTHY[0/1] UPTODATE[1] [containers: webapp ContainerCreating]
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| STATUS: ENDPOINTS[http://webapp-lingering-dust-e9ae3a77.local.on-acorn.io => webapp:80] HEALTHY[1] UPTODATE[1] OK |
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| STATUS: ENDPOINTS[http://webapp-lingering-dust-e9ae3a77.local.on-acorn.io => webapp:80] HEALTHY[1] UPTODATE[1] OK |
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

$acorn run ghcr.io/acorn-io/library/hello-world:latest

$ crane digest ghcr.io/acorn-io/library/hello-world:latest                                     
sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb

$ acorn run ghcr.io/acorn-io/library/hello-world@sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb
quiet-fog
STATUS: ENDPOINTS[] HEALTHY[] UPTODATE[] 
STATUS: ENDPOINTS[] HEALTHY[0] UPTODATE[0] pending
STATUS: ENDPOINTS[] HEALTHY[0/1] UPTODATE[1] [containers: webapp ContainerCreating]
STATUS: ENDPOINTS[http://webapp-quiet-fog-2b2e3b48.local.on-acorn.io => webapp:80] HEALTHY[0/1] UPTODATE[1] [containers: webapp ContainerCreating]
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| STATUS: ENDPOINTS[http://webapp-quiet-fog-2b2e3b48.local.on-acorn.io => webapp:80] HEALTHY[1] UPTODATE[1] OK |
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| STATUS: ENDPOINTS[http://webapp-quiet-fog-2b2e3b48.local.on-acorn.io => webapp:80] HEALTHY[1] UPTODATE[1] OK |
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
</details>

<details>
<summary>:heavy_check_mark: <code>acorn pull</code></summary>

```bash
$ acorn pull ghcr.io/acorn-io/library/hello-world@sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb                                           
 [112231571/112231571] ██████████████████████████████████████████████ 100% | 11s

$ acorn images                                                                                                           
REPOSITORY   TAG       IMAGE-ID


$ acorn images -a
REPOSITORY                             TAG       IMAGE-ID
ghcr.io/acorn-io/library/hello-world   <none>    1a6c64d2ccd0

$ kubectl describe images.api.acorn.io -n acorn 1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb        
Name:         1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb
Namespace:    acorn
Labels:       <none>
Annotations:  <none>
API Version:  api.acorn.io/v1
Digest:       sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb
Kind:         Image
Metadata:
  Creation Timestamp:  2023-03-16T11:38:52Z
  Generation:          2
  Managed Fields:
    API Version:  internal.acorn.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:digest:
      f:tags:
    Manager:         acorn
    Operation:       Update
    Time:            2023-03-16T11:38:52Z
  Resource Version:  1061
  UID:               653ae389-ed6d-4e33-8034-a1e094d45ad0-p
Tags:
  ghcr.io/acorn-io/library/hello-world
Events:  <none>
```

</details>

<details>
<summary> :heavy_check_mark: <code>acorn image rm</code></summary>


- Command: `acorn image rm ghcr.io/acorn-io/library/hello-world`
- Case 1: only a single tag (reg/rep only, as pulled by sha256) -> deletes the remaining single instance
- Case 2: multiple tags, one of which is reg/repo only and another which is `:latest` -> deletes `latest`
- Case 3: multple tags, one of which is reg/repo, but no `:latest` present -> fails
  - Error: `✗  ERROR:  deleting ghcr.io/acorn-io/library/hello-world: unable to delete ghcr.io/acorn-io/library/hello-world (must be forced) - image is referenced in multiple repositories`
  - 
</details>