### PR TITLE
fix faq to allow docker credentials to be used for acorn cmds (#1334)

### DIFF
--- a/docs/docs/110-faq.md
+++ b/docs/docs/110-faq.md
@@ -60,14 +60,27 @@ If the endpoint is non-HTTP, like TCP, your cluster needs the ability to support
 
 If you are experiencing rate limiting issues from DockerHub, you can log in to your account to increase the number of requests.
 
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: index.docker.io
+  labels:
+    acorn.io/credential: "true"
+type: acorn.io/credential
+data:
+  username: # base64-encoded username
+  password: # base64-encoded password
+  serverAddress: # base64-encoded "index.docker.io"
+```
+
 ```shell
-#create a secret that includes docker account credentials
-kubectl create secret docker-registry <secret-name> --docker-server=https://index.docker.io/v1/ --docker-username=<docker-username> --docker-password=<docker-password> -n acorn-image-system
+#apply yaml to the acorn-image-system namespace
+kubectl apply -f dockersecret.yaml -n acorn-image-system
 
 #verify secret was created
 kubectl get secrets -n acorn-image-system
 
-#add the secret to the default service account
-kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "<secret-name>"}]}' -n acorn-image-system
+#acorn build/push/pull will now use these credentials
 ```
 


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
#1334 
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

