### PR TITLE
refactor cli/run_test.go to use gomock

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -208,6 +208,9 @@ func (s RunArgs) ToOpts() (client.AppRunOptions, error) {
 	return opts, nil
 }
 
+// isDirectory checks that the path from the provided directory
+// point to a directory. If it does not point to a directory and it points at a file,
+// it errors. Otherwise, the function returns false.
 func isDirectory(cwd string) (bool, error) {
 	if s, err := os.Stat(cwd); os.IsNotExist(err) {
 		return false, nil

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -1,10 +1,20 @@
 package cli
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/acorn-io/acorn/pkg/client"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/mocks"
+	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/acorn-io/acorn/pkg/cli/testdata"
 	"github.com/spf13/cobra"
@@ -28,41 +38,80 @@ func TestRunArgs_Env(t *testing.T) {
 	assert.Equal(t, "1", opts.Env[1].Value)
 }
 
-func TestRunMemory(t *testing.T) {
+func TestRun(t *testing.T) {
+	baseMock := func(f *mocks.MockClient) {
+		f.EXPECT().AppGet(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, name string) (*apiv1.App, error) {
+				switch name {
+				case "dne":
+					return nil, fmt.Errorf("error: app %s does not exist", name)
+				case "found":
+					return &apiv1.App{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "found"},
+						Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
+						Status:     v1.AppInstanceStatus{Ready: true},
+					}, nil
+				case "found.container":
+					return &apiv1.App{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
+						Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
+						Status:     v1.AppInstanceStatus{},
+					}, nil
+				}
+				return nil, nil
+			}).AnyTimes()
+		f.EXPECT().AppRun(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, image string, opts *client.AppRunOptions) (*apiv1.App, error) {
+				switch image {
+				case "dne":
+					return nil, fmt.Errorf("error: app %s does not exist", image)
+				case "found":
+					return &apiv1.App{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "found"},
+						Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
+						Status:     v1.AppInstanceStatus{Ready: true},
+					}, nil
+				case "found.container":
+					return &apiv1.App{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "found.container"},
+						Spec:       v1.AppInstanceSpec{Secrets: []v1.SecretBinding{{Secret: "found.secret", Target: "found"}}},
+						Status:     v1.AppInstanceStatus{},
+					}, nil
+				}
+				return nil, fmt.Errorf("error: app %s does not exist", image)
+			}).AnyTimes()
+	}
+
 	type fields struct {
-		All   bool
-		Type  []string
-		Force bool
+		Quiet  bool
+		Output string
+		All    bool
+		Force  bool
 	}
 	type args struct {
-		cmd    *cobra.Command
-		args   []string
-		client *testdata.MockClient
+		cmd  *cobra.Command
+		args []string
 	}
-	var _, w, _ = os.Pipe()
 	tests := []struct {
-		name           string
-		fields         fields
-		args           args
-		wantErr        bool
-		wantOut        string
-		commandContext CommandContext
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		wantOut string
+		prepare func(t *testing.T, f *mocks.MockClient)
 	}{
 		{
 			name: "acorn run -h", fields: fields{
 				All:   false,
-				Type:  nil,
 				Force: true,
 			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
-			},
+
 			args: args{
-				args:   []string{"-h"},
-				client: &testdata.MockClient{},
+				args: []string{"-h"},
 			},
 			wantErr: false,
 			wantOut: "./testdata/run/acorn_run_help.txt",
@@ -70,18 +119,21 @@ func TestRunMemory(t *testing.T) {
 		{
 			name: "acorn run -m found.container=256Miii found ", fields: fields{
 				All:   false,
-				Type:  nil,
 				Force: true,
 			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
-			},
 			args: args{
-				args:   []string{"-m found.container=256Miii", "found"},
-				client: &testdata.MockClient{},
+				args: []string{"-m found.container=256Miii", "found"},
+			},
+			prepare: func(t *testing.T, f *mocks.MockClient) {
+				t.Helper()
+				f.EXPECT().Info(gomock.Any()).Return(
+					[]apiv1.Info{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec:       apiv1.InfoSpec{},
+						},
+					}, nil)
 			},
 			wantErr: true,
 			wantOut: "invalid number \"256Miii\"",
@@ -89,30 +141,156 @@ func TestRunMemory(t *testing.T) {
 		{
 			name: "acorn run -m found.container=notallowed found ", fields: fields{
 				All:   false,
-				Type:  nil,
 				Force: true,
 			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
-			},
+
 			args: args{
-				args:   []string{"-m found.container=notallowed", "found"},
-				client: &testdata.MockClient{},
+				args: []string{"-m found.container=notallowed", "found"},
+			},
+			prepare: func(t *testing.T, f *mocks.MockClient) {
+				t.Helper()
+				f.EXPECT().Info(gomock.Any()).Return(
+					[]apiv1.Info{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec:       apiv1.InfoSpec{},
+						},
+					}, nil)
 			},
 			wantErr: true,
 			wantOut: "illegal number start \"notallowed\"",
 		},
+		{
+			name: "acorn run app name already in use", fields: fields{
+				All:   false,
+				Force: true,
+			},
+
+			args: args{
+				args: []string{"-n=found", "run-name"},
+			},
+			prepare: func(t *testing.T, f *mocks.MockClient) {
+				t.Helper()
+			},
+			wantErr: true,
+			wantOut: "app \"found\" already exists",
+		},
+		{
+			name: "acorn run ./folder but folder doesn't exist", fields: fields{
+				All:   false,
+				Force: true,
+			},
+
+			args: args{
+				args: []string{"./folder"},
+			},
+			prepare: func(t *testing.T, f *mocks.MockClient) {
+				t.Helper()
+				f.EXPECT().Info(gomock.Any()).Return(
+					[]apiv1.Info{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec:       apiv1.InfoSpec{},
+						},
+					}, nil)
+			},
+			wantErr: true,
+			wantOut: "error: app ./folder does not exist",
+		},
+		{
+			name: "acorn_run_pointed_at_working_dir_without_acornfile", fields: fields{
+				All:   false,
+				Force: true,
+			},
+
+			args: args{
+				args: []string{"."},
+			},
+			prepare: func(t *testing.T, f *mocks.MockClient) {
+				t.Helper()
+				f.EXPECT().Info(gomock.Any()).Return(
+					[]apiv1.Info{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec:       apiv1.InfoSpec{},
+						},
+					}, nil)
+			},
+			wantErr: true,
+			wantOut: "open Acornfile: no such file or directory",
+		},
+		{
+			name: "acorn_run_points_at_file", fields: fields{
+				All:   false,
+				Force: true,
+			},
+			args: args{
+				args: []string{"Acornfile_temp"},
+			},
+			prepare: func(t *testing.T, f *mocks.MockClient) {
+				t.Helper()
+				// Create a placeholder acorn file
+				dir, err := os.Getwd()
+				if err != nil {
+					t.Fatalf("failed to get current working directory: %v", err)
+				}
+				file, err := os.Create(dir + "/Acornfile_temp")
+				if err != nil {
+					t.Fatalf("failed to get current working directory: %v", err)
+				}
+				t.Cleanup(func() { os.Remove(file.Name()) })
+
+				if _, err = file.Write([]byte("content")); err != nil {
+					t.Fatal(err.Error())
+				}
+				if err = file.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err != nil {
+					t.Fatal()
+				}
+
+				f.EXPECT().Info(gomock.Any()).Return(
+					[]apiv1.Info{
+						{
+							TypeMeta:   metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec:       apiv1.InfoSpec{},
+						},
+					}, nil)
+			},
+			wantErr: true,
+			wantOut: "Acornfile_temp is not a directory",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			//Mocked client for cli's client calls.
+			mClient := mocks.NewMockClient(ctrl)
+
+			baseMock(mClient)
+			if tt.prepare != nil {
+				tt.prepare(t, mClient)
+			}
+
 			r, w, _ := os.Pipe()
 			os.Stdout = w
-			tt.args.cmd = NewRun(tt.commandContext)
+			// Mock client factory just returns the gomock client.
+			tt.args.cmd = NewRun(CommandContext{
+				ClientFactory: &testdata.MockClientFactoryManual{
+					Client: mClient,
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader(""),
+			})
 			tt.args.cmd.SetArgs(tt.args.args)
 			err := tt.args.cmd.Execute()
+
 			if err != nil && !tt.wantErr {
 				assert.Failf(t, "got err when err not expected", "got err: %s", err.Error())
 			} else if err != nil && tt.wantErr {
@@ -120,8 +298,11 @@ func TestRunMemory(t *testing.T) {
 			} else {
 				w.Close()
 				out, _ := io.ReadAll(r)
-				testOut, _ := os.ReadFile(tt.wantOut)
-				assert.Equal(t, string(testOut), string(out))
+				wantOut := tt.wantOut
+				if testOut, err := os.ReadFile(tt.wantOut); err == nil {
+					wantOut = string(testOut)
+				}
+				assert.Equal(t, wantOut, string(out))
 			}
 		})
 	}


### PR DESCRIPTION
Refactored cli/run_test.go to use gomock and changed the behavior of IsDirectory to be more intuitive.

Working on adding tests to identify the alias issue in acorn run -v. This involved refactoring the run tests, so figured I'd submit this in a separate PR change to make reviews easier.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

