### PR TITLE
Revert default project validation (#1335)

### DIFF
--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -121,30 +121,24 @@ func (a *Acorn) PersistentPre(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	cfg, err := config.ReadCLIConfig()
-	if err != nil {
-		return err
-	}
-	clientFactory := CommandClientFactory{
-		cmd:   cmd,
-		acorn: a,
-	}
-	//check default project to ensure it exists in the current context
-	//except for project cmds to allow project use <valid project> to succeed
-	if a.Project == "" && !isProjectCmd(cmd) {
-		a.Project = cfg.CurrentProject
-	}
+
 	if a.Project != "" {
+		clientFactory := CommandClientFactory{
+			cmd:   cmd,
+			acorn: a,
+		}
+		cfg, err := config.ReadCLIConfig()
+		if err != nil {
+			return err
+		}
+
 		err = project.Exists(cmd.Context(), clientFactory.Options().WithCLIConfig(cfg), a.Project)
 		if err != nil {
 			return err
 		}
 	}
-	return nil
-}
 
-func isProjectCmd(cmd *cobra.Command) bool {
-	return (cmd.Parent() != nil && cmd.Parent().Name() == "project") || (cmd.Name() == "project")
+	return nil
 }
 
 func (a *Acorn) Run(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 	"k8s.io/klog/v2"
 )
 
@@ -132,7 +131,7 @@ func (a *Acorn) PersistentPre(cmd *cobra.Command, args []string) error {
 	}
 	//check default project to ensure it exists in the current context
 	//except for project cmds to allow project use <valid project> to succeed
-	if a.Project == "" && !isProjectCmd(cmd) && !isProjectAgnostic(cmd) {
+	if a.Project == "" && !isProjectCmd(cmd) {
 		a.Project = cfg.CurrentProject
 	}
 	if a.Project != "" {
@@ -146,11 +145,6 @@ func (a *Acorn) PersistentPre(cmd *cobra.Command, args []string) error {
 
 func isProjectCmd(cmd *cobra.Command) bool {
 	return (cmd.Parent() != nil && cmd.Parent().Name() == "project") || (cmd.Name() == "project")
-}
-
-func isProjectAgnostic(cmd *cobra.Command) bool {
-	agnosticCommands := []string{"install", "check", "uninstall", "render"}
-	return slices.Contains(agnosticCommands, cmd.Name())
 }
 
 func (a *Acorn) Run(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
### Checklist
- [] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
 #1335 
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

