### PR TITLE
Replacing docker images with ghcr images (#1022)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM ghcr.io/yashgiri/acorn-images-mirror/tonistiigi/binfmt:qemu-v6.2.0 AS binfmt
-FROM ghcr.io/yashgiri/acorn-images-mirror/moby/buildkit:v0.10.6 AS buildkit
+FROM ghcr.io/acorn-io/images-mirror/tonistiigi/binfmt:qemu-v6.2.0 AS binfmt
+FROM ghcr.io/acorn-io/images-mirror/moby/buildkit:v0.10.6 AS buildkit
 FROM ghcr.io/acorn-io/images-mirror/registry:2.8.1 AS registry
-FROM ghcr.io/yashgiri/acorn-images-mirror/rancher/klipper-lb:v0.3.5 AS klipper-lb
+FROM ghcr.io/acorn-io/images-mirror/rancher/klipper-lb:v0.3.5 AS klipper-lb
 
 FROM ghcr.io/acorn-io/images-mirror/golang:1.20-alpine AS helper
 WORKDIR /usr/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,21 @@
 
 FROM tonistiigi/binfmt:qemu-v6.2.0 AS binfmt
 FROM moby/buildkit:v0.10.6 AS buildkit
-FROM public.ecr.aws/docker/library/registry:2.8.1 AS registry
+FROM ghcr.io/acorn-io/images-mirror/registry:2.8.1 AS registry
 FROM rancher/klipper-lb:v0.3.5 AS klipper-lb
 
-FROM public.ecr.aws/docker/library/golang:1.20-alpine AS helper
+FROM ghcr.io/acorn-io/images-mirror/golang:1.20-alpine AS helper
 WORKDIR /usr/src
 RUN apk -U add curl
 RUN curl -sfL https://github.com/loft-sh/devspace/archive/refs/tags/v5.18.5.tar.gz | tar xzf - --strip-components=1
 RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o /usr/local/bin/acorn-helper -ldflags "-s -w" ./helper
 
-FROM public.ecr.aws/docker/library/golang:1.20 AS build
+FROM ghcr.io/acorn-io/images-mirror/golang:1.20 AS build
 COPY / /src
 WORKDIR /src
 RUN --mount=type=cache,target=/go/pkg --mount=type=cache,target=/root/.cache/go-build make build
 
-FROM public.ecr.aws/docker/library/nginx:1.23.2-alpine AS base
+FROM ghcr.io/acorn-io/images-mirror/nginx:1.23.2-alpine AS base
 RUN apk add --no-cache ca-certificates iptables ip6tables fuse3 git openssh pigz xz \
   && ln -s fusermount3 /usr/bin/fusermount
 RUN adduser -D acorn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM tonistiigi/binfmt:qemu-v6.2.0 AS binfmt
-FROM moby/buildkit:v0.10.6 AS buildkit
+FROM ghcr.io/yashgiri/acorn-images-mirror/tonistiigi/binfmt:qemu-v6.2.0 AS binfmt
+FROM ghcr.io/yashgiri/acorn-images-mirror/moby/buildkit:v0.10.6 AS buildkit
 FROM ghcr.io/acorn-io/images-mirror/registry:2.8.1 AS registry
-FROM rancher/klipper-lb:v0.3.5 AS klipper-lb
+FROM ghcr.io/yashgiri/acorn-images-mirror/rancher/klipper-lb:v0.3.5 AS klipper-lb
 
 FROM ghcr.io/acorn-io/images-mirror/golang:1.20-alpine AS helper
 WORKDIR /usr/src

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -6,7 +6,7 @@ RUN yarn install
 FROM src as bin
 RUN yarn build
 
-FROM nginx as static
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest as static
 COPY --from=bin /usr/src/build /usr/share/nginx/html
 
 FROM src as dynamic

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/yashgiri/acorn-images-mirror/node:19-buster as src
+FROM ghcr.io/acorn-io/images-mirror/node:19-buster as src
 COPY / /usr/src
 WORKDIR /usr/src
 RUN yarn install

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-buster as src
+FROM ghcr.io/yashgiri/acorn-images-mirror/node:19-buster as src
 COPY / /usr/src
 WORKDIR /usr/src
 RUN yarn install

--- a/integration/build/testdata/build-default/Acornfile
+++ b/integration/build/testdata/build-default/Acornfile
@@ -5,5 +5,5 @@ args: {
 profiles: build: include: bool | *true
 
 if args.include {
-	containers: default: image: "public.ecr.aws/docker/library/busybox:latest"
+	containers: default: image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 }

--- a/integration/build/testdata/contextdir/Dockerfile
+++ b/integration/build/testdata/contextdir/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/busybox:latest AS not-default
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest AS not-default
 
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 COPY this-will-fail /

--- a/integration/build/testdata/dev/Acornfile
+++ b/integration/build/testdata/dev/Acornfile
@@ -1,5 +1,5 @@
 containers: {
 	if args.dev {
-		default: image: "public.ecr.aws/docker/library/busybox:latest"
+		default: image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 	}
 }

--- a/integration/build/testdata/jobs/Dockerfile
+++ b/integration/build/testdata/jobs/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest

--- a/integration/build/testdata/jobs/Dockerfile.sidecar
+++ b/integration/build/testdata/jobs/Dockerfile.sidecar
@@ -1,2 +1,2 @@
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 CMD ["sidecar"]

--- a/integration/build/testdata/sidecar/Dockerfile
+++ b/integration/build/testdata/sidecar/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest

--- a/integration/build/testdata/sidecar/Dockerfile.sidecar
+++ b/integration/build/testdata/sidecar/Dockerfile.sidecar
@@ -1,2 +1,2 @@
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 CMD ["sidecar"]

--- a/integration/build/testdata/similar/one/Acornfile
+++ b/integration/build/testdata/similar/one/Acornfile
@@ -1,7 +1,7 @@
 // This file must match its sibling except for the value of index.txt
 containers: {
 	web: {
-		image: "public.ecr.aws/docker/library/busybox:latest"
+		image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 		files: {
 			"/foo/index.txt": "1"
 		}

--- a/integration/build/testdata/similar/two/Acornfile
+++ b/integration/build/testdata/similar/two/Acornfile
@@ -1,7 +1,7 @@
 // This file must match its sibling except for the value of index.txt
 containers: {
 	web: {
-		image: "public.ecr.aws/docker/library/busybox:latest"
+		image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 		files: {
 			"/foo/index.txt": "2"
 		}

--- a/integration/build/testdata/simple-two/Acornfile
+++ b/integration/build/testdata/simple-two/Acornfile
@@ -6,7 +6,7 @@ containers: {
 	    build: images.itwo.build
 	}
 	three: {
-	    image: "public.ecr.aws/docker/library/busybox:latest"
+	    image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 	}
 }
 
@@ -21,6 +21,6 @@ images: {
 		}
 	}
 	three: {
-	    image: "public.ecr.aws/docker/library/busybox:latest"
+	    image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 	}
 }

--- a/integration/build/testdata/simple-two/one/Dockerfile
+++ b/integration/build/testdata/simple-two/one/Dockerfile
@@ -1,2 +1,2 @@
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 COPY data.txt /

--- a/integration/build/testdata/simple-two/two/subdir/Dockerfile.txt
+++ b/integration/build/testdata/simple-two/two/subdir/Dockerfile.txt
@@ -1,2 +1,2 @@
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 COPY data.txt /

--- a/integration/build/testdata/simple/Dockerfile
+++ b/integration/build/testdata/simple/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest

--- a/integration/build/testdata/target/Dockerfile
+++ b/integration/build/testdata/target/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/busybox:latest AS not-default
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest AS not-default
 
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 COPY this-will-fail /

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -121,6 +121,6 @@ func TestFriendlyNameInContainer(t *testing.T) {
 
 	_, img, _ := strings.Cut(image.ImageData.Containers["default"].Image, "@")
 	assert.Len(t, cs, 1)
-	assert.Equal(t, "public.ecr.aws/docker/library/nginx:latest", cs[0].Spec.Image)
+	assert.Equal(t, "ghcr.io/acorn-io/images-mirror/nginx:latest", cs[0].Spec.Image)
 	assert.True(t, strings.HasSuffix(cs[0].Status.ImageID, img))
 }

--- a/integration/client/testdata/dependson/Acornfile
+++ b/integration/client/testdata/dependson/Acornfile
@@ -1,16 +1,16 @@
 containers: {
 	one: {
-		image: "public.ecr.aws/docker/library/nginx:latest"
+		image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
 		ports: "80/http"
 		dependsOn: ["job1", "job2"]
 	}
 	two: {
-		image: "public.ecr.aws/docker/library/nginx:latest"
+		image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
 		ports: "80/http"
 		dependsOn: "one"
 	}
 	three: {
-		image: "public.ecr.aws/docker/library/nginx:latest"
+		image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
 		ports: "80/http"
 		dependsOn: "two"
 	}
@@ -18,12 +18,12 @@ containers: {
 
 jobs: {
 	job1: {
-		image:"public.ecr.aws/docker/library/busybox:latest"
+		image:"ghcr.io/acorn-io/images-mirror/busybox:latest"
 		command: "/bin/true"
 		dependsOn: "job2"
 	}
 	job2: {
-		image:"public.ecr.aws/docker/library/busybox:latest"
+		image:"ghcr.io/acorn-io/images-mirror/busybox:latest"
 		command: "/bin/true"
 	}
 }

--- a/integration/client/testdata/nginx/Acornfile
+++ b/integration/client/testdata/nginx/Acornfile
@@ -1,2 +1,2 @@
-containers: default: image: "public.ecr.aws/docker/library/nginx:latest"
+containers: default: image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
 containers: default: dirs: "/usr/share/www": "vol"

--- a/integration/client/testdata/nginx2/Acornfile
+++ b/integration/client/testdata/nginx2/Acornfile
@@ -1,2 +1,2 @@
-containers: nginx2: image: "public.ecr.aws/docker/library/nginx:latest"
+containers: nginx2: image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
 containers: nginx2: dirs: "/usr/share/www": "vol"

--- a/integration/client/testdata/sidecar/Acornfile
+++ b/integration/client/testdata/sidecar/Acornfile
@@ -1,10 +1,10 @@
 containers: {
 	web: {
-		image: "public.ecr.aws/docker/library/nginx:latest"
+		image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
         files: "/tmp/file": "This is the web container"
 
         sidecars: sidecar: {
-            image: "public.ecr.aws/docker/library/busybox:latest"
+            image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
             command: ["/bin/sh", "-c", "sleep 9999"]
             files: "/tmp/file": "This is the sidecar"
         }

--- a/integration/dev/dev_test.go
+++ b/integration/dev/dev_test.go
@@ -20,10 +20,10 @@ const (
 containers: default: build: {}
 `
 	dockerfile1 = `
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 CMD ["echo", "hi"]`
 	dockerfile2 = `
-FROM public.ecr.aws/docker/library/busybox:latest
+FROM ghcr.io/acorn-io/images-mirror/busybox:latest
 CMD ["echo", "bye"]`
 )
 

--- a/integration/log/testdata/Acornfile
+++ b/integration/log/testdata/Acornfile
@@ -1,23 +1,23 @@
 containers: {
 	"cont1-1": {
-		image: "public.ecr.aws/docker/library/busybox:latest"
+		image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 		command: [
 			"sh", "-c", "echo -e \"line 1-1\nline 1-2\"; sleep 9999"
 		]
 		sidecars: "cont2-1": {
-			image: "public.ecr.aws/docker/library/busybox:latest"
+			image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 			command: [
 				"sh", "-c", "echo -e \"line 1-3\nline 1-4\"; sleep 9999"
 			]
 		}
 	}
 	"cont1-2": {
-		image: "public.ecr.aws/docker/library/busybox:latest"
+		image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 		command: [
 			"sh", "-c", "echo -e \"line 2-1\nline 2-2\"; sleep 9999"
 		]
 		sidecars: "cont2-2": {
-			image: "public.ecr.aws/docker/library/busybox:latest"
+			image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 			command: [
 			  "sh", "-c", "echo -e \"line 2-3\nline 2-4\"; sleep 9999"
 			]

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -788,7 +788,7 @@ func TestImageNameAnnotation(t *testing.T) {
 		}
 
 		_, digest, _ := strings.Cut(pod.Spec.Containers[0].Image, "sha256:")
-		return mapping["sha256:"+digest] == "public.ecr.aws/docker/library/nginx:latest"
+		return mapping["sha256:"+digest] == "ghcr.io/acorn-io/images-mirror/nginx:latest"
 	})
 }
 

--- a/integration/run/testdata/cluster-volume-class-with-values/Dockerfile
+++ b/integration/run/testdata/cluster-volume-class-with-values/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/run/testdata/cluster-volume-class/Dockerfile
+++ b/integration/run/testdata/cluster-volume-class/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/run/testdata/computeclass/Dockerfile
+++ b/integration/run/testdata/computeclass/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/run/testdata/named/Acornfile
+++ b/integration/run/testdata/named/Acornfile
@@ -1,1 +1,1 @@
-containers: default: image: "public.ecr.aws/docker/library/nginx:latest"
+containers: default: image: "ghcr.io/acorn-io/images-mirror/nginx:latest"

--- a/integration/run/testdata/no-class-with-values/Dockerfile
+++ b/integration/run/testdata/no-class-with-values/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/run/testdata/params/Acornfile
+++ b/integration/run/testdata/params/Acornfile
@@ -7,6 +7,6 @@ containers: {
 		env: {
 			arg: "\(args.someInt)"
 		}
-		image: "public.ecr.aws/docker/library/nginx:latest"
+		image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
 	}
 }

--- a/integration/run/testdata/simple/Dockerfile
+++ b/integration/run/testdata/simple/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/run/testdata/volume-bad-class/Dockerfile
+++ b/integration/run/testdata/volume-bad-class/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/run/testdata/volume-custom-class/Dockerfile
+++ b/integration/run/testdata/volume-custom-class/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/run/testdata/volume/Dockerfile
+++ b/integration/run/testdata/volume/Dockerfile
@@ -1,1 +1,1 @@
-FROM public.ecr.aws/docker/library/nginx:latest
+FROM ghcr.io/acorn-io/images-mirror/nginx:latest

--- a/integration/secrets/testdata/encryption/Acornfile
+++ b/integration/secrets/testdata/encryption/Acornfile
@@ -1,7 +1,7 @@
 args: encdata: ""
 
 containers: app: {
-    image: "public.ecr.aws/docker/library/busybox:latest"
+    image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
     env: secretVal: "secret://test/key"
 }
 

--- a/integration/secrets/testdata/generated-json/Acornfile
+++ b/integration/secrets/testdata/generated-json/Acornfile
@@ -3,7 +3,7 @@ jobs: {
 		env: {
 			PASS: "secret://zzz/password"
 		}
-		image: "public.ecr.aws/docker/library/busybox:latest"
+		image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 		files: "/run.sh": """
 			#!/bin/sh
 			cat << EOF > /run/secrets/output

--- a/integration/secrets/testdata/generated/Acornfile
+++ b/integration/secrets/testdata/generated/Acornfile
@@ -3,7 +3,7 @@ jobs: {
 		env: {
 			PASS: "secret://zzz/password"
 		}
-		image: "public.ecr.aws/docker/library/busybox:latest"
+		image: "ghcr.io/acorn-io/images-mirror/busybox:latest"
 		cmd: ["sh", "-c", "echo -n $PASS > /run/secrets/output"]
 	}
 	cronpass: {schedule: "* * * * * "} & pass

--- a/integration/secrets/testdata/issue-552/Acornfile
+++ b/integration/secrets/testdata/issue-552/Acornfile
@@ -1,6 +1,6 @@
 containers: {
   "icinga2-master": {
-    image: "public.ecr.aws/docker/library/nginx:latest"
+    image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
     dirs: {
       "/data/var": "volume://icinga-data"
     }

--- a/pkg/appdefinition/appdefinition_test.go
+++ b/pkg/appdefinition/appdefinition_test.go
@@ -146,7 +146,7 @@ containers: {
         build: {}
       }
       right: {
-        image: "public.ecr.aws/docker/library/nginx:latest"
+        image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
         dirs: "/var/tmp": "./foo/bar"
       }
     }
@@ -223,9 +223,9 @@ acorns: {
 	assert.Equal(t, "Dockerfile", buildSpec.Containers["file"].Sidecars["left"].Build.Dockerfile)
 	assert.Equal(t, ".", buildSpec.Containers["file"].Sidecars["left"].Build.Context)
 
-	assert.Equal(t, "public.ecr.aws/docker/library/nginx:latest", buildSpec.Containers["file"].Sidecars["right"].Image)
+	assert.Equal(t, "ghcr.io/acorn-io/images-mirror/nginx:latest", buildSpec.Containers["file"].Sidecars["right"].Image)
 	assert.Equal(t, "Dockerfile", buildSpec.Containers["file"].Sidecars["right"].Build.Dockerfile)
-	assert.Equal(t, "public.ecr.aws/docker/library/nginx:latest", buildSpec.Containers["file"].Sidecars["right"].Build.BaseImage)
+	assert.Equal(t, "ghcr.io/acorn-io/images-mirror/nginx:latest", buildSpec.Containers["file"].Sidecars["right"].Build.BaseImage)
 	assert.Equal(t, ".", buildSpec.Containers["file"].Sidecars["right"].Build.Context)
 	assert.Equal(t, "./foo/bar", buildSpec.Containers["file"].Sidecars["right"].Build.ContextDirs["/var/tmp"])
 

--- a/pkg/appdefinition/params_test.go
+++ b/pkg/appdefinition/params_test.go
@@ -94,7 +94,7 @@ profiles: {
 
 containers: {
 	web: {
-		image: "public.ecr.aws/docker/library/nginx:latest"
+		image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
 		scale: args.replicas
 	}
 }`)


### PR DESCRIPTION
### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

This PR replaces use of aws ecr images to ghcr images.
Relevant tests have been modified.
Agreed with Craig on the idea that ghcr token expiring is fine.