### PR TITLE
fix: custom Digest() func to error out on HEAD 404 (#1414)

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -73,7 +73,7 @@ func ensureSignatureArtifact(ctx context.Context, c client.Reader, namespace str
 		return nil, fmt.Errorf("failed to get signature tag: %w", err)
 	}
 
-	sigDigest, err := crane.Digest(sigTag.Name(), craneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
+	sigDigest, err := SimpleDigest(sigTag, craneOpts...) // similar to crane.Digest, but fails if HEAD returns 404 Not Found
 	if err != nil {
 		if terr, ok := err.(*transport.Error); ok && terr.StatusCode == http.StatusNotFound {
 			// signature artifact not found -> that's an actual verification error

--- a/pkg/cosign/registry.go
+++ b/pkg/cosign/registry.go
@@ -1,0 +1,68 @@
+package cosign
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/sirupsen/logrus"
+)
+
+/* DISCLAIMER: Some parts of this code are copied from the crane package.
+ * Source: github.com/google/go-containerregistry/pkg/crane
+ * Original License below:
+ * ------------------------------------------------------------
+ * Copyright 2018 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------
+ */
+
+// SimpleDigest is an adaption of crane.Digest
+//   - it returns the sha256 hash of the remote image at ref.
+//   - removed: it does not support platform specific images (we don't need that here)
+//   - added: it returns an error if the image is not found on first try with HEAD
+//     (to lower the number of GET requests against potentially rate limited registries)
+func SimpleDigest(ref name.Reference, opt ...crane.Option) (string, error) {
+	o := makeOptions(opt...)
+	desc, err := crane.Head(ref.Name(), opt...)
+	if err != nil {
+		if terr, ok := err.(*transport.Error); ok && terr.StatusCode == http.StatusNotFound {
+			return "", fmt.Errorf("ref %s not found: %w", ref, terr)
+		}
+		logrus.Debugf("HEAD request failed for ref %s, falling back on GET: %v", ref, err)
+		rdesc, err := remote.Get(ref, o.Remote...)
+		if err != nil {
+			return "", err
+		}
+		return rdesc.Digest.String(), nil
+	}
+	return desc.Digest.String(), nil
+}
+
+func makeOptions(opts ...crane.Option) crane.Options {
+	opt := crane.Options{
+		Remote: []remote.Option{
+			remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		},
+		Keychain: authn.DefaultKeychain,
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}


### PR DESCRIPTION
When getting the digest for signature artifacts, crane.Digest() always fell back to a GET request if HEAD failed, without checking the status code. The custom function will just error out if HEAD returns a 404, as it's common that the signature artifact is not present.

This should reduce the possibility of hitting e.g. DockerHub's rate limit.

Ref #1414


### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section --> None
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description --> None
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

