### PR TITLE
Ensure default volume class region is validated (#1435)

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -196,7 +196,7 @@ func (s *Validator) check(ctx context.Context, sar *authv1.SubjectAccessReview, 
 	return nil
 }
 
-func (s *Validator) checkNonResourceRole(ctx context.Context, sar *authv1.SubjectAccessReview, rule v1.PolicyRule, namespace string) error {
+func (s *Validator) checkNonResourceRole(ctx context.Context, sar *authv1.SubjectAccessReview, rule v1.PolicyRule) error {
 	if len(rule.Verbs) == 0 {
 		return fmt.Errorf("can not deploy acorn due to requesting role with empty verbs")
 	}
@@ -289,7 +289,7 @@ func (s *Validator) checkRules(ctx context.Context, sar *authv1.SubjectAccessRev
 	var errs []error
 	for _, rule := range rules {
 		if len(rule.NonResourceURLs) > 0 {
-			if err := s.checkNonResourceRole(ctx, sar, rule, namespace); err != nil {
+			if err := s.checkNonResourceRole(ctx, sar, rule); err != nil {
 				errs = append(errs, err)
 			}
 		} else {
@@ -476,21 +476,18 @@ func validateVolumeClasses(ctx context.Context, c kclient.Client, namespace stri
 		volumeBindings[vol.Target] = vol
 	}
 
-	var (
-		volClass adminv1.ProjectVolumeClassInstance
-		ok       bool
-	)
+	var volClass adminv1.ProjectVolumeClassInstance
 	for volName, vol := range appSpec.Volumes {
 		calculatedVolumeRequest := volume.CopyVolumeDefaults(vol, volumeBindings[volName], v1.VolumeDefault{})
 		if calculatedVolumeRequest.Class != "" {
-			volClass, ok = volumeClasses[calculatedVolumeRequest.Class]
-			if !ok || volClass.Inactive || (!slices.Contains(volClass.SupportedRegions, defaultRegion) && !slices.Contains(volClass.SupportedRegions, appInstanceSpec.Region)) {
-				return field.Invalid(field.NewPath("spec", "image"), appInstanceSpec.Image, fmt.Sprintf("%s is not a valid volume class", calculatedVolumeRequest.Class))
-			}
+			volClass = volumeClasses[calculatedVolumeRequest.Class]
 		} else if defaultVolumeClass != nil {
 			volClass = *defaultVolumeClass
 		} else {
 			return field.Invalid(field.NewPath("spec", "image"), appInstanceSpec.Image, fmt.Sprintf("no volume class found for %s", volName))
+		}
+		if volClass.Inactive || (!slices.Contains(volClass.SupportedRegions, defaultRegion) && !slices.Contains(volClass.SupportedRegions, appInstanceSpec.Region)) {
+			return field.Invalid(field.NewPath("spec", "image"), appInstanceSpec.Image, fmt.Sprintf("%s is not a valid volume class", calculatedVolumeRequest.Class))
 		}
 
 		if calculatedVolumeRequest.Size != "" {


### PR DESCRIPTION
If an app used a default volume class, app's region was not validated against the class. These changes ensure the app's region is validated against the default volume class.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/acorn/issues/1435