### PR TITLE
Fix panic when no ports are set

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -110,8 +110,8 @@ func toExternalService(ctx context.Context, c kclient.Client, cfg *apiv1.Config,
 		return nil, nil, err
 	}
 
-	if len(svc.Spec.Ports) == 0 {
-		return nil, nil, nil
+	if svc == nil || len(svc.Spec.Ports) == 0 {
+		return nil, missing, nil
 	}
 
 	newService := &corev1.Service{


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

