### PR TITLE
Add back support for app.image and app.namespace

### DIFF
--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -10,11 +10,13 @@ import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/digest"
 	"github.com/acorn-io/acorn/pkg/labels"
+	"github.com/acorn-io/acorn/pkg/tags"
 	"github.com/acorn-io/acorn/pkg/volume"
 	"github.com/acorn-io/aml/pkg/replace"
 	"github.com/acorn-io/baaah/pkg/apply"
 	"github.com/acorn-io/baaah/pkg/merr"
 	"github.com/acorn-io/baaah/pkg/router"
+	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +122,18 @@ func (i *Interpolator) resolveApp(keyName string) (string, bool, error) {
 	case "name":
 		return i.app.Name, true, nil
 	case "namespace":
-		return i.app.Status.Namespace, true, nil
+		return i.app.Namespace, true, nil
+	case "image":
+		if tags.IsLocalReference(i.app.Status.AppImage.ID) {
+			return i.app.Status.AppImage.ID, true, nil
+		} else if i.app.Status.AppImage.ID != "" && i.app.Status.AppImage.Digest != "" {
+			tag, err := name.NewTag(i.app.Status.AppImage.ID)
+			if err != nil {
+				return "", false, err
+			}
+			return tag.Digest(i.app.Status.AppImage.Digest).String(), true, nil
+		}
+		return "", false, nil
 	default:
 		return "", false, nil
 	}


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

