### PR TITLE
Handle issues when stdin is closed on exec start

### DIFF
--- a/pkg/client/term/term.go
+++ b/pkg/client/term/term.go
@@ -2,6 +2,7 @@ package term
 
 import (
 	"io"
+	"time"
 
 	"github.com/acorn-io/acorn/pkg/streams"
 	"golang.org/x/sync/errgroup"
@@ -61,7 +62,22 @@ func copyIO(cIO *ExecIO, streams *streams.Streams) <-chan struct{} {
 	result := make(chan struct{})
 
 	go func() {
-		_, _ = io.Copy(cIO.Stdin, streams.In)
+		c, err := io.Copy(cIO.Stdin, streams.In)
+		if c == 0 && err == nil {
+			// Very good chance the stdin was closed at start, so just wait
+			// until stdout/stderr are done
+			<-result
+		} else {
+			// This is an unfortunate hack. It does not seem possible to close the
+			// stdin side of an exec session to kubernetes over a WebSocket. This
+			// means that for a command like "echo hi | acorn exec container cat" we
+			// can not reliably run it. For a command like that you have to finish
+			// reading stdin, close it, and then fully read the response.  If you
+			// don't close stdin, the "cat" command will not exit.  If you do
+			// don't fully read the response you lose the output. So here we just
+			// sleep one second hoping that is enough time to read the output
+			time.Sleep(1 * time.Second)
+		}
 		_ = cIO.Stdin.Close()
 	}()
 
@@ -76,7 +92,7 @@ func copyIO(cIO *ExecIO, streams *streams.Streams) <-chan struct{} {
 	})
 	go func() {
 		_ = eg.Wait()
-		result <- struct{}{}
+		close(result)
 	}()
 
 	return result


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

