### PR TITLE
Don't expose ports in test

### DIFF
--- a/integration/secrets/testdata/issue-552/Acornfile
+++ b/integration/secrets/testdata/issue-552/Acornfile
@@ -8,7 +8,6 @@ containers: {
       "/data/etc/icinga2/constants.conf": "secret://icinga2-master-constants-file/template"
       "/data/etc/icinga2/conf.d/api-users.conf": "secret://icinga2-master-api-user-file/template"
     }
-    ports: "publish": "80/http"
     env: {
       "ICINGA_MASTER": "1"
       "ICINGA_CN": "icinga2-master"


### PR DESCRIPTION
Exposing a port causes Rancher to update the deployment annotations
causing the generation to go to 2.

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

