### PR TITLE
Remove project placements

### DIFF
--- a/pkg/apis/api.acorn.io/v1/region.go
+++ b/pkg/apis/api.acorn.io/v1/region.go
@@ -30,12 +30,8 @@ func (in *Region) NamespaceScoped() bool {
 	return false
 }
 
-func (in *Region) ForRegion(region string) bool {
+func (in *Region) HasRegion(region string) bool {
 	return in.Spec.RegionName == region
-}
-
-func (in *Region) ForOtherRegions(region string) bool {
-	return in.Spec.RegionName != region
 }
 
 func (in *Region) Conditions() *[]v1.Condition {

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -93,10 +93,10 @@ type ContainerReplicaStatus struct {
 	Region string `json:"region,omitempty"`
 }
 
-// ForRegion checks or sets the region of a ContainerReplica.
-// If a ContainerReplica's region is unset, ForRegion sets it to the given region and returns true.
+// EnsureRegion checks or sets the region of a ContainerReplica.
+// If a ContainerReplica's region is unset, EnsureRegion sets it to the given region and returns true.
 // Otherwise, it returns true if and only if the ContainerReplica belongs to the given region.
-func (in *ContainerReplica) ForRegion(region string) bool {
+func (in *ContainerReplica) EnsureRegion(region string) bool {
 	// If the region of a Container Replica is not set, then it hasn't been synced yet. In this case, we assume that it is in
 	// the same region as the app, and return true.
 	if in.Status.Region == "" {
@@ -104,10 +104,6 @@ func (in *ContainerReplica) ForRegion(region string) bool {
 	}
 
 	return in.Status.Region == region
-}
-
-func (in *ContainerReplica) ForOtherRegions(region string) bool {
-	return in.Status.Region != region
 }
 
 func (in *ContainerReplica) GetRegion() string {
@@ -254,7 +250,10 @@ type VolumeColumns struct {
 	AccessModes string `json:"accessModes,omitempty"`
 }
 
-func (in *Volume) ForRegion(region string) bool {
+// EnsureRegion checks or sets the region of a ContainerReplica.
+// If a ContainerReplica's region is unset, EnsureRegion sets it to the given region and returns true.
+// Otherwise, it returns true if and only if the ContainerReplica belongs to the given region.
+func (in *Volume) EnsureRegion(region string) bool {
 	// If the region of a volume is not set, then it hasn't been synced yet. In this case, we assume that the volume is in
 	// the same region as the app, and return true.
 	if in.Status.Region == "" {
@@ -262,10 +261,6 @@ func (in *Volume) ForRegion(region string) bool {
 	}
 
 	return in.Status.Region == region
-}
-
-func (in *Volume) ForOtherRegions(region string) bool {
-	return in.Status.Region != region
 }
 
 // +k8s:conversion-gen:explicit-from=net/url.Values
@@ -425,15 +420,8 @@ func (in *Project) NamespaceScoped() bool {
 	return false
 }
 
-func (in *Project) ForRegion(region string) bool {
+func (in *Project) HasRegion(region string) bool {
 	return region == "" || in.Status.DefaultRegion == region || slices.Contains(in.Spec.SupportedRegions, region)
-}
-
-func (in *Project) ForOtherRegions(region string) bool {
-	if len(in.Spec.SupportedRegions) == 0 {
-		return false
-	}
-	return len(in.Spec.SupportedRegions) > 1 || in.Spec.SupportedRegions[0] != region
 }
 
 func (in *Project) GetRegion() string {

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -53,6 +53,21 @@ func (in *AppInstance) ForOtherRegions(region string) bool {
 	return in.Spec.Region != "" && in.Spec.Region != region || in.Status.Defaults.Region != "" && in.Status.Defaults.Region != region
 }
 
+func (in *AppInstance) GetRegion() string {
+	if in.Spec.Region != "" {
+		return in.Spec.Region
+	}
+	return in.Status.Defaults.Region
+}
+
+func (in *AppInstance) SetDefaultRegion(region string) {
+	if in.Spec.Region == "" {
+		in.Status.Defaults.Region = region
+	} else {
+		in.Status.Defaults.Region = ""
+	}
+}
+
 func (in *AppInstance) ShortID() string {
 	if len(in.UID) > 11 {
 		return string(in.UID[:12])

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -45,12 +45,8 @@ type AppInstance struct {
 	Status AppInstanceStatus `json:"status,omitempty"`
 }
 
-func (in *AppInstance) ForRegion(region string) bool {
+func (in *AppInstance) HasRegion(region string) bool {
 	return in.Status.Defaults.Region == region || in.Spec.Region == region
-}
-
-func (in *AppInstance) ForOtherRegions(region string) bool {
-	return in.Spec.Region != "" && in.Spec.Region != region || in.Status.Defaults.Region != "" && in.Status.Defaults.Region != region
 }
 
 func (in *AppInstance) GetRegion() string {

--- a/pkg/apis/internal.acorn.io/v1/build.go
+++ b/pkg/apis/internal.acorn.io/v1/build.go
@@ -76,10 +76,27 @@ type AcornImageBuildInstanceStatus struct {
 	AppImage           AppImage    `json:"appImage,omitempty"`
 	Conditions         []Condition `json:"conditions,omitempty"`
 	BuildError         string      `json:"buildError,omitempty"`
+	Region             string      `json:"region,omitempty"`
 }
 
 func (in *AcornImageBuildInstance) Conditions() *[]Condition {
 	return &in.Status.Conditions
+}
+
+func (in *AcornImageBuildInstance) ForRegion(region string) bool {
+	return in.Status.Region == region
+}
+
+func (in *AcornImageBuildInstance) ForOtherRegions(region string) bool {
+	return in.Status.Region != region
+}
+
+func (in *AcornImageBuildInstance) GetRegion() string {
+	return in.Status.Region
+}
+
+func (in *AcornImageBuildInstance) SetDefaultRegion(region string) {
+	in.Status.Region = region
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -106,6 +123,23 @@ type BuilderInstanceStatus struct {
 	Endpoint           string `json:"endpoint,omitempty"`
 	PublicKey          string `json:"publicKey,omitempty"`
 	ServiceName        string `json:"serviceName,omitempty"`
+	Region             string `json:"region,omitempty"`
+}
+
+func (b *BuilderInstance) ForRegion(region string) bool {
+	return b.Status.Region == region
+}
+
+func (b *BuilderInstance) ForOtherRegions(region string) bool {
+	return b.Status.Region != region
+}
+
+func (b *BuilderInstance) GetRegion() string {
+	return b.Status.Region
+}
+
+func (b *BuilderInstance) SetDefaultRegion(region string) {
+	b.Status.Region = region
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/internal.acorn.io/v1/build.go
+++ b/pkg/apis/internal.acorn.io/v1/build.go
@@ -83,12 +83,8 @@ func (in *AcornImageBuildInstance) Conditions() *[]Condition {
 	return &in.Status.Conditions
 }
 
-func (in *AcornImageBuildInstance) ForRegion(region string) bool {
+func (in *AcornImageBuildInstance) HasRegion(region string) bool {
 	return in.Status.Region == region
-}
-
-func (in *AcornImageBuildInstance) ForOtherRegions(region string) bool {
-	return in.Status.Region != region
 }
 
 func (in *AcornImageBuildInstance) GetRegion() string {
@@ -126,12 +122,8 @@ type BuilderInstanceStatus struct {
 	Region             string `json:"region,omitempty"`
 }
 
-func (b *BuilderInstance) ForRegion(region string) bool {
+func (b *BuilderInstance) HasRegion(region string) bool {
 	return b.Status.Region == region
-}
-
-func (b *BuilderInstance) ForOtherRegions(region string) bool {
-	return b.Status.Region != region
 }
 
 func (b *BuilderInstance) GetRegion() string {

--- a/pkg/apis/internal.admin.acorn.io/v1/types.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/types.go
@@ -15,7 +15,8 @@ func (in *ClusterComputeClassInstance) NamespaceScoped() bool {
 	return false
 }
 
-func (in *ClusterComputeClassInstance) ForRegion(region string) bool {
+// EnsureRegion checks that the class supports the region. If it does not, then the region is added.
+func (in *ClusterComputeClassInstance) EnsureRegion(region string) bool {
 	for _, r := range in.SupportedRegions {
 		if r == region {
 			return true
@@ -26,6 +27,7 @@ func (in *ClusterComputeClassInstance) ForRegion(region string) bool {
 }
 
 // ForOtherRegions returns true if there are other regions that this instance is supported in.
+// The region passed here is removed for the supported regions.
 func (in *ClusterComputeClassInstance) ForOtherRegions(region string) bool {
 	regions := make([]string, 0, len(in.SupportedRegions))
 	for _, r := range in.SupportedRegions {

--- a/pkg/apis/internal.admin.acorn.io/v1/types.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/types.go
@@ -27,12 +27,14 @@ func (in *ClusterComputeClassInstance) ForRegion(region string) bool {
 
 // ForOtherRegions returns true if there are other regions that this instance is supported in.
 func (in *ClusterComputeClassInstance) ForOtherRegions(region string) bool {
-	for i, r := range in.SupportedRegions {
-		if r == region {
-			in.SupportedRegions = append(in.SupportedRegions[:i], in.SupportedRegions[i+1:]...)
+	regions := make([]string, 0, len(in.SupportedRegions))
+	for _, r := range in.SupportedRegions {
+		if r != region {
+			regions = append(regions, region)
 		}
 	}
 
+	in.SupportedRegions = regions
 	return len(in.SupportedRegions) > 0
 }
 

--- a/pkg/apis/internal.admin.acorn.io/v1/volumes.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/volumes.go
@@ -42,7 +42,8 @@ func (c *ClusterVolumeClassInstance) NamespaceScoped() bool {
 	return false
 }
 
-func (c *ClusterVolumeClassInstance) ForRegion(region string) bool {
+// EnsureRegion checks that the class supports the region. If it does not, then the region is added.
+func (c *ClusterVolumeClassInstance) EnsureRegion(region string) bool {
 	for _, r := range c.SupportedRegions {
 		if r == region {
 			return true
@@ -53,6 +54,7 @@ func (c *ClusterVolumeClassInstance) ForRegion(region string) bool {
 }
 
 // ForOtherRegions returns true if there are other regions that this instance is supported in.
+// The region passed here is removed for the supported regions.
 func (c *ClusterVolumeClassInstance) ForOtherRegions(region string) bool {
 	regions := make([]string, 0, len(c.SupportedRegions))
 	for _, r := range c.SupportedRegions {

--- a/pkg/apis/internal.admin.acorn.io/v1/volumes.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/volumes.go
@@ -54,12 +54,14 @@ func (c *ClusterVolumeClassInstance) ForRegion(region string) bool {
 
 // ForOtherRegions returns true if there are other regions that this instance is supported in.
 func (c *ClusterVolumeClassInstance) ForOtherRegions(region string) bool {
-	for i, r := range c.SupportedRegions {
-		if r == region {
-			c.SupportedRegions = append(c.SupportedRegions[:i], c.SupportedRegions[i+1:]...)
+	regions := make([]string, 0, len(c.SupportedRegions))
+	for _, r := range c.SupportedRegions {
+		if r != region {
+			regions = append(regions, region)
 		}
 	}
 
+	c.SupportedRegions = regions
 	return len(c.SupportedRegions) > 0
 }
 

--- a/pkg/cli/builder/table/funcs.go
+++ b/pkg/cli/builder/table/funcs.go
@@ -251,8 +251,8 @@ func AppGeneration(app apiv1.App, msg string) string {
 
 func OwnerReferenceName(obj metav1.Object) string {
 	owners := obj.GetOwnerReferences()
-	if len(owners) == 0 || owners[0].Name == "" {
-		return "local"
+	if len(owners) == 0 {
+		return ""
 	}
 
 	return owners[0].Name

--- a/pkg/cli/regions_test.go
+++ b/pkg/cli/regions_test.go
@@ -39,7 +39,7 @@ func TestRegions(t *testing.T) {
 			args:    []string{},
 			quiet:   false,
 			wantErr: false,
-			wantOut: "NAME      ACCOUNT   REGION NAME   CREATED   DESCRIPTION\nlocal     local     us-east-2     10y ago   Test region\n",
+			wantOut: "NAME      ACCOUNT   REGION NAME   CREATED   DESCRIPTION\nlocal               us-east-2     10y ago   Test region\n",
 		},
 		{
 			name: "acorn regions with one region with owner reference",
@@ -92,7 +92,7 @@ func TestRegions(t *testing.T) {
 			args:    []string{},
 			quiet:   false,
 			wantErr: false,
-			wantOut: "NAME      ACCOUNT   REGION NAME   CREATED   DESCRIPTION\nlocal     local     us-east-2     10y ago   Test region\nlocal     local     us-west-2     10y ago   Another test region\n",
+			wantOut: "NAME      ACCOUNT   REGION NAME   CREATED   DESCRIPTION\nlocal               us-east-2     10y ago   Test region\nlocal               us-west-2     10y ago   Another test region\n",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/acornimagebuildinstance/buildinstance.go
+++ b/pkg/controller/acornimagebuildinstance/buildinstance.go
@@ -3,6 +3,7 @@ package acornimagebuildinstance
 import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/acorn/pkg/controller/defaults"
 	"github.com/acorn-io/baaah/pkg/router"
 )
 
@@ -16,4 +17,8 @@ func MarkRecorded(req router.Request, resp router.Response) error {
 	}
 	req.Object.(*v1.AcornImageBuildInstance).Status.Recorded = true
 	return nil
+}
+
+func SetRegion(req router.Request, _ router.Response) error {
+	return defaults.AddDefaultRegion(req.Ctx, req.Client, req.Object.(*v1.AcornImageBuildInstance))
 }

--- a/pkg/controller/builder/region.go
+++ b/pkg/controller/builder/region.go
@@ -1,0 +1,11 @@
+package builder
+
+import (
+	internalv1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/controller/defaults"
+	"github.com/acorn-io/baaah/pkg/router"
+)
+
+func SetRegion(req router.Request, _ router.Response) error {
+	return defaults.AddDefaultRegion(req.Ctx, req.Client, req.Object.(*internalv1.BuilderInstance))
+}

--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -45,7 +45,7 @@ func calculate(req router.Request, appInstance *internalv1.AppInstance) error {
 		return err
 	}
 
-	if err = addDefaultRegion(req.Ctx, req.Client, appInstance); err != nil {
+	if err = AddDefaultRegion(req.Ctx, req.Client, appInstance); err != nil {
 		return err
 	}
 

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -68,8 +68,10 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 
 	router.Type(&v1.ServiceInstance{}).HandlerFunc(service.RenderServices)
 
+	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.SetRegion)
 	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.DeployBuilder)
 
+	router.Type(&v1.AcornImageBuildInstance{}).HandlerFunc(acornimagebuildinstance.SetRegion)
 	router.Type(&v1.AcornImageBuildInstance{}).HandlerFunc(acornimagebuildinstance.MarkRecorded)
 
 	router.Type(&v1.ServiceInstance{}).HandlerFunc(gc.GCOrphans)

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -2159,6 +2159,12 @@ func schema_pkg_apis_apiacornio_v1_ContainerReplicaStatus(ref common.ReferenceCa
 							Format: "",
 						},
 					},
+					"region": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"ready", "restartCount", "image", "imageID"},
 			},
@@ -3113,12 +3119,6 @@ func schema_pkg_apis_apiacornio_v1_ProjectStatus(ref common.ReferenceCallback) c
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"placement": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -4372,6 +4372,12 @@ func schema_pkg_apis_internalacornio_v1_AcornImageBuildInstanceStatus(ref common
 							Format: "",
 						},
 					},
+					"region": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -5405,6 +5411,12 @@ func schema_pkg_apis_internalacornio_v1_BuilderInstanceStatus(ref common.Referen
 						},
 					},
 					"serviceName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"region": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -368,11 +368,8 @@ func (s *Validator) checkScheduling(ctx context.Context, params *apiv1.App, proj
 	var (
 		memory        = params.Spec.Memory
 		computeClass  = params.Spec.ComputeClass
-		defaultRegion = project.Spec.DefaultRegion
+		defaultRegion = project.GetRegion()
 	)
-	if defaultRegion == "" {
-		defaultRegion = project.Status.DefaultRegion
-	}
 
 	var validationErrors []*field.Error
 	err := validateMemoryRunFlags(memory, workloads)
@@ -458,11 +455,7 @@ func validateVolumeClasses(ctx context.Context, c kclient.Client, namespace stri
 		return nil
 	}
 
-	defaultRegion := project.Spec.DefaultRegion
-	if defaultRegion == "" {
-		defaultRegion = project.Status.DefaultRegion
-	}
-
+	defaultRegion := project.GetRegion()
 	volumeClasses, defaultVolumeClass, err := volume.GetVolumeClasses(ctx, c, namespace)
 	if err != nil {
 		return field.Invalid(field.NewPath("spec", "image"), appInstanceSpec.Image, err.Error())

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -158,7 +158,7 @@ func (s *Validator) validateRegion(app *apiv1.App, project *apiv1.Project) error
 		return nil
 	}
 
-	if !project.ForRegion(app.Spec.Region) {
+	if !project.HasRegion(app.Spec.Region) {
 		return fmt.Errorf("region %s is not supported for project %s", app.Spec.Region, app.Namespace)
 	}
 

--- a/pkg/server/registry/apigroups/acorn/projects/validator.go
+++ b/pkg/server/registry/apigroups/acorn/projects/validator.go
@@ -24,7 +24,7 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) field.Erro
 	// Reset the default region on status to indicate that a "real" default is set.
 	project.Status.DefaultRegion = ""
 
-	if !project.ForRegion(project.Spec.DefaultRegion) {
+	if !project.HasRegion(project.Spec.DefaultRegion) {
 		return append(result, field.Invalid(field.NewPath("spec", "defaultRegion"), project.Spec.DefaultRegion, "default region is not in the supported regions list"))
 	}
 

--- a/pkg/server/registry/apigroups/acorn/regions/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/regions/strategy.go
@@ -28,6 +28,11 @@ func (s *strategy) Get(_ context.Context, _, name string) (types.Object, error) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "local",
 			CreationTimestamp: s.startTime,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "local",
+				},
+			},
 		},
 		Spec: apiv1.RegionSpec{
 			Description: "Local Region",


### PR DESCRIPTION
In order to remove project placements, the role of regions is expanded. More objects are designated as regioned and more methods to get and set the region are added.

