### PR TITLE
disable cache for setup go action

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -24,6 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
       - run: make validate-code
       - run: make build

--- a/.github/workflows/main-mac-smoke-test.yaml
+++ b/.github/workflows/main-mac-smoke-test.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
       - uses: debianmaster/actions-k3s@v1.0.5
         with:

--- a/.github/workflows/validate-docs.yaml
+++ b/.github/workflows/validate-docs.yaml
@@ -16,6 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: "1.20"
       - run: make init-docs
       - run: make validate-docs


### PR DESCRIPTION
Disabling the setup-go cache, enabled by default. The cache size has been growing and growing every run and no easy solution, so disabling caching for now. 

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

