### PR TITLE
Add goimports to lint check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,4 +19,6 @@ linters:
   - typecheck
   - thelper
   - unused
+  - goimports
   fast: false
+  max-same-issues: 50

--- a/integration/client/info/info_test.go
+++ b/integration/client/info/info_test.go
@@ -1,6 +1,9 @@
 package info_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/acorn-io/acorn/integration/helper"
 	v1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/client"
@@ -8,8 +11,6 @@ import (
 	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	"github.com/acorn-io/acorn/pkg/project"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestDefaultClientInfoOneNamespace(t *testing.T) {

--- a/integration/log/log_test.go
+++ b/integration/log/log_test.go
@@ -2,15 +2,16 @@ package log
 
 import (
 	"context"
+	"sort"
+	"strings"
+	"testing"
+
 	"github.com/acorn-io/acorn/integration/helper"
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"sort"
-	"strings"
-	"testing"
 )
 
 const sampleLog = `line 1-1

--- a/pkg/cli/containers.go
+++ b/pkg/cli/containers.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/cli/builder/table"
 	"github.com/acorn-io/acorn/pkg/client"

--- a/pkg/cli/containers_test.go
+++ b/pkg/cli/containers_test.go
@@ -2,21 +2,21 @@ package cli
 
 import (
 	"fmt"
-	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
-	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
-	"github.com/acorn-io/acorn/pkg/client"
-	"github.com/acorn-io/acorn/pkg/mocks"
-	"github.com/golang/mock/gomock"
 	"io"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/cli/testdata"
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/acorn/pkg/mocks"
+	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (

--- a/pkg/cli/info_test.go
+++ b/pkg/cli/info_test.go
@@ -1,18 +1,18 @@
 package cli
 
 import (
-	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
-	"github.com/acorn-io/acorn/pkg/mocks"
 	"io"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"strings"
 	"testing"
 
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/cli/testdata"
+	"github.com/acorn-io/acorn/pkg/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestInfo(t *testing.T) {

--- a/pkg/controller/appdefinition/deploy_test.go
+++ b/pkg/controller/appdefinition/deploy_test.go
@@ -2,13 +2,13 @@ package appdefinition
 
 import (
 	"encoding/base64"
-	"github.com/acorn-io/acorn/pkg/digest"
-	"github.com/acorn-io/acorn/pkg/secrets"
 	"testing"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/controller/namespace"
+	"github.com/acorn-io/acorn/pkg/digest"
 	"github.com/acorn-io/acorn/pkg/scheme"
+	"github.com/acorn-io/acorn/pkg/secrets"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/acorn-io/baaah/pkg/router/tester"
 	"github.com/google/go-containerregistry/pkg/name"

--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -2,13 +2,13 @@ package appdefinition
 
 import (
 	"fmt"
-	"github.com/acorn-io/acorn/pkg/secrets"
 	"sort"
 	"strconv"
 	"strings"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/labels"
+	"github.com/acorn-io/acorn/pkg/secrets"
 	"github.com/acorn-io/acorn/pkg/volume"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/acorn-io/baaah/pkg/typed"

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	policyv1 "k8s.io/api/policy/v1"
 	"net/http"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
@@ -26,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"

--- a/pkg/controller/secrets/secret_test.go
+++ b/pkg/controller/secrets/secret_test.go
@@ -1,6 +1,8 @@
 package secrets
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
@@ -10,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"regexp"
-	"strings"
 )
 
 func TestSecretImageReference(t *testing.T) {

--- a/pkg/dns/helpers.go
+++ b/pkg/dns/helpers.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/imagesystem/buildertemplate.go
+++ b/pkg/imagesystem/buildertemplate.go
@@ -2,10 +2,10 @@ package imagesystem
 
 import (
 	"fmt"
-	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
-	"github.com/acorn-io/acorn/pkg/labels"
 	"path/filepath"
 
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/acorn/pkg/tolerations"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io"
-	"k8s.io/utils/strings/slices"
 	"strings"
 	"sync"
 	"time"
@@ -19,6 +17,7 @@ import (
 	applabels "github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	"github.com/acorn-io/baaah/pkg/watcher"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,11 +1,12 @@
 package log
 
 import (
+	"testing"
+
 	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 var (

--- a/pkg/log/output.go
+++ b/pkg/log/output.go
@@ -2,12 +2,13 @@ package log
 
 import (
 	"context"
+	"strings"
+	"time"
+
 	v1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
-	"strings"
-	"time"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Craig Jellick <craig@acorn.io>

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

