### PR TITLE
Changes to prevent pull every upgrade interval for private images (#1398)

### DIFF
--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -194,7 +194,7 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 			// If we have autoUpgradeTagPattern, we need to use it to compare the current tag against all the tags
 			tagPattern, isPattern := AutoUpgradePattern(app.Spec.Image)
 			if isPattern {
-				nextAppImage, updated, err = findLatestTagForImageWithPattern(ctx, d.client, imageKey.namespace, imageKey.image, tagPattern)
+				nextAppImage, updated, err = findLatestTagForImageWithPattern(ctx, d.client, current.Identifier(), imageKey.namespace, imageKey.image, tagPattern)
 				if err != nil {
 					logrus.Errorf("Problem finding latest tag for app %v: %v", appKey, err)
 					continue

--- a/pkg/autoupgrade/daemon_test.go
+++ b/pkg/autoupgrade/daemon_test.go
@@ -185,10 +185,11 @@ func TestRefreshImages(t *testing.T) {
 	thirtySecondsAgo := now.Add(-30 * time.Second)
 	ptrTrue := &[]bool{true}[0]
 	appImages := map[string]string{
-		"test-1":      "acorn/test-1:v#.#.#",
-		"acorn-1":     "docker.io/acorn/acorn-1:v1.1.1-*",
-		"enabled-app": "docker.io/acorn/enabled:latest",
-		"notify-app":  "docker.io/acorn/notify:latest",
+		"test-1":           "acorn/test-1:v#.#.#",
+		"acorn-1":          "docker.io/acorn/acorn-1:v1.1.1-*",
+		"enabled-app":      "docker.io/acorn/enabled:latest",
+		"notify-app":       "docker.io/acorn/notify:latest",
+		"test-autoupgrade": "index.docker.io/acorn/test-autoupgrade:v#.#.#",
 	}
 	apps := make(map[kclient.ObjectKey]v1.AppInstance, len(appImages))
 	for _, entry := range typed.Sorted(appImages) {
@@ -343,27 +344,25 @@ func TestRefreshImages(t *testing.T) {
 		},
 		{
 			name:                   "Auto refresh tag with multiple remote tags with latest tag image denied and current being an older image",
-			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1", "v1.1.2"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-1:v1.1.2": {}}},
-			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
-			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-1:v1.1.1", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
-			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
-			appsUpdated:            map[string]string{"test-1": "index.docker.io/acorn/test-1:v1.1.1"},
+			client:                 &mockDaemonClient{remoteImageDigest: "sha256:acorn1234index.docker.io/acorn/test-autoupgradeabcd", remoteTags: []string{"v1.1.1", "v1.1.2"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-autoupgrade:v1.1.2": {}}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-autoupgrade"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-autoupgrade:v1.1.1", namespace: "acorn"}: {router.Key("acorn", "test-autoupgrade")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-autoupgrade"): now},
 		},
 		{
 			name:                   "Auto refresh tag with multiple remote tags with latest tag image denied and current being latest image",
-			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1", "v1.1.2"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-1:v1.1.2": {}}},
-			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
-			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-1:v1.1.2", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
-			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
-			appsUpdated:            map[string]string{"test-1": "index.docker.io/acorn/test-1:v1.1.2"},
+			client:                 &mockDaemonClient{remoteImageDigest: "sha256:acorn1234index.docker.io/acorn/test-autoupgradeabcd", remoteTags: []string{"v1.1.1", "v1.1.2"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-autoupgrade:v1.1.2": {}}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-autoupgrade"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-autoupgrade:v1.1.2", namespace: "acorn"}: {router.Key("acorn", "test-autoupgrade")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-autoupgrade"): now},
 		},
 		{
 			name:                   "Auto refresh tag with multiple remote tags with non-latest tag image denied and current being the oldest image",
-			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1", "v1.1.2", "v1.1.3"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-1:v1.1.2": {}}},
-			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
-			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-1", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
-			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
-			appsUpdated:            map[string]string{"test-1": "index.docker.io/acorn/test-1:v1.1.3"},
+			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1", "v1.1.2", "v1.1.3"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-autoupgrade:v1.1.2": {}}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-autoupgrade"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-autoupgrade", namespace: "acorn"}: {router.Key("acorn", "test-autoupgrade")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-autoupgrade"): now},
+			appsUpdated:            map[string]string{"test-autoupgrade": "index.docker.io/acorn/test-autoupgrade:v1.1.3"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/autoupgrade/daemon_test.go
+++ b/pkg/autoupgrade/daemon_test.go
@@ -25,6 +25,7 @@ type mockDaemonClient struct {
 	localTags, remoteTags               []string
 	remoteImageDigest, resolvedLocalTag string
 	localTagFound                       bool
+	imageDenyList                       map[string]struct{}
 }
 
 func (m *mockDaemonClient) getConfig(_ context.Context) (*apiv1.Config, error) {
@@ -63,8 +64,11 @@ func (m *mockDaemonClient) resolveLocalTag(context.Context, string, string) (str
 	return m.resolvedLocalTag, m.localTagFound, nil
 }
 
-func (m *mockDaemonClient) checkImageAllowed(context.Context, string, string) error {
-	return nil // TODO: use some switch to mock an error e.g. based on mockDaemonClient.imageDenyList
+func (m *mockDaemonClient) checkImageAllowed(_ context.Context, _ string, img string) error {
+	if _, ok := m.imageDenyList[img]; ok {
+		return fmt.Errorf("Mock error - Image %s Denied", img)
+	}
+	return nil
 }
 
 func TestDetermineAppsToRefresh(t *testing.T) {
@@ -336,6 +340,30 @@ func TestRefreshImages(t *testing.T) {
 			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "docker.io/acorn/notify", namespace: "acorn"}: {router.Key("acorn", "notify-app")}},
 			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "notify-app"): now},
 			appsUpdated:            map[string]string{"notify-app": "docker.io/acorn/notify"},
+		},
+		{
+			name:                   "Auto refresh tag with multiple remote tags with latest tag image denied and current being an older image",
+			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1", "v1.1.2"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-1:v1.1.2": {}}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-1:v1.1.1", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
+			appsUpdated:            map[string]string{"test-1": "index.docker.io/acorn/test-1:v1.1.1"},
+		},
+		{
+			name:                   "Auto refresh tag with multiple remote tags with latest tag image denied and current being latest image",
+			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1", "v1.1.2"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-1:v1.1.2": {}}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-1:v1.1.2", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
+			appsUpdated:            map[string]string{"test-1": "index.docker.io/acorn/test-1:v1.1.2"},
+		},
+		{
+			name:                   "Auto refresh tag with multiple remote tags with non-latest tag image denied and current being the oldest image",
+			client:                 &mockDaemonClient{remoteTags: []string{"v1.1.1", "v1.1.2", "v1.1.3"}, imageDenyList: map[string]struct{}{"index.docker.io/acorn/test-1:v1.1.2": {}}},
+			appKeysPrevCheckBefore: map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): thirtySecondsAgo},
+			imagesToRefresh:        map[imageAndNamespaceKey][]kclient.ObjectKey{{image: "index.docker.io/acorn/test-1", namespace: "acorn"}: {router.Key("acorn", "test-1")}},
+			appKeysPrevCheckAfter:  map[kclient.ObjectKey]time.Time{router.Key("acorn", "test-1"): now},
+			appsUpdated:            map[string]string{"test-1": "index.docker.io/acorn/test-1:v1.1.3"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/autoupgrade/tags.go
+++ b/pkg/autoupgrade/tags.go
@@ -43,17 +43,15 @@ func findLatestTagForImageWithPattern(ctx context.Context, c daemonClient, curre
 		return "", false, err
 	}
 
-	var newTag string
-	if current == "" {
+	newTag := current
+	if newTag == "" {
 		newTag = invalidTag
-	} else {
-		newTag = current
 	}
 	newImage := strings.TrimPrefix(ref.Context().Tag(newTag).Name(), defaultNoReg+"/")
 	for len(tags) > 0 {
 		nTag, err := FindLatest(current, pattern, tags)
 		if err != nil || nTag == current {
-			// resorting to default tag, so stop trying (we don't want to loop forever)
+			// resorting to current tag, so stop trying (we don't want to loop forever)
 			break
 		}
 		img := strings.TrimPrefix(ref.Context().Tag(nTag).Name(), defaultNoReg+"/")

--- a/pkg/autoupgrade/tags.go
+++ b/pkg/autoupgrade/tags.go
@@ -13,6 +13,8 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const invalidTag = "+notfound+"
+
 func getTagsForImagePattern(ctx context.Context, c daemonClient, namespace, image string) (imagename.Reference, []string, error) {
 	current, err := imagename.ParseReference(image, imagename.WithDefaultRegistry(defaultNoReg))
 	if err != nil {
@@ -35,17 +37,22 @@ func getTagsForImagePattern(ctx context.Context, c daemonClient, namespace, imag
 	return current, append(tags, localTags...), nil
 }
 
-func findLatestTagForImageWithPattern(ctx context.Context, c daemonClient, namespace, image, pattern string) (string, bool, error) {
+func findLatestTagForImageWithPattern(ctx context.Context, c daemonClient, current, namespace, image, pattern string) (string, bool, error) {
 	ref, tags, err := getTagsForImagePattern(ctx, c, namespace, strings.TrimSuffix(image, ":"+pattern))
 	if err != nil {
 		return "", false, err
 	}
 
-	newTag := imagename.DefaultTag
+	var newTag string
+	if current == "" {
+		newTag = invalidTag
+	} else {
+		newTag = current
+	}
 	newImage := strings.TrimPrefix(ref.Context().Tag(newTag).Name(), defaultNoReg+"/")
 	for len(tags) > 0 {
-		nTag, err := FindLatest(imagename.DefaultTag, pattern, tags)
-		if err != nil || nTag == imagename.DefaultTag {
+		nTag, err := FindLatest(current, pattern, tags)
+		if err != nil || nTag == current {
 			// resorting to default tag, so stop trying (we don't want to loop forever)
 			break
 		}
@@ -61,12 +68,17 @@ func findLatestTagForImageWithPattern(ctx context.Context, c daemonClient, names
 		}
 	}
 
-	return newImage, newTag != imagename.DefaultTag, err
+	// no new image needs to be returned since no new tags were found
+	if newTag == invalidTag {
+		return "", false, err
+	}
+
+	return newImage, newTag != current, err
 }
 
 // FindLatestTagForImageWithPattern will return the latest tag for image corresponding to the pattern.
-func FindLatestTagForImageWithPattern(ctx context.Context, c kclient.Client, namespace, image, pattern string) (string, bool, error) {
-	return findLatestTagForImageWithPattern(ctx, &client{c}, namespace, image, pattern)
+func FindLatestTagForImageWithPattern(ctx context.Context, c kclient.Client, current, namespace, image, pattern string) (string, bool, error) {
+	return findLatestTagForImageWithPattern(ctx, &client{c}, current, namespace, image, pattern)
 }
 
 // FindLatest returns the tag from the tags slice that sorts as the "latest" according to the supplied pattern. The supplied

--- a/pkg/imagedetails/imagedetails.go
+++ b/pkg/imagedetails/imagedetails.go
@@ -21,7 +21,7 @@ func GetImageDetails(ctx context.Context, c kclient.Client, namespace, imageName
 	name := strings.ReplaceAll(imageName, "/", "+")
 
 	if tagPattern, isPattern := autoupgrade.AutoUpgradePattern(imageName); isPattern {
-		if latestImage, found, err := autoupgrade.FindLatestTagForImageWithPattern(ctx, c, namespace, imageName, tagPattern); err != nil {
+		if latestImage, found, err := autoupgrade.FindLatestTagForImageWithPattern(ctx, c, "", namespace, imageName, tagPattern); err != nil {
 			return nil, err
 		} else if !found {
 			return nil, fmt.Errorf("unable to find an image for %v matching pattern %v", imageName, tagPattern)


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

