### PR TITLE
fix: match transport error to catch 404 on HEAD to get digests (#1414)

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -75,7 +75,8 @@ func ensureSignatureArtifact(ctx context.Context, c client.Reader, namespace str
 
 	sigDigest, err := SimpleDigest(sigTag, craneOpts...) // similar to crane.Digest, but fails if HEAD returns 404 Not Found
 	if err != nil {
-		if terr, ok := err.(*transport.Error); ok && terr.StatusCode == http.StatusNotFound {
+		var terr *transport.Error
+		if ok := errors.As(err, &terr); ok && terr.StatusCode == http.StatusNotFound {
 			// signature artifact not found -> that's an actual verification error
 			return nil, fmt.Errorf("%w: expected signature artifact %s not found", cosign.ErrNoMatchingSignatures, sigTag.Name())
 		}


### PR DESCRIPTION
We were still hitting rate limits because the check to catch 404s on the HEAD request to get the signature artifact digest wasn't working.

Ref #1414

Signed-off-by: Thorsten Klein <tk@thklein.io>

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

