### PR TITLE
fix: signature verification registry authentication and rate limits (#1412 & #1414)

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -11,11 +11,9 @@ import (
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/imagesystem"
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/oci"
@@ -31,7 +29,8 @@ import (
 )
 
 type VerifyOpts struct {
-	ImageRef           string
+	ImageRef           name.Digest
+	SignatureRef       name.Reference
 	Namespace          string
 	AnnotationRules    v1.SignatureAnnotations
 	Key                string
@@ -41,15 +40,14 @@ type VerifyOpts struct {
 	NoCache            bool
 }
 
-// VerifySignature checks if the image is signed with the given key and if the annotations match the given rules
-// This does a lot of image and image manifest juggling to fetch artifacts, digests, etc. from the registry, so we have to be
-// careful to not do too many GET requests that count against registry rate limits (e.g. for DockerHub).
-// Crane uses HEAD (with GET as a fallback) wherever it can, so it's a good choice here e.g. for fetching digests.
-func VerifySignature(ctx context.Context, c client.Reader, opts VerifyOpts) error {
+// EnsureReferences will enrich the VerifyOpts with the image digest and signature reference.
+// It's outsourced here, so we can ensure that it's used as few times as possible to reduce the number of potential
+// GET requests to the registry which would count against potential rate limits.
+func EnsureReferences(ctx context.Context, c client.Reader, img string, opts *VerifyOpts) error {
 	// --- image name to digest hash
-	imgRef, err := name.ParseReference(opts.ImageRef)
+	imgRef, err := name.ParseReference(img)
 	if err != nil {
-		return fmt.Errorf("failed to parse image %s: %w", opts.ImageRef, err)
+		return fmt.Errorf("failed to parse image %s: %w", img, err)
 	}
 
 	imgDigest, err := crane.Digest(imgRef.Name(), opts.CraneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
@@ -57,9 +55,95 @@ func VerifySignature(ctx context.Context, c client.Reader, opts VerifyOpts) erro
 		return fmt.Errorf("failed to resolve image digest: %w", err)
 	}
 
-	imgRef = imgRef.Context().Digest(imgDigest)
+	opts.ImageRef = imgRef.Context().Digest(imgDigest)
 
-	imgDigestHash, err := ggcrv1.NewHash(imgDigest)
+	signatureRef, err := ensureSignatureArtifact(ctx, c, opts.Namespace, opts.ImageRef, opts.NoCache, opts.OciRemoteOpts, opts.CraneOpts)
+	if err != nil {
+		return fmt.Errorf("failed to ensure signature artifact: %w", err)
+	}
+	opts.SignatureRef = signatureRef
+
+	return nil
+}
+
+func ensureSignatureArtifact(ctx context.Context, c client.Reader, namespace string, img name.Digest, noCache bool, ociRemoteOpts []ociremote.Option, craneOpts []crane.Option) (name.Reference, error) {
+	// -- signature hash
+	sigTag, err := ociremote.SignatureTag(img, ociRemoteOpts...) // we force imgRef to be a digest above, so this should *not* make a GET request to the registry
+	if err != nil {
+		return nil, fmt.Errorf("failed to get signature tag: %w", err)
+	}
+
+	sigDigest, err := crane.Digest(sigTag.Name(), craneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
+	if err != nil {
+		if terr, ok := err.(*transport.Error); ok && terr.StatusCode == http.StatusNotFound {
+			// signature artifact not found -> that's an actual verification error
+			return nil, fmt.Errorf("%w: expected signature artifact %s not found", cosign.ErrNoMatchingSignatures, sigTag.Name())
+		}
+		return nil, fmt.Errorf("failed to get signature digest: %w", err)
+	}
+
+	sigRefToUse, err := name.ParseReference(sigTag.Name(), name.WeakValidation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse signature reference: %w", err)
+	}
+	logrus.Debugf("Signature %s has digest: %s", sigRefToUse.Name(), sigDigest)
+
+	if !noCache {
+		internalRepo, _, err := imagesystem.GetInternalRepoForNamespace(ctx, c, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get internal repo for namespace %s: %w", namespace, err)
+		}
+
+		localSignatureArtifact := fmt.Sprintf("%s:%s", internalRepo, sigTag.Identifier())
+
+		// --- check if we have the signature artifact locally, if not, copy it over from external registry
+		mustPull := false
+		localSigSHA, err := crane.Digest(localSignatureArtifact, craneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
+		if err != nil {
+			var terr *transport.Error
+			if ok := errors.As(err, &terr); ok && terr.StatusCode == http.StatusNotFound {
+				logrus.Debugf("signature artifact %s not found locally, will try to pull it", localSignatureArtifact)
+				mustPull = true
+			} else {
+				return nil, fmt.Errorf("failed to get local signature digest, cannot check if we have it cached locally: %w", err)
+			}
+		} else if localSigSHA != sigDigest {
+			logrus.Debugf("Local signature digest %s does not match remote signature digest %s, will try to pull it", localSigSHA, sigDigest)
+			mustPull = true
+		}
+
+		if mustPull {
+			// --- pull signature artifact
+			err := crane.Copy(sigTag.Name(), localSignatureArtifact, craneOpts...) // Pull (GET) counts against the rate limits, so this shouldn't be done too often
+			if err != nil {
+				return nil, fmt.Errorf("failed to copy signature artifact: %w", err)
+			}
+		}
+
+		lname, err := name.ParseReference(localSignatureArtifact, name.WeakValidation)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse local signature artifact %s: %w", localSignatureArtifact, err)
+		}
+
+		sigRefToUse = lname
+
+		logrus.Debugf("Checking if image %s is signed with %s (cache: %s)", img, sigTag, localSignatureArtifact)
+	}
+
+	return sigRefToUse, nil
+}
+
+// VerifySignature checks if the image is signed with the given key and if the annotations match the given rules
+// This does a lot of image and image manifest juggling to fetch artifacts, digests, etc. from the registry, so we have to be
+// careful to not do too many GET requests that count against registry rate limits (e.g. for DockerHub).
+// Crane uses HEAD (with GET as a fallback) wherever it can, so it's a good choice here e.g. for fetching digests.
+func VerifySignature(ctx context.Context, opts VerifyOpts) error {
+	sigs, err := ociremote.Signatures(opts.SignatureRef, opts.OciRemoteOpts...) // this runs against our internal registry, so it should not count against the rate limits
+	if err != nil {
+		return fmt.Errorf("failed to get signatures: %w", err)
+	}
+
+	imgDigestHash, err := ggcrv1.NewHash(opts.ImageRef.DigestStr())
 	if err != nil {
 		return err
 	}
@@ -81,74 +165,6 @@ func VerifySignature(ctx context.Context, c client.Reader, opts VerifyOpts) erro
 		cosignOpts.SigVerifier = verifier
 	}
 
-	// -- signature hash
-	sigTag, err := ociremote.SignatureTag(imgRef, opts.OciRemoteOpts...) // we force imgRef to be a digest above, so this should *not* make a GET request to the registry
-	if err != nil {
-		return fmt.Errorf("failed to get signature tag: %w", err)
-	}
-
-	sigDigest, err := crane.Digest(sigTag.Name(), opts.CraneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
-	if err != nil {
-		if terr, ok := err.(*transport.Error); ok && terr.StatusCode == http.StatusNotFound {
-			// signature artifact not found -> that's an actual verification error
-			return fmt.Errorf("%w: expected signature artifact %s not found", cosign.ErrNoMatchingSignatures, sigTag.Name())
-		}
-		return fmt.Errorf("failed to get signature digest: %w", err)
-	}
-
-	sigRefToUse, err := name.ParseReference(sigTag.Name(), name.WeakValidation)
-	if err != nil {
-		return fmt.Errorf("failed to parse signature reference: %w", err)
-	}
-	logrus.Debugf("Signature %s has digest: %s", sigRefToUse.Name(), sigDigest)
-
-	if !opts.NoCache {
-		internalRepo, _, err := imagesystem.GetInternalRepoForNamespace(ctx, c, opts.Namespace)
-		if err != nil {
-			return fmt.Errorf("failed to get internal repo for namespace %s: %w", opts.Namespace, err)
-		}
-
-		localSignatureArtifact := fmt.Sprintf("%s:%s", internalRepo, sigTag.Identifier())
-
-		// --- check if we have the signature artifact locally, if not, copy it over from external registry
-		mustPull := false
-		localSigSHA, err := crane.Digest(localSignatureArtifact, opts.CraneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
-		if err != nil {
-			var terr *transport.Error
-			if ok := errors.As(err, &terr); ok && terr.StatusCode == http.StatusNotFound {
-				logrus.Debugf("signature artifact %s not found locally, will try to pull it", localSignatureArtifact)
-				mustPull = true
-			} else {
-				return fmt.Errorf("failed to get local signature digest, cannot check if we have it cached locally: %w", err)
-			}
-		} else if localSigSHA != sigDigest {
-			logrus.Debugf("Local signature digest %s does not match remote signature digest %s, will try to pull it", localSigSHA, sigDigest)
-			mustPull = true
-		}
-
-		if mustPull {
-			// --- pull signature artifact
-			err := crane.Copy(sigTag.Name(), localSignatureArtifact, opts.CraneOpts...) // Pull (GET) counts against the rate limits, so this shouldn't be done too often
-			if err != nil {
-				return fmt.Errorf("failed to copy signature artifact: %w", err)
-			}
-		}
-
-		lname, err := name.ParseReference(localSignatureArtifact, name.WeakValidation)
-		if err != nil {
-			return fmt.Errorf("failed to parse local signature artifact %s: %w", localSignatureArtifact, err)
-		}
-
-		sigRefToUse = lname
-
-		logrus.Debugf("Checking if image %s is signed with %s (cache: %s)", imgRef, sigTag, localSignatureArtifact)
-	}
-
-	sigs, err := ociremote.Signatures(sigRefToUse, ociremote.WithRemoteOptions(remote.WithAuthFromKeychain(authn.DefaultKeychain))) // this runs against our internal registry, so it should not count against the rate limits
-	if err != nil {
-		return fmt.Errorf("failed to get signatures: %w", err)
-	}
-
 	// --- get and verify signatures
 	signatures, bundlesVerified, err := verifySignatures(ctx, sigs, imgDigestHash, cosignOpts)
 	if err != nil {
@@ -158,7 +174,7 @@ func VerifySignature(ctx context.Context, c client.Reader, opts VerifyOpts) erro
 		return fmt.Errorf("failed to verify image signatures: %w", err)
 	}
 
-	logrus.Debugf("image %s: %d signatures verified (bundle verified: %v)", imgRef, len(signatures), bundlesVerified)
+	logrus.Debugf("image %s: %d signatures verified (bundle verified: %v)", opts.ImageRef.Name(), len(signatures), bundlesVerified)
 
 	// --- extract payloads for subsequent checks
 	payloads, err := extractPayload(signatures)
@@ -173,7 +189,7 @@ func VerifySignature(ctx context.Context, c client.Reader, opts VerifyOpts) erro
 		}
 		return fmt.Errorf("failed to check annotations: %w", err)
 	}
-	logrus.Debugf("image %s: Annotations (%+v) verified", imgRef, opts.AnnotationRules)
+	logrus.Debugf("image %s: Annotations (%+v) verified", opts.ImageRef.Name(), opts.AnnotationRules)
 
 	return nil
 }

--- a/pkg/imageallowrules/imageallowrules.go
+++ b/pkg/imageallowrules/imageallowrules.go
@@ -7,6 +7,8 @@ import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/cosign"
 	"github.com/acorn-io/acorn/pkg/images"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/rancher/wrangler/pkg/merr"
 	ocosign "github.com/sigstore/cosign/pkg/cosign"
@@ -44,10 +46,15 @@ func CheckImageAllowed(ctx context.Context, c client.Reader, namespace, image st
 		return err
 	}
 
-	return CheckImageAgainstRules(ctx, c, namespace, image, rulesList.Items, opts...)
+	keychain, err := images.GetAuthenticationRemoteKeychainWithLocalAuth(ctx, nil, nil, c, namespace)
+	if err != nil {
+		return err
+	}
+
+	return CheckImageAgainstRules(ctx, c, namespace, image, rulesList.Items, keychain, opts...)
 }
 
-func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace string, image string, imageAllowRules []v1.ImageAllowRuleInstance, opts ...remote.Option) error {
+func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace string, image string, imageAllowRules []v1.ImageAllowRuleInstance, keychain authn.Keychain, opts ...remote.Option) error {
 	if len(imageAllowRules) == 0 {
 		// No ImageAllowRules found, so allow the image
 		return nil
@@ -62,7 +69,8 @@ func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace stri
 		AnnotationRules:    v1.SignatureAnnotations{},
 		Key:                "",
 		SignatureAlgorithm: "sha256", // FIXME: make signature algorithm configurable (?)
-		RegistryClientOpts: []ociremote.Option{ociremote.WithRemoteOptions(opts...)},
+		OciRemoteOpts:      []ociremote.Option{ociremote.WithRemoteOptions(opts...)},
+		CraneOpts:          []crane.Option{crane.WithContext(ctx), crane.WithAuthFromKeychain(keychain)},
 	}
 	for _, imageAllowRule := range imageAllowRules {
 		notAllowedErr := &ErrImageNotAllowed{Rule: fmt.Sprintf("%s/%s", imageAllowRule.Namespace, imageAllowRule.Name), Image: image}

--- a/pkg/images/operations.go
+++ b/pkg/images/operations.go
@@ -162,7 +162,7 @@ func GetImageReference(ctx context.Context, c client.Reader, namespace, image st
 	return imagename.ParseReference(image)
 }
 
-func GetAuthenticationRemoteOptionsWithLocalAuth(ctx context.Context, registry authn.Resource, localAuth *apiv1.RegistryAuth, client client.Reader, namespace string, additionalOpts ...remote.Option) ([]remote.Option, error) {
+func GetAuthenticationRemoteKeychainWithLocalAuth(ctx context.Context, registry authn.Resource, localAuth *apiv1.RegistryAuth, client client.Reader, namespace string) (authn.Keychain, error) {
 	authn, err := pullsecret.Keychain(ctx, client, namespace)
 	if err != nil {
 		return nil, err
@@ -170,6 +170,15 @@ func GetAuthenticationRemoteOptionsWithLocalAuth(ctx context.Context, registry a
 
 	if localAuth != nil {
 		authn = NewSimpleKeychain(registry, *localAuth, authn)
+	}
+
+	return authn, nil
+}
+
+func GetAuthenticationRemoteOptionsWithLocalAuth(ctx context.Context, registry authn.Resource, localAuth *apiv1.RegistryAuth, client client.Reader, namespace string, additionalOpts ...remote.Option) ([]remote.Option, error) {
+	authn, err := GetAuthenticationRemoteKeychainWithLocalAuth(ctx, registry, localAuth, client, namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	result := []remote.Option{


### PR DESCRIPTION
## About

- Ref:  #1412 
- Ref: #1414 

- before, crane functions used the default keychain instead of the one derived from the Acorn environment
- before, we used ociremote functions to determine the digests, which defaulted to GET requests that count against e.g. DockerHub's pull rate limits -> switching to crane functions should help here
- additionally, the refactored code will call those digest and pull functions at most once and not, as before, for every signature that we check in a rule

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

