### PR TITLE
change: also check imageAllowRules for auto-upgrade without pattern (#1428)

### DIFF
--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -227,7 +227,7 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 				if !updated && digest != "" {
 					if err := d.client.checkImageAllowed(ctx, app.Namespace, nextAppImage); err != nil {
 						if errors.Is(err, &imageallowrules.ErrImageNotAllowed{}) {
-							logrus.Warnf("Updated image %s for %s/%s is not allowed: %v", nextAppImage, app.Namespace, app.Name, err)
+							logrus.Debugf("Updated image %s for %s/%s is not allowed: %v", nextAppImage, app.Namespace, app.Name, err)
 							continue
 						}
 						logrus.Errorf("error checking if updated image %s for %s/%s  is allowed: %v", app.Namespace, app.Name, nextAppImage, err)

--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -228,6 +228,7 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 					if err := d.client.checkImageAllowed(ctx, app.Namespace, nextAppImage); err != nil {
 						if errors.Is(err, &imageallowrules.ErrImageNotAllowed{}) {
 							logrus.Debugf("Updated image %s for %s/%s is not allowed: %v", nextAppImage, app.Namespace, app.Name, err)
+							d.appKeysPrevCheck[appKey] = updateTime
 							continue
 						}
 						logrus.Errorf("error checking if updated image %s for %s/%s  is allowed: %v", app.Namespace, app.Name, nextAppImage, err)
@@ -239,12 +240,14 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 				switch mode {
 				case "enabled":
 					if app.Status.AvailableAppImage == nextAppImage {
+						d.appKeysPrevCheck[appKey] = updateTime
 						continue
 					}
 					app.Status.AvailableAppImage = nextAppImage
 					app.Status.ConfirmUpgradeAppImage = ""
 				case "notify":
 					if app.Status.ConfirmUpgradeAppImage == nextAppImage {
+						d.appKeysPrevCheck[appKey] = updateTime
 						continue
 					}
 					app.Status.ConfirmUpgradeAppImage = nextAppImage


### PR DESCRIPTION
Ref #1428

@cjellick & @thedadams I guess when the nextAppImage fails validation, we should still set a new updateTime, so it won't keep trying forever?

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

