### PR TITLE
fix acorn run --update behavior to allow --name flag (#1444, #1448)

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -271,7 +271,10 @@ func (s *Run) Run(cmd *cobra.Command, args []string) error {
 		if s.Interactive {
 			return fmt.Errorf("cannot use --update/-u or --replace/-r with --dev/-i")
 		}
-		return updateHelper(cmd, args, s, c, isDir, cwd)
+		//if app does not exist but --update/--replace flag is used create app instead
+		if existingApp != nil {
+			return updateHelper(cmd, args, s, c, isDir, cwd)
+		}
 	}
 
 	if s.Interactive {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -285,8 +285,6 @@ func TestRun(t *testing.T) {
 							Spec:       apiv1.InfoSpec{},
 						},
 					}, nil)
-				f.EXPECT().ImageDetails(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					nil, fmt.Errorf("error: app image-dne does not exist"))
 			},
 		},
 		{


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
#1444 #1448 
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

This PR changes the behavior when a user does `acorn run --update -n app_name ` prior if the app did not exist an error would be thrown, after the behavior will be that a new app w/ name app_name will be created