### PR TITLE
Disable NetworkPolicies for the nightly EKS test

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -47,6 +47,7 @@ jobs:
           if acorn check; then
             acorn uninstall -af
           fi
+          # Install Acorn with NetworkPolicies disabled because EKS does not enforce them, so tests will fail if we leave them enabled
           acorn install --image ghcr.io/acorn-io/acorn:main --network-policies=false
           
         env:

--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -47,7 +47,7 @@ jobs:
           if acorn check; then
             acorn uninstall -af
           fi
-          acorn install --image ghcr.io/acorn-io/acorn:main
+          acorn install --image ghcr.io/acorn-io/acorn:main --network-policies=false
           
         env:
           KUBECONFIG: "/home/runner/.kube/config"


### PR DESCRIPTION
Unless/until we have EKS using a CNI that enforces NetworkPolicies, we should disable them on our nightly test so that the test that relies on them will skip instead of just failing.

