### PR TITLE
Create containing dirs for EKS test artifacts to live in

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -80,7 +80,7 @@ jobs:
         if: always()
         # Add any artifacts that should be associated with this run to /tmp/artifacts/${{ github.run_id }}
         run: |
-          mkdir -p /tmp/artifacts/${{ github.run_id }}
+          mkdir -p /tmp/artifacts/${{ github.run_id }}/logs /tmp/artifacts/${{ github.run_id }}/resources
           kubectl logs -n acorn-system -l app=acorn-api > /tmp/artifacts/${{ github.run_id }}/logs/acorn-api.log || true
           kubectl logs -n acorn-system -l app=acorn-controller > /tmp/artifacts/${{ github.run_id }}/logs/acorn-controller.log || true
           kubectl get all -n acorn-image-system > /tmp/artifacts/${{ github.run_id }}/resources/acorn-image-system.txt || true

--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -80,9 +80,9 @@ jobs:
         if: always()
         # Add any artifacts that should be associated with this run to /tmp/artifacts/${{ github.run_id }}
         run: |
-          mkdir -p /tmp/artifacts/${{ github.run_id }}/logs /tmp/artifacts/${{ github.run_id }}/resources
-          kubectl logs -n acorn-system -l app=acorn-api > /tmp/artifacts/${{ github.run_id }}/logs/acorn-api.log || true
-          kubectl logs -n acorn-system -l app=acorn-controller > /tmp/artifacts/${{ github.run_id }}/logs/acorn-controller.log || true
+          mkdir -p /tmp/artifacts/${{ github.run_id }}/{logs,resources}
+          kubectl logs -n acorn-system -l app=acorn-api --tail -1 > /tmp/artifacts/${{ github.run_id }}/logs/acorn-api.log || true
+          kubectl logs -n acorn-system -l app=acorn-controller --tail -1 > /tmp/artifacts/${{ github.run_id }}/logs/acorn-controller.log || true
           kubectl get all -n acorn-image-system > /tmp/artifacts/${{ github.run_id }}/resources/acorn-image-system.txt || true
           kubectl get all -n acorn-system > /tmp/artifacts/${{ github.run_id }}/resources/acorn-system.txt || true
           kubectl get all -n acorn > /tmp/artifacts/${{ github.run_id }}/resources/acorn.txt || true


### PR DESCRIPTION
- Fixing issue with artifacts not being created due to parent directories not existing
- Increasing default 10 lines for log output to be unlimited

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

