### PR TITLE
parse project syntax for cli

### DIFF
--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client/term"
@@ -138,8 +139,23 @@ func (a *Acorn) PersistentPre(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// parse the form project::resource
+	for i, arg := range args {
+		if projectOverride, newArg, ok := strings.Cut(arg, "::"); ok {
+			args[i] = newArg
+			a.Project = projectOverride
+		}
+	}
+	cmd.SetArgs(args)
+
 	return nil
 }
+
+// This runs from running acorn. How do I get this to run before all commands
+//func (a *Acorn) Pre(cmd *cobra.Command, args []string) error {
+//
+//
+//}
 
 func (a *Acorn) Run(cmd *cobra.Command, args []string) error {
 	return cmd.Help()

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -8,15 +8,31 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
+// cli.projectscoped command
+// takes a command, add a new prerun to it, that is the project scope parser that I wrote
+// iterate over all flags and args, if any of them have the thing i set, ::
+// break it out into -j
+
+// or create 1 fun in 1 place
+// inside builder, projectscope.go, func that takes args of an app and flags of a command
+// iterate over them, does prerun i was writing,
+// fun a* app = pre, call that scope function
+
+// is there anything that is not project scoped, what would I want to not touch with this?
+
+//global flag info
+// bc acorn is root command, all flags attached are global commands for the sub commands
+
 func NewApp(c CommandContext) *cobra.Command {
 	return cli.Command(&App{client: c.ClientFactory}, cobra.Command{
 		Use:     "app [flags] [APP_NAME...]",
 		Aliases: []string{"apps", "a", "ps"},
 		Example: `
 acorn app`,
-		SilenceUsage:      true,
-		Short:             "List or get apps",
-		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
+		SilenceUsage: true,
+		Short:        "List or get apps",
+		//PreRun: c.ClientFactory.
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).checkProjectPrefix().complete,
 	})
 }
 
@@ -29,6 +45,7 @@ type App struct {
 
 func (a *App) Run(cmd *cobra.Command, args []string) error {
 	c, err := a.client.CreateDefault()
+
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/computeclasses.go
+++ b/pkg/cli/computeclasses.go
@@ -16,7 +16,7 @@ func NewComputeClasses(c CommandContext) *cobra.Command {
 acorn computeclasses`,
 		SilenceUsage:      true,
 		Short:             "List available ComputeClasses",
-		ValidArgsFunction: newCompletion(c.ClientFactory, computeClassCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, computeClassCompletion).checkProjectPrefix().complete,
 	})
 }
 

--- a/pkg/cli/containers.go
+++ b/pkg/cli/containers.go
@@ -18,7 +18,7 @@ func NewContainer(c CommandContext) *cobra.Command {
 acorn containers`,
 		SilenceUsage:      true,
 		Short:             "Manage containers",
-		ValidArgsFunction: newCompletion(c.ClientFactory, containersCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, containersCompletion).checkProjectPrefix().complete,
 	})
 	cmd.AddCommand(NewContainerDelete(c))
 	return cmd

--- a/pkg/cli/containers_rm.go
+++ b/pkg/cli/containers_rm.go
@@ -16,7 +16,7 @@ acorn container kill app-name.containername-generated-hash`,
 		SilenceUsage:      true,
 		Short:             "Delete a container",
 		Aliases:           []string{"rm"},
-		ValidArgsFunction: newCompletion(c.ClientFactory, containersCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, containersCompletion).checkProjectPrefix().complete,
 	})
 	return cmd
 }

--- a/pkg/cli/credential.go
+++ b/pkg/cli/credential.go
@@ -18,7 +18,7 @@ func NewCredential(c CommandContext) *cobra.Command {
 acorn credential`,
 		SilenceUsage:      true,
 		Short:             "Manage registry credentials",
-		ValidArgsFunction: newCompletion(c.ClientFactory, credentialsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, credentialsCompletion).checkProjectPrefix().complete,
 	})
 	cmd.AddCommand(NewCredentialLogin(false, c))
 	cmd.AddCommand(NewCredentialLogout(false, c))

--- a/pkg/cli/credential_logout.go
+++ b/pkg/cli/credential_logout.go
@@ -20,7 +20,7 @@ acorn logout ghcr.io`,
 		SilenceUsage:      true,
 		Short:             "Remove registry credentials",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, credentialsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, credentialsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).checkProjectPrefix().complete,
 	})
 	if root {
 		cmd.Aliases = nil

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -23,7 +23,7 @@ acorn images`,
 		SilenceUsage:      true,
 		Short:             "Manage images",
 		Args:              cobra.MaximumNArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).withShouldCompleteOptions(onlyNumArgs(1)).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).checkProjectPrefix().withShouldCompleteOptions(onlyNumArgs(1)).complete,
 	})
 	cmd.AddCommand(NewImageDelete(c))
 	return cmd

--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -14,7 +14,7 @@ func NewImageDelete(c CommandContext) *cobra.Command {
 		Example:           `acorn image rm my-image`,
 		SilenceUsage:      true,
 		Short:             "Delete an Image",
-		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).checkProjectPrefix().complete,
 	})
 	return cmd
 }

--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -16,7 +16,7 @@ func NewPush(c CommandContext) *cobra.Command {
 		SilenceUsage:      true,
 		Short:             "Push an image to a remote registry",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(false)).withShouldCompleteOptions(onlyNumArgs(1)).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(false)).withShouldCompleteOptions(onlyNumArgs(1)).checkProjectPrefix().complete,
 	})
 }
 

--- a/pkg/cli/rm.go
+++ b/pkg/cli/rm.go
@@ -13,7 +13,7 @@ acorn rm APP_NAME
 acorn rm -t volume,container APP_NAME`,
 		SilenceUsage:      true,
 		Short:             "Delete an app, container, secret or volume",
-		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).checkProjectPrefix().complete,
 		Args:              cobra.MinimumNArgs(1),
 	})
 }

--- a/pkg/cli/secret.go
+++ b/pkg/cli/secret.go
@@ -22,7 +22,7 @@ func NewSecret(c CommandContext) *cobra.Command {
 acorn secret`,
 		SilenceUsage:      true,
 		Short:             "Manage secrets",
-		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).checkProjectPrefix().complete,
 	})
 	cmd.AddCommand(NewSecretCreate(c))
 	cmd.AddCommand(NewSecretDelete(c))

--- a/pkg/cli/secret_expose.go
+++ b/pkg/cli/secret_expose.go
@@ -17,7 +17,7 @@ acorn secret`,
 		SilenceUsage:      true,
 		Short:             "Manage secrets",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).checkProjectPrefix().complete,
 	})
 	return cmd
 }

--- a/pkg/cli/secret_rm.go
+++ b/pkg/cli/secret_rm.go
@@ -14,7 +14,7 @@ func NewSecretDelete(c CommandContext) *cobra.Command {
 acorn secret rm my-secret`,
 		SilenceUsage:      true,
 		Short:             "Delete a secret",
-		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, secretsCompletion).checkProjectPrefix().complete,
 	})
 	return cmd
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -16,7 +16,7 @@ acorn start my-app
 acorn start my-app1 my-app2`,
 		SilenceUsage:      true,
 		Short:             "Start an app",
-		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).checkProjectPrefix().complete,
 	})
 }
 

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -16,7 +16,7 @@ acorn stop my-app
 acorn stop my-app1 my-app2`,
 		SilenceUsage:      true,
 		Short:             "Stop an app",
-		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).checkProjectPrefix().complete,
 	})
 }
 

--- a/pkg/cli/tag.go
+++ b/pkg/cli/tag.go
@@ -11,7 +11,7 @@ func NewTag(c CommandContext) *cobra.Command {
 		SilenceUsage:      true,
 		Short:             "Tag an image",
 		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).withShouldCompleteOptions(onlyNumArgs(2)).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).withShouldCompleteOptions(onlyNumArgs(2)).checkProjectPrefix().complete,
 	})
 }
 

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -391,7 +391,7 @@ func (m *MockClient) ContainerReplicaList(ctx context.Context, opts *client.Cont
 	}
 	return []apiv1.ContainerReplica{{
 		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
+		ObjectMeta: metav1.ObjectMeta{Name: "container"},
 		Spec:       apiv1.ContainerReplicaSpec{AppName: "found"},
 		Status:     apiv1.ContainerReplicaStatus{},
 	}}, nil

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -19,7 +19,7 @@ func NewUpdate(c CommandContext) *cobra.Command {
 		SilenceUsage:      true,
 		Short:             "Update a deployed app",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).checkProjectPrefix().complete,
 	})
 	cmd.PersistentFlags().Lookup("dangerous").Hidden = true
 	cmd.Flags().SetInterspersed(false)

--- a/pkg/cli/volume_classes.go
+++ b/pkg/cli/volume_classes.go
@@ -16,7 +16,7 @@ func NewVolumeClasses(c CommandContext) *cobra.Command {
 acorn offering volumeclasses`,
 		SilenceUsage:      true,
 		Short:             "List available volume classes",
-		ValidArgsFunction: newCompletion(c.ClientFactory, volumeClassCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, volumeClassCompletion).checkProjectPrefix().complete,
 	})
 	return cmd
 }

--- a/pkg/cli/volume_rm.go
+++ b/pkg/cli/volume_rm.go
@@ -13,7 +13,7 @@ func NewVolumeDelete(c CommandContext) *cobra.Command {
 		Example:           `acorn volume rm my-volume`,
 		SilenceUsage:      true,
 		Short:             "Delete a volume",
-		ValidArgsFunction: newCompletion(c.ClientFactory, volumesCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, volumesCompletion).checkProjectPrefix().complete,
 	})
 	return cmd
 }

--- a/pkg/cli/volumes.go
+++ b/pkg/cli/volumes.go
@@ -16,7 +16,7 @@ func NewVolume(c CommandContext) *cobra.Command {
 acorn volume`,
 		SilenceUsage:      true,
 		Short:             "Manage volumes",
-		ValidArgsFunction: newCompletion(c.ClientFactory, volumesCompletion).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, volumesCompletion).checkProjectPrefix().complete,
 	})
 	cmd.AddCommand(NewVolumeDelete(c))
 	return cmd

--- a/pkg/cli/wait.go
+++ b/pkg/cli/wait.go
@@ -12,7 +12,7 @@ func NewWait(c CommandContext) *cobra.Command {
 		SilenceUsage:      true,
 		Short:             "Wait an app to be ready then exit with status code 0",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).checkProjectPrefix().complete,
 	})
 }
 


### PR DESCRIPTION
Accept any argument of the form project::resource and set the current project to the one provided. Also implemented for autocompletion.

To reviewers: I'd like a more elegant solution to implementing autocompletion instead of wrapping every function manually. I may set this by default to be wrapped in completion.go's complete function, unless a noCompletionOptions is set to turn off projectcompletion. Worth bothering with?

Still want to write some tests with images, as they can use a single colon as well

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Addresses #1362
