### PR TITLE
Print username on successful login attempt

### DIFF
--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -159,6 +159,6 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	pterm.Success.Printf("Login to %s succeeded\n", serverAddress)
+	pterm.Success.Printf("Login to %s as %s succeeded\n", serverAddress, a.Username)
 	return nil
 }


### PR DESCRIPTION
Prints the user name after a successful login attempt:

```
acorn login -p 4trckdbpzqh4q2k6vnc69mtz2zdlhk24xgjcw9rlkxq9zd9qs8hbzd localhost:8080
  •  Run "acorn projects localhost:8080" to list available projects
  •  Run "acorn project use localhost:8080/dev-user/acorn" to set default project
  ✔  Login to localhost:8080 as dev-user succeeded
```

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

