### PR TITLE
NetworkPolicies: Handle case where an Ingress routes to an ExternalName Service (#456)

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -14,6 +14,7 @@ import (
 	adminv1 "github.com/acorn-io/acorn/pkg/apis/internal.admin.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/appdefinition"
 	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/acorn/pkg/config"
 	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/run"
@@ -1149,6 +1150,13 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 	ctx := helper.GetCTX(t)
 	c, _ := helper.ClientAndNamespace(t)
 	kc := helper.MustReturn(kclient.Default)
+
+	cfg, err := config.Get(ctx, kc)
+	if err != nil {
+		t.Fatal(err)
+	} else if !*cfg.NetworkPolicies {
+		t.SkipNow() // skip this test because NetworkPolicies are not enabled
+	}
 
 	// create two separate projects in which to run two Nginx apps
 	proj1, err := c.ProjectCreate(ctx, "proj1", "local")

--- a/pkg/controller/appdefinition/networkpolicy.go
+++ b/pkg/controller/appdefinition/networkpolicy.go
@@ -76,12 +76,6 @@ func NetworkPolicyForApp(req router.Request, resp router.Response) error {
 // Acorn apps from the ingress controller. If the ingress controller namespace is not defined, traffic from
 // all namespaces will be allowed instead.
 func NetworkPolicyForIngress(req router.Request, resp router.Response) error {
-	// check if this is being called as a finalizer for a deleted Ingress
-	// we need this because we sometimes create NetworkPolicies in different namespaces from where their owning Ingresses live
-	if !req.Object.GetDeletionTimestamp().IsZero() {
-		return nil
-	}
-
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil {
 		return err

--- a/pkg/controller/appdefinition/networkpolicy.go
+++ b/pkg/controller/appdefinition/networkpolicy.go
@@ -55,6 +55,9 @@ func NetworkPolicyForApp(req router.Request, resp router.Response) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      app.Name,
 			Namespace: podNamespace,
+			Labels: map[string]string{
+				labels.AcornManaged: "true",
+			},
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
@@ -176,6 +179,9 @@ func NetworkPolicyForIngress(req router.Request, resp router.Response) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      netPolName,
 				Namespace: svc.Namespace,
+				Labels: map[string]string{
+					labels.AcornManaged: "true",
+				},
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -258,6 +264,9 @@ func NetworkPolicyForService(req router.Request, resp router.Response) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.SafeConcatName(projectName, appName, service.Name, containerName),
 			Namespace: service.Namespace,
+			Labels: map[string]string{
+				labels.AcornManaged: "true",
+			},
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{

--- a/pkg/controller/appdefinition/networkpolicy.go
+++ b/pkg/controller/appdefinition/networkpolicy.go
@@ -130,8 +130,7 @@ func NetworkPolicyForIngress(req router.Request, resp router.Response) error {
 			}
 
 			svc = corev1.Service{}
-			err = req.Get(&svc, svcNamespace, svcName)
-			if err != nil {
+			if err = req.Get(&svc, svcNamespace, svcName); err != nil {
 				if apierror.IsNotFound(err) {
 					return fmt.Errorf("failed to find service '%s', targeted by ExternalName '%s'", svcName, externalName)
 				}

--- a/pkg/controller/appdefinition/networkpolicy_test.go
+++ b/pkg/controller/appdefinition/networkpolicy_test.go
@@ -15,6 +15,10 @@ func TestNetworkPolicyForIngress(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/ingress", NetworkPolicyForIngress)
 }
 
+func TestNetworkPolicyForIngressExternalName(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/externalname", NetworkPolicyForIngress)
+}
+
 func TestNetworkPolicyForService(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/service", NetworkPolicyForService)
 }

--- a/pkg/controller/appdefinition/testdata/networkpolicy/appinstance/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/appinstance/expected.yaml
@@ -4,6 +4,8 @@ kind: NetworkPolicy
 metadata:
   name: app-name
   namespace: app-created-namespace
+  labels:
+    "acorn.io/managed": "true"
 spec:
   ingress:
     - from:

--- a/pkg/controller/appdefinition/testdata/networkpolicy/externalname/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/externalname/existing.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+data:
+  config: '{"ingressControllerNamespace":"traefik"}'
+kind: ConfigMap
+metadata:
+  name: acorn-config
+  namespace: acorn-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-7777
+  namespace: my-app-namespace
+  labels:
+    acorn.io/service-name: service-7777
+spec:
+  type: ClusterIP
+  ports:
+    - name: "7777"
+      port: 7777
+      protocol: TCP
+      targetPort: 9999
+  selector:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: acorn
+    acorn.io/managed: "true"
+    port-number.acorn.io/9999: "true"
+    service-name.acorn.io/service-7777: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-7777
+  namespace: other-namespace
+spec:
+  type: ExternalName
+  externalName: service-7777.my-app-namespace.svc.cluster.local
+  ports:
+    - appProtocol: HTTP
+      name: "7777"
+      port: 7777
+      protocol: TCP
+      targetPort: 7777

--- a/pkg/controller/appdefinition/testdata/networkpolicy/externalname/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/externalname/expected.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: acorn-my-app-service-7777-service-7777-9999
+  namespace: my-app-namespace
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: acorn-system
+      ports:
+        - port: 9999
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      acorn.io/app-name: my-app
+      acorn.io/app-namespace: acorn
+      acorn.io/managed: "true"
+      port-number.acorn.io/9999: "true"
+      service-name.acorn.io/service-7777: "true"
+  policyTypes:
+    - Ingress

--- a/pkg/controller/appdefinition/testdata/networkpolicy/externalname/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/externalname/expected.yaml
@@ -3,6 +3,8 @@ kind: NetworkPolicy
 metadata:
   name: acorn-my-app-service-7777-service-7777-9999
   namespace: my-app-namespace
+  labels:
+    "acorn.io/managed": "true"
 spec:
   ingress:
     - from:

--- a/pkg/controller/appdefinition/testdata/networkpolicy/externalname/input.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/externalname/input.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    acorn.io/app-name: my-app
+    acorn.io/app-namespace: acorn
+    acorn.io/managed: "true"
+    acorn.io/service-name: my-service
+  name: service-7777
+  namespace: other-namespace
+spec:
+  rules:
+    - host: myhostname.on-acorn.io
+      http:
+        paths:
+          - backend:
+              service:
+                name: service-7777
+                port:
+                  number: 7777
+            path: /seven
+            pathType: Prefix

--- a/pkg/controller/appdefinition/testdata/networkpolicy/ingress/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/ingress/expected.yaml
@@ -4,6 +4,8 @@ kind: NetworkPolicy
 metadata:
   name: acorn-my-app-my-service-service-7777-9999-10000
   namespace: my-app-namespace
+  labels:
+    "acorn.io/managed": "true"
 spec:
   ingress:
     - from:
@@ -33,6 +35,8 @@ kind: NetworkPolicy
 metadata:
   name: acorn-my-app-my-service-nginx-9090-9090
   namespace: my-app-namespace
+  labels:
+    "acorn.io/managed": "true"
 spec:
   ingress:
     - from:

--- a/pkg/controller/appdefinition/testdata/networkpolicy/service/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/service/expected.yaml
@@ -4,6 +4,8 @@ kind: NetworkPolicy
 metadata:
   name: acorn-my-app-one-publish-one
   namespace: my-app-namespace
+  labels:
+    "acorn.io/managed": "true"
 spec:
   podSelector:
     matchLabels:

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -88,6 +88,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	router.Type(&storagev1.StorageClass{}).HandlerFunc(volume.SyncVolumeClasses)
 	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(appdefinition.NetworkPolicyForService)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(appdefinition.NetworkPolicyForIngress)
+	router.Type(&netv1.Ingress{}).Selector(managedSelector).FinalizeFunc("acorn.io/netpol", appdefinition.NetworkPolicyForIngress)
 
 	configRouter := router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName)
 	configRouter.Handler(config.NewDNSConfigHandler())

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -88,7 +88,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	router.Type(&storagev1.StorageClass{}).HandlerFunc(volume.SyncVolumeClasses)
 	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(appdefinition.NetworkPolicyForService)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(appdefinition.NetworkPolicyForIngress)
-	router.Type(&netv1.Ingress{}).Selector(managedSelector).FinalizeFunc("acorn.io/netpol", appdefinition.NetworkPolicyForIngress)
+	router.Type(&netv1.NetworkPolicy{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)
 
 	configRouter := router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName)
 	configRouter.Handler(config.NewDNSConfigHandler())


### PR DESCRIPTION
re: #456

Using a router and links, it is possible to expose a port in a service in a different namespace than the namespace in which the corresponding Ingress lives. Here is an example:

```cue
containers: "two": {
  image: "nginx:latest"
  ports: "80/http"
  files: {
    "etc/nginx/conf.d/default.conf": """
    server {
      listen 80;
      server_name localhost;
      location /two {
        return 200;
      }
    }
    """
  }
}
```

Run the above Acornfile: `acorn run --name two .`

```cue
services: {
  one: {
    container: "nginx-one"
    ports: ["80/http"]
    default: true
  }
}

routers: default: routes: {
  "/one": "one:80"
  "/two": "two:80"
}

containers: {
  "nginx-one": {
    image: "nginx:latest"
    ports: "80/http"
    files: {
      "/etc/nginx/conf.d/default.conf": """
      server {
        listen 80;
        server_name localhost;
        location /one {
          return 200;
        }
      }
      """
    }
  }
}
```

Run the above Acornfile and link it to the container from the previous one: `acorn run --name one --link two:two .`

This will create an Ingress in `one`'s namespace that routes to an ExternalName Service, which then resolves to a ClusterIP service in `two`'s namespace. I wasn't accounting for this scenario before, so these changes deal with that.

Unfortunately I also had to add a finalizer in here. Since we sometimes create NetworkPolicies in namespaces outside where the owning Ingress lives, if the app that created the Ingress is removed (in this example, `acorn rm one`), the namespace for the app might delete too quickly, and the NetworkPolicy in the other namespace (`two`'s namespace in this example) will get left behind. The finalizer ensures that the NetworkPolicy gets cleaned up properly.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in paranthesis, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keyworkds](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

