### PR TITLE
Create allow-all-ingress NetPol for each app and clean up all other NetPols created by Acorn

### DIFF
--- a/pkg/controller/appdefinition/networkpolicy.go
+++ b/pkg/controller/appdefinition/networkpolicy.go
@@ -16,7 +16,7 @@ func NetworkPolicy(req router.Request, resp router.Response) error {
 			Namespace: app.Status.Namespace,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
-			Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		},
 		Status: networkingv1.NetworkPolicyStatus{},

--- a/pkg/controller/appdefinition/networkpolicy.go
+++ b/pkg/controller/appdefinition/networkpolicy.go
@@ -1,0 +1,7 @@
+package appdefinition
+
+import "github.com/acorn-io/baaah/pkg/router"
+
+func NetworkPolicy(req router.Request, resp router.Response) error {
+	return nil
+}

--- a/pkg/controller/appdefinition/networkpolicy.go
+++ b/pkg/controller/appdefinition/networkpolicy.go
@@ -1,7 +1,26 @@
 package appdefinition
 
-import "github.com/acorn-io/baaah/pkg/router"
+import (
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/baaah/pkg/router"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func NetworkPolicy(req router.Request, resp router.Response) error {
+	app := req.Object.(*v1.AppInstance)
+
+	resp.Objects(&networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      app.Name,
+			Namespace: app.Status.Namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+		Status: networkingv1.NetworkPolicyStatus{},
+	})
+
 	return nil
 }

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -54,8 +54,9 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	appRouter.HandlerFunc(appdefinition.JobStatus)
 	appRouter.HandlerFunc(appdefinition.VolumeStatus)
 	appRouter.HandlerFunc(appdefinition.ReadyStatus)
-	appRouter.HandlerFunc(appdefinition.UpdateGeneration)
+	appRouter.HandlerFunc(appdefinition.NetworkPolicy)
 	appRouter.HandlerFunc(appdefinition.AddAcornProjectLabel)
+	appRouter.HandlerFunc(appdefinition.UpdateGeneration)
 
 	router.Type(&v1.AppInstance{}).HandlerFunc(appdefinition.CLIStatus)
 
@@ -75,9 +76,6 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).Middleware(ingress.RequireLBs).Handler(ingress.NewDNSHandler())
 	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, including the on-acorn.io wildcard cert
 	router.Type(&storagev1.StorageClass{}).HandlerFunc(volume.SyncVolumeClasses)
-	router.Type(&netv1.NetworkPolicy{}).Selector(klabels.SelectorFromSet(map[string]string{
-		"apply.acorn.io/owner-gvk": "internal.acorn.io/v1, kind=AppInstance",
-	})).HandlerFunc(appdefinition.NetworkPolicy)
 
 	configRouter := router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName)
 	configRouter.Handler(config.NewDNSConfigHandler())

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -75,6 +75,9 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).Middleware(ingress.RequireLBs).Handler(ingress.NewDNSHandler())
 	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, including the on-acorn.io wildcard cert
 	router.Type(&storagev1.StorageClass{}).HandlerFunc(volume.SyncVolumeClasses)
+	router.Type(&netv1.NetworkPolicy{}).Selector(klabels.SelectorFromSet(map[string]string{
+		"apply.acorn.io/owner-gvk": "internal.acorn.io/v1, kind=AppInstance",
+	})).HandlerFunc(appdefinition.NetworkPolicy)
 
 	configRouter := router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName)
 	configRouter.Handler(config.NewDNSConfigHandler())

--- a/pkg/install/role.yaml
+++ b/pkg/install/role.yaml
@@ -41,6 +41,7 @@ rules:
     apiGroups: ["networking.k8s.io"]
     resources:
       - ingresses
+      - networkpolicies
   - verbs: ["get", "list", "watch"]
     apiGroups: ["networking.k8s.io"]
     resources:


### PR DESCRIPTION
### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

