### PR TITLE
add volume aliases (#1227)

### DIFF
--- a/pkg/cli/rm_helper.go
+++ b/pkg/cli/rm_helper.go
@@ -37,14 +37,17 @@ func addRmObject(rmObjects *RmObjects, obj string) {
 func getSecretsToRemove(arg string, client client.Client, cmd *cobra.Command) ([]string, error) {
 	var result []string
 	secrets, err := client.SecretList(cmd.Context())
-	apps, _ := client.AppList(cmd.Context())
+	if err != nil {
+		return nil, err
+	}
 
+	apps, err := client.AppList(cmd.Context())
 	if err != nil {
 		return nil, err
 	}
 
 	for _, secret := range secrets {
-		aliasList := aliases(&secret, apps)
+		aliasList := secretAliases(&secret, apps)
 		if len(aliasList) != 0 {
 			secretName := strings.Split(aliasList[0], ".")
 			if len(secretName) != 0 && arg == secretName[0] {
@@ -62,10 +65,9 @@ func getVolumesToDelete(arg string, client client.Client, cmd *cobra.Command) ([
 	}
 
 	for _, volume := range volumes {
-		if arg == volume.Status.AppName {
+		if arg == volume.Status.AppName { // if the volume is a part of the app
 			result = append(result, volume.Name)
 		}
-
 	}
 	return result, nil
 }

--- a/pkg/cli/rm_test.go
+++ b/pkg/cli/rm_test.go
@@ -239,7 +239,7 @@ func TestAppRm(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "Removed: found.volume\n",
+			wantOut: "Removed: volume\n",
 		},
 		{
 			name: "does exist volume type long", fields: fields{
@@ -258,7 +258,7 @@ func TestAppRm(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "Removed: found.volume\n",
+			wantOut: "Removed: volume\n",
 		},
 		{
 			name: "does exist secret type short", fields: fields{
@@ -315,7 +315,7 @@ func TestAppRm(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "Removed: found\nRemoved: found.volume\nRemoved: found.secret\n",
+			wantOut: "Removed: found\nRemoved: volume\nRemoved: found.secret\n",
 		},
 		{
 			name: "no app name arg default type", fields: fields{

--- a/pkg/cli/secret.go
+++ b/pkg/cli/secret.go
@@ -47,7 +47,7 @@ func (a *Secret) Run(cmd *cobra.Command, args []string) error {
 
 	out := table.NewWriter(tables.Secret, a.Quiet, a.Output)
 	out.AddFormatFunc("alias", func(obj apiv1.Secret) string {
-		return strings.Join(aliases(&obj, apps), ",")
+		return strings.Join(secretAliases(&obj, apps), ",")
 	})
 
 	if len(args) == 1 {
@@ -77,7 +77,7 @@ func (a *Secret) Run(cmd *cobra.Command, args []string) error {
 	return out.Err()
 }
 
-func aliases(secret *apiv1.Secret, apps []apiv1.App) (result []string) {
+func secretAliases(secret *apiv1.Secret, apps []apiv1.App) (result []string) {
 	names := sets.NewString()
 	for _, app := range apps {
 		for _, binding := range app.Spec.Secrets {

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -3,6 +3,7 @@ package testdata
 import (
 	"context"
 	"fmt"
+	"github.com/acorn-io/acorn/pkg/labels"
 	"net"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
@@ -451,10 +452,14 @@ func (m *MockClient) VolumeList(ctx context.Context) ([]apiv1.Volume, error) {
 		return m.Volumes, nil
 	}
 	return []apiv1.Volume{{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found.volume"},
-		Spec:       apiv1.VolumeSpec{},
-		Status:     apiv1.VolumeStatus{AppName: "found", VolumeName: "found.volume"},
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "volume",
+			Labels: map[string]string{
+				labels.AcornVolumeName: "vol",
+				labels.AcornAppName:    "found",
+			}},
+		Spec:   apiv1.VolumeSpec{},
+		Status: apiv1.VolumeStatus{AppName: "found", VolumeName: "vol"},
 	}}, nil
 }
 
@@ -462,15 +467,23 @@ func (m *MockClient) VolumeGet(ctx context.Context, name string) (*apiv1.Volume,
 	if m.VolumeItem != nil {
 		return m.VolumeItem, nil
 	}
+	potentialVol := apiv1.Volume{TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "volume",
+			Labels: map[string]string{
+				labels.AcornVolumeName: "vol",
+				labels.AcornAppName:    "found",
+			}},
+		Spec:   apiv1.VolumeSpec{},
+		Status: apiv1.VolumeStatus{AppName: "found", VolumeName: "vol"},
+	}
+
 	switch name {
 	case "dne":
 		return nil, fmt.Errorf("error: volume %s does not exist", name)
-	case "found.volume":
-		return &apiv1.Volume{TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{Name: "found.volume"},
-			Spec:       apiv1.VolumeSpec{},
-			Status:     apiv1.VolumeStatus{AppName: "found", VolumeName: "found.volume"},
-		}, nil
+	case "volume":
+		return &potentialVol, nil
+	case "found.vol":
+		return &potentialVol, nil
 	}
 	return nil, nil
 }
@@ -482,7 +495,9 @@ func (m *MockClient) VolumeDelete(ctx context.Context, name string) (*apiv1.Volu
 	switch name {
 	case "dne":
 		return nil, nil
-	case "found.volume":
+	case "volume":
+		return &apiv1.Volume{}, nil
+	case "found.vol":
 		return &apiv1.Volume{}, nil
 	}
 	return nil, nil

--- a/pkg/cli/testdata/all/all_test.txt
+++ b/pkg/cli/testdata/all/all_test.txt
@@ -8,8 +8,8 @@ NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAG
 found.container                                 0              292y ago   
 
 VOLUMES:
-NAME           APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
-found.volume   found      found.volume   <nil>                                              292y ago
+ALIAS       NAME      APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
+found.vol   volume    found      vol            <nil>                                              292y ago
 
 SECRETS:
 ALIAS         NAME           TYPE      KEYS      CREATED

--- a/pkg/cli/testdata/all/all_test_i.txt
+++ b/pkg/cli/testdata/all/all_test_i.txt
@@ -8,8 +8,8 @@ NAME              APP       IMAGE     STATE     RESTARTCOUNT   CREATED    MESSAG
 found.container                                 0              292y ago   
 
 VOLUMES:
-NAME           APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
-found.volume   found      found.volume   <nil>                                              292y ago
+ALIAS       NAME      APP-NAME   BOUND-VOLUME   CAPACITY   VOLUME-CLASS   STATUS    ACCESS-MODES   CREATED
+found.vol   volume    found      vol            <nil>                                              292y ago
 
 SECRETS:
 ALIAS         NAME           TYPE      KEYS      CREATED

--- a/pkg/cli/testdata/all/all_test_json.txt
+++ b/pkg/cli/testdata/all/all_test_json.txt
@@ -49,13 +49,13 @@ CONTAINERS:
 VOLUMES:
 {
     "metadata": {
-        "name": "found.volume",
+        "name": "volume",
         "creationTimestamp": null
     },
     "spec": {},
     "status": {
         "appName": "found",
-        "volumeName": "found.volume",
+        "volumeName": "vol",
         "columns": {}
     }
 }

--- a/pkg/cli/testdata/all/all_test_yaml.txt
+++ b/pkg/cli/testdata/all/all_test_yaml.txt
@@ -38,12 +38,12 @@ VOLUMES:
 ---
 metadata:
   creationTimestamp: null
-  name: found.volume
+  name: volume
 spec: {}
 status:
   appName: found
   columns: {}
-  volumeName: found.volume
+  volumeName: vol
 
 
 SECRETS:

--- a/pkg/cli/volumes.go
+++ b/pkg/cli/volumes.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"fmt"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/cli/builder/table"
+	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/tables"
 	"github.com/spf13/cobra"
 	"k8s.io/utils/strings/slices"
@@ -35,6 +39,9 @@ func (a *Volume) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	out := table.NewWriter(tables.Volume, a.Quiet, a.Output)
+	out.AddFormatFunc("alias", func(obj apiv1.Volume) string {
+		return volumeAlias(&obj)
+	})
 
 	if len(args) == 1 {
 		volume, err := c.VolumeGet(cmd.Context(), args[0])
@@ -61,4 +68,14 @@ func (a *Volume) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return out.Err()
+}
+
+// volumeAliases matches the correct app name to the given volume
+func volumeAlias(volume *apiv1.Volume) string {
+
+	if len(volume.Labels[labels.AcornVolumeName]) > 0 && len(volume.Labels[labels.AcornAppName]) > 0 {
+		return fmt.Sprintf("%s.%s", volume.Labels[labels.AcornAppName], volume.Labels[labels.AcornVolumeName])
+	}
+
+	return ""
 }

--- a/pkg/cli/volumes.go
+++ b/pkg/cli/volumes.go
@@ -72,7 +72,6 @@ func (a *Volume) Run(cmd *cobra.Command, args []string) error {
 
 // volumeAliases matches the correct app name to the given volume
 func volumeAlias(volume *apiv1.Volume) string {
-
 	if len(volume.Labels[labels.AcornVolumeName]) > 0 && len(volume.Labels[labels.AcornAppName]) > 0 {
 		return fmt.Sprintf("%s.%s", volume.Labels[labels.AcornAppName], volume.Labels[labels.AcornVolumeName])
 	}

--- a/pkg/cli/volumes_test.go
+++ b/pkg/cli/volumes_test.go
@@ -69,7 +69,6 @@ func TestVolume(t *testing.T) {
 				}
 				return nil, nil
 			}).AnyTimes()
-
 	}
 
 	type fields struct {

--- a/pkg/server/registry/apigroups/acorn/secrets/translator.go
+++ b/pkg/server/registry/apigroups/acorn/secrets/translator.go
@@ -25,7 +25,7 @@ type Translator struct {
 
 func (t *Translator) FromPublicName(ctx context.Context, namespace, name string) (string, string, error) {
 	i := strings.LastIndex(name, ".")
-	if i == -1 || i+1 > len(name) {
+	if i == -1 || i+1 >= len(name) {
 		return namespace, name, nil
 	}
 

--- a/pkg/server/registry/apigroups/acorn/volumes/translator.go
+++ b/pkg/server/registry/apigroups/acorn/volumes/translator.go
@@ -22,6 +22,33 @@ type Translator struct {
 }
 
 func (t *Translator) FromPublicName(ctx context.Context, namespace, name string) (string, string, error) {
+
+	i := strings.LastIndex(name, ".")
+	// If there is not a period, or string ends with period, parse it not as an alias
+	if i == -1 || i+1 >= len(name) {
+		return "", name, nil
+	}
+
+	// parse it of the form <appName>.<shortVolName>
+	prefix := name[:i]
+	volumeName := name[i+1:]
+
+	volumes := &apiv1.VolumeList{}
+	err := t.c.List(ctx, volumes, &kclient.ListOptions{
+		Namespace: namespace,
+		LabelSelector: klabels.SelectorFromSet(map[string]string{
+			labels.AcornAppName:    prefix,
+			labels.AcornVolumeName: volumeName,
+		}),
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(volumes.Items) == 1 {
+		return "", volumes.Items[0].Name, nil
+	}
+
 	return "", name, nil
 }
 

--- a/pkg/server/registry/apigroups/acorn/volumes/translator.go
+++ b/pkg/server/registry/apigroups/acorn/volumes/translator.go
@@ -22,7 +22,6 @@ type Translator struct {
 }
 
 func (t *Translator) FromPublicName(ctx context.Context, namespace, name string) (string, string, error) {
-
 	i := strings.LastIndex(name, ".")
 	// If there is not a period, or string ends with period, parse it not as an alias
 	if i == -1 || i+1 >= len(name) {

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -25,6 +25,7 @@ var (
 	AppConverter = MustConverter(App)
 
 	Volume = [][]string{
+		{"Alias", "{{alias .}}"},
 		{"Name", "{{ . | name }}"},
 		{"App-Name", "Status.AppName"},
 		{"Bound-Volume", "Status.VolumeName"},


### PR DESCRIPTION
Acorn volumes has a new category: alias. This is `<appName>.<volumeName>`

Refactored old tests which suggested aliases already worked due to how the mockclient was set up, to more accurately match what the client is replying with.

Modified the volume translator to either accept the k8 volume name (IE: pvc-xxxx), or of the alias structure  `<appName>.<volumeName>`

addresses #1227

Also fixed an off-by-one error for parsing secret aliases


### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

