### PR TITLE
Update alpine image that wasn't using the mirror

### DIFF
--- a/integration/build/testdata/multiarch/Dockerfile
+++ b/integration/build/testdata/multiarch/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine
+FROM ghcr.io/acorn-io/images-mirror/alpine:latest
 RUN apk -U add bash


### PR DESCRIPTION
I hit a rate limit for the `alpine` image in [this PR ](https://github.com/acorn-io/acorn/actions/runs/4612387099/jobs/8153553875?pr=1436) so I went ahead and fixed it.
### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

