### PR TITLE
fix: default to :latest for non-SHA-like image inputs (#1450)

### DIFF
--- a/integration/client/apps/update_test.go
+++ b/integration/client/apps/update_test.go
@@ -30,7 +30,7 @@ func TestUpdatePull(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, "foo:latest", &client.AppRunOptions{Name: "test"})
+	app, err := c.AppRun(ctx, "foo", &client.AppRunOptions{Name: "test"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -178,15 +178,18 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 		if err != nil {
 			return nil, "", err
 		}
-		if dig, ok := ref.(name.Digest); ok {
+		if ref.Identifier() == "" {
+			tagNameDefault = ref.Name()
+		} else if dig, ok := ref.(name.Digest); ok {
 			repoDigest = dig
 		} else {
-			tagName = strings.TrimSuffix(ref.Name(), ":") // drop pontential trailing ":" if no tag was specified
+			tagName = ref.Name()
 		}
 	}
 
 	if tagNameDefault != "" {
-		t, err := name.ParseReference(imageName, name.WithDefaultRegistry(""))
+		// add default tag (:latest)
+		t, err := name.ParseReference(tagNameDefault, name.WithDefaultRegistry(""))
 		if err != nil {
 			return nil, "", err
 		}


### PR DESCRIPTION
Ref #1450

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

