### PR TITLE
simplify acorn run --help and add --help-advanced (#1358)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -12,99 +12,61 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
 ### Examples
 
 ```
-# Publish and Expose Port Syntax
-  # Publish port 80 for any containers that define it as a port
-  acorn run -p 80 .
 
-  # Publish container "myapp" using the hostname app.example.com
-  acorn run --publish app.example.com:myapp .
+ # Build and run from a directory
+   acorn run .
 
-  # Expose port 80 to the rest of the cluster as port 8080
-  acorn run --expose 8080:80/http .
+ # Run from an image
+   acorn run ghcr.io/acorn-io/library/hello-world
 
-# Labels and Annotations Syntax
-  # Add a label to all resources created by the app
-  acorn run --label key=value .
+ # Automatic upgrades
+   # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will be sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.
+   
+   # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
 
-  # Add a label to resources created for all containers
-  acorn run --label containers:key=value .
+   # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
+   acorn run myorg/hello-world:v#.#.#
 
-  # Add a label to the resources created for the volume named "myvolume"
-  acorn run --label volumes:myvolume:key=value .
+   # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
+  
+   # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
+   acorn run myorg/hello-world:*
 
-# Link Syntax
-  # Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
-  acorn run --link mydatabase:db .
+   # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
+   
+   # This example would sort numerically according to major and minor version (i.e. v1.2) and ignore anything following the "-":
+   acorn run myorg/hello-world:v#.#-**
 
-# Secret Syntax
-  # Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
-  acorn run --secret mycredentials:creds .
+   # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so acorn can parse them:
+   acorn run "myorg/hello-world:v#.#-**"
 
-# Volume Syntax
-  # Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
-  acorn run --volume mydata,size=5G,class=fast .
+   # Automatic upgrades can be configured explicitly via a flag.
 
-  # Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
-  acorn run --volume mydata:data .
+   # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
+   acorn run --auto-upgrade myorg/hello-world:latest
 
-# Automatic upgrades
-  # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.
+   # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
+   acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
 
-  # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
-  # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
-  acorn run myorg/hello-world:v#.#.#
-
-  # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
-  # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
-  acorn run myorg/hello-world:*
-
-  # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
-  # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
-  acorn run myorg/hello-world:v#.#-**
-
-  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
-  acorn run "myorg/hello-world:v#.#-**"
-
-  # Automatic upgrades can be configured explicitly via a flag.
-  # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
-  acorn run --auto-upgrade myorg/hello-world:latest
-
-  # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
-  acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
-  # To proceed with an upgrade you've been notified of:
-  acorn update --confirm-upgrade myapp
-
+   # To proceed with an upgrade you've been notified of:
+   acorn update --confirm-upgrade myapp
 ```
 
 ### Options
 
 ```
-      --annotation strings        Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --auto-upgrade              Enabled automatic upgrades.
-  -b, --bidirectional-sync        In interactive mode download changes in addition to uploading
-      --compute-class strings     Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
-  -i, --dev                       Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
-  -e, --env strings               Environment variables to set on running containers
-  -f, --file string               Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help                      help for run
-      --interval string           If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
-  -l, --label strings             Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --link strings              Link external app as a service in the current app (format app-name:container-name)
-  -m, --memory strings            Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
-  -n, --name string               Name of app to create
-      --notify-upgrade            If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string             Output API request without creating app (json, yaml)
-      --profile strings           Profile to assign default values
-  -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
-  -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
-  -q, --quiet                     Do not print status
-      --region string             Region in which to deploy the app, immutable
-      --replace                   Replace the app with only defined values, resetting undefined fields to default values
-  -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
-      --target-namespace string   The name of the namespace to be created and deleted for the application resources
-  -u, --update                    Update the app if it already exists
-  -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
-      --wait                      Wait for app to become ready before command exiting (default true)
+      --auto-upgrade      Enabled automatic upgrades.
+  -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help              help for run
+      --help-advanced     Show verbose help text
+  -n, --name string       Name of app to create
+      --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string     Output API request without creating app (json, yaml)
+      --profile strings   Profile to assign default values
+  -q, --quiet             Do not print status
+      --replace           Replace the app with only defined values, resetting undefined fields to default values
+  -u, --update            Update the app if it already exists
+      --wait              Wait for app to become ready before command exiting (default: true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -12,32 +12,18 @@ acorn update [flags] APP_NAME [deploy flags]
 ### Options
 
 ```
-      --annotation strings        Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --auto-upgrade              Enabled automatic upgrades.
-      --compute-class strings     Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
-      --confirm-upgrade           When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade.
-  -e, --env strings               Environment variables to set on running containers
-  -f, --file string               Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help                      help for update
-      --image string              Acorn image name
-      --interval string           If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
-  -l, --label strings             Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --link strings              Link external app as a service in the current app (format app-name:container-name)
-  -m, --memory strings            Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
-  -n, --name string               Name of app to create
-      --notify-upgrade            If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string             Output API request without creating app (json, yaml)
-      --profile strings           Profile to assign default values
-  -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
-  -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
-      --pull                      Re-pull the app's image, which will cause the app to re-deploy if the image has changed
-  -q, --quiet                     Do not print status
-      --region string             Region in which to deploy the app, immutable
-      --replace                   Replace the app with only defined values, resetting undefined fields to default values
-  -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
-      --target-namespace string   The name of the namespace to be created and deleted for the application resources
-  -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
-      --wait                      Wait for app to become ready before command exiting (default true)
+      --auto-upgrade      Enabled automatic upgrades.
+      --confirm-upgrade   When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade.
+  -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help              help for update
+  -n, --name string       Name of app to create
+      --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string     Output API request without creating app (json, yaml)
+      --profile strings   Profile to assign default values
+      --pull              Re-pull the app's image, which will cause the app to re-deploy if the image has changed
+  -q, --quiet             Do not print status
+      --replace           Replace the app with only defined values, resetting undefined fields to default values
+      --wait              Wait for app to become ready before command exiting (default: true)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -28,68 +28,45 @@ func NewRun(c CommandContext) *cobra.Command {
 		SilenceUsage:      true,
 		Short:             "Run an app from an image or Acornfile",
 		ValidArgsFunction: newCompletion(c.ClientFactory, imagesCompletion(true)).withSuccessDirective(cobra.ShellCompDirectiveDefault).withShouldCompleteOptions(onlyNumArgs(1)).complete,
-		Example: `# Publish and Expose Port Syntax
-  # Publish port 80 for any containers that define it as a port
-  acorn run -p 80 .
+		Example: `
+ # Build and run from a directory
+   acorn run .
 
-  # Publish container "myapp" using the hostname app.example.com
-  acorn run --publish app.example.com:myapp .
+ # Run from an image
+   acorn run ghcr.io/acorn-io/library/hello-world
 
-  # Expose port 80 to the rest of the cluster as port 8080
-  acorn run --expose 8080:80/http .
+ # Automatic upgrades
+   # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will be sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.
+   
+   # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
 
-# Labels and Annotations Syntax
-  # Add a label to all resources created by the app
-  acorn run --label key=value .
+   # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
+   acorn run myorg/hello-world:v#.#.#
 
-  # Add a label to resources created for all containers
-  acorn run --label containers:key=value .
+   # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
+  
+   # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
+   acorn run myorg/hello-world:*
 
-  # Add a label to the resources created for the volume named "myvolume"
-  acorn run --label volumes:myvolume:key=value .
+   # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
+   
+   # This example would sort numerically according to major and minor version (i.e. v1.2) and ignore anything following the "-":
+   acorn run myorg/hello-world:v#.#-**
 
-# Link Syntax
-  # Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
-  acorn run --link mydatabase:db .
+   # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so acorn can parse them:
+   acorn run "myorg/hello-world:v#.#-**"
 
-# Secret Syntax
-  # Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
-  acorn run --secret mycredentials:creds .
+   # Automatic upgrades can be configured explicitly via a flag.
 
-# Volume Syntax
-  # Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
-  acorn run --volume mydata,size=5G,class=fast .
+   # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
+   acorn run --auto-upgrade myorg/hello-world:latest
 
-  # Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
-  acorn run --volume mydata:data .
+   # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
+   acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
 
-# Automatic upgrades
-  # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.
-
-  # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
-  # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
-  acorn run myorg/hello-world:v#.#.#
-
-  # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
-  # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
-  acorn run myorg/hello-world:*
-
-  # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
-  # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
-  acorn run myorg/hello-world:v#.#-**
-
-  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
-  acorn run "myorg/hello-world:v#.#-**"
-
-  # Automatic upgrades can be configured explicitly via a flag.
-  # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
-  acorn run --auto-upgrade myorg/hello-world:latest
-
-  # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
-  acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
-  # To proceed with an upgrade you've been notified of:
-  acorn update --confirm-upgrade myapp
-`})
+   # To proceed with an upgrade you've been notified of:
+   acorn update --confirm-upgrade myapp`,
+	})
 
 	// These will produce an error if the flag doesn't exist or a completion function has already been registered for the
 	// flag. Not returning the error since neither of these is likely occur.
@@ -102,19 +79,64 @@ func NewRun(c CommandContext) *cobra.Command {
 	if err := cmd.RegisterFlagCompletionFunc("region", newCompletion(c.ClientFactory, regionsCompletion).complete); err != nil {
 		cmd.Printf("Error registering completion function for --region flag: %v\n", err)
 	}
-	cmd.PersistentFlags().Lookup("dangerous").Hidden = true
 	cmd.Flags().SetInterspersed(false)
+	toggleHiddenFlags(cmd, hideRunFlags, true)
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Println(cmd.Short + "\n")
+		fmt.Println(cmd.UsageString())
+	})
 	return cmd
 }
+
+const AdvancedHelp = `    
+More Usages:
+     # Publish and Expose Port Syntax
+     - Publish port 80 for any containers that define it as a port
+      	acorn run -p 80 .
+
+     - Publish container "myapp" using the hostname app.example.com
+      	acorn run --publish app.example.com:myapp .
+
+     - Expose port 80 to the rest of the cluster as port 8080
+      	acorn run --expose 8080:80/http .
+
+     # Labels and Annotations Syntax
+     - Add a label to all resources created by the app
+       	acorn run --label key=value .
+
+     - Add a label to resources created for all containers
+      	acorn run --label containers:key=value .
+
+     - Add a label to the resources created for the volume named "myvolume"
+      	acorn run --label volumes:myvolume:key=value .
+
+     # Link Syntax
+     - Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
+       	acorn run --link mydatabase:db .
+
+     # Secret Syntax
+     - Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
+         acorn run --secret mycredentials:creds .
+
+     # Volume Syntax
+     - Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
+        acorn run --volume mydata,size=5G,class=fast .
+     - Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
+        acorn run --volume mydata:data .`
+
+var hideRunFlags = []string{"dangerous", "memory", "target-namespace", "secret", "volume", "region", "publish-all",
+	"publish", "link", "label", "interval", "env", "compute-class", "annotation", "dev", "bidirectional-sync"}
 
 type Run struct {
 	RunArgs
 	Dev               bool  `usage:"Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit" short:"i"`
 	BidirectionalSync bool  `usage:"In interactive mode download changes in addition to uploading" short:"b"`
-	Wait              *bool `usage:"Wait for app to become ready before command exiting (default true)"`
+	Wait              *bool `usage:"Wait for app to become ready before command exiting (default: true)"`
 	Quiet             bool  `usage:"Do not print status" short:"q"`
 	Update            bool  `usage:"Update the app if it already exists" short:"u"`
 	Replace           bool  `usage:"Replace the app with only defined values, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
+	HelpAdvanced      bool  `usage:"Show verbose help text"`
 
 	out    io.Writer
 	client ClientFactory
@@ -209,6 +231,10 @@ func (s RunArgs) ToOpts() (client.AppRunOptions, error) {
 }
 
 func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
+	if s.HelpAdvanced {
+		setAdvancedHelp(cmd)
+		return cmd.Help()
+	}
 	defer func() {
 		if errors.Is(err, pflag.ErrHelp) {
 			err = nil
@@ -354,4 +380,20 @@ func outputApp(out io.Writer, format string, app *apiv1.App) error {
 		_, err = out.Write(data)
 	}
 	return err
+}
+
+func toggleHiddenFlags(cmd *cobra.Command, flagsToHide []string, hide bool) {
+	for _, flag := range flagsToHide {
+		cmd.PersistentFlags().Lookup(flag).Hidden = hide
+	}
+}
+
+func setAdvancedHelp(cmd *cobra.Command) {
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Println(cmd.Short + "\n")
+		// toggle advanced flags on before printing flags out in cmd.UsageString
+		toggleHiddenFlags(cmd, hideRunFlags, false)
+		fmt.Println(cmd.UsageString())
+		fmt.Println(AdvancedHelp)
+	})
 }

--- a/pkg/cli/testdata/run/acorn_run_help.txt
+++ b/pkg/cli/testdata/run/acorn_run_help.txt
@@ -4,93 +4,56 @@ Usage:
   run [flags] IMAGE|DIRECTORY [acorn args]
 
 Examples:
-# Publish and Expose Port Syntax
-  # Publish port 80 for any containers that define it as a port
-  acorn run -p 80 .
 
-  # Publish container "myapp" using the hostname app.example.com
-  acorn run --publish app.example.com:myapp .
+ # Build and run from a directory
+   acorn run .
 
-  # Expose port 80 to the rest of the cluster as port 8080
-  acorn run --expose 8080:80/http .
+ # Run from an image
+   acorn run ghcr.io/acorn-io/library/hello-world
 
-# Labels and Annotations Syntax
-  # Add a label to all resources created by the app
-  acorn run --label key=value .
+ # Automatic upgrades
+   # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will be sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.
+   
+   # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
 
-  # Add a label to resources created for all containers
-  acorn run --label containers:key=value .
+   # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
+   acorn run myorg/hello-world:v#.#.#
 
-  # Add a label to the resources created for the volume named "myvolume"
-  acorn run --label volumes:myvolume:key=value .
+   # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
+  
+   # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
+   acorn run myorg/hello-world:*
 
-# Link Syntax
-  # Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
-  acorn run --link mydatabase:db .
+   # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
+   
+   # This example would sort numerically according to major and minor version (i.e. v1.2) and ignore anything following the "-":
+   acorn run myorg/hello-world:v#.#-**
 
-# Secret Syntax
-  # Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
-  acorn run --secret mycredentials:creds .
+   # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so acorn can parse them:
+   acorn run "myorg/hello-world:v#.#-**"
 
-# Volume Syntax
-  # Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
-  acorn run --volume mydata,size=5G,class=fast .
+   # Automatic upgrades can be configured explicitly via a flag.
 
-  # Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
-  acorn run --volume mydata:data .
+   # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
+   acorn run --auto-upgrade myorg/hello-world:latest
 
-# Automatic upgrades
-  # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.
+   # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
+   acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
 
-  # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
-  # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
-  acorn run myorg/hello-world:v#.#.#
-
-  # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
-  # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
-  acorn run myorg/hello-world:*
-
-  # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
-  # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
-  acorn run myorg/hello-world:v#.#-**
-
-  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
-  acorn run "myorg/hello-world:v#.#-**"
-
-  # Automatic upgrades can be configured explicitly via a flag.
-  # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
-  acorn run --auto-upgrade myorg/hello-world:latest
-
-  # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
-  acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
-  # To proceed with an upgrade you've been notified of:
-  acorn update --confirm-upgrade myapp
-
+   # To proceed with an upgrade you've been notified of:
+   acorn update --confirm-upgrade myapp
 
 Flags:
-      --annotation strings        Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --auto-upgrade              Enabled automatic upgrades.
-  -b, --bidirectional-sync        In interactive mode download changes in addition to uploading
-      --compute-class strings     Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
-  -i, --dev                       Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
-  -e, --env strings               Environment variables to set on running containers
-  -f, --file string               Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help                      help for run
-      --interval string           If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
-  -l, --label strings             Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
-      --link strings              Link external app as a service in the current app (format app-name:container-name)
-  -m, --memory strings            Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
-  -n, --name string               Name of app to create
-      --notify-upgrade            If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string             Output API request without creating app (json, yaml)
-      --profile strings           Profile to assign default values
-  -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
-  -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
-  -q, --quiet                     Do not print status
-      --region string             Region in which to deploy the app, immutable
-      --replace                   Replace the app with only defined values, resetting undefined fields to default values
-  -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
-      --target-namespace string   The name of the namespace to be created and deleted for the application resources
-  -u, --update                    Update the app if it already exists
-  -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
-      --wait                      Wait for app to become ready before command exiting (default true)
+      --auto-upgrade      Enabled automatic upgrades.
+  -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help              help for run
+      --help-advanced     Show verbose help text
+  -n, --name string       Name of app to create
+      --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string     Output API request without creating app (json, yaml)
+      --profile strings   Profile to assign default values
+  -q, --quiet             Do not print status
+      --replace           Replace the app with only defined values, resetting undefined fields to default values
+  -u, --update            Update the app if it already exists
+      --wait              Wait for app to become ready before command exiting (default: true)
+

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -16,7 +16,10 @@ func NewUpdate(c CommandContext) *cobra.Command {
 		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 		Args:              cobra.MinimumNArgs(1),
 	})
-	cmd.PersistentFlags().Lookup("dangerous").Hidden = true
+	hideUpdateFlags := []string{"dangerous", "memory", "target-namespace", "secret", "volume", "region", "publish-all",
+		"publish", "link", "label", "interval", "image", "env", "compute-class", "annotation"}
+
+	toggleHiddenFlags(cmd, hideUpdateFlags, true)
 	cmd.Flags().SetInterspersed(false)
 	return cmd
 }
@@ -27,7 +30,7 @@ type Update struct {
 	ConfirmUpgrade bool   `usage:"When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade."`
 	Pull           bool   `usage:"Re-pull the app's image, which will cause the app to re-deploy if the image has changed"`
 	Replace        bool   `usage:"Replace the app with only defined values, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
-	Wait           *bool  `usage:"Wait for app to become ready before command exiting (default true)"`
+	Wait           *bool  `usage:"Wait for app to become ready before command exiting (default: true)"`
 	Quiet          bool   `usage:"Do not print status" short:"q"`
 
 	out    io.Writer


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
#1358 
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

This PR simplifies `acorn run -h` output and moves a lot of the flags/usages to `acorn run --help-advanced `



<details><summary>old: acorn run -h</summary>
<p>

```
Run an app from an image or Acornfile

Usage:
  acorn run [flags] IMAGE|DIRECTORY [acorn args]

Examples:
# Publish and Expose Port Syntax
  # Publish port 80 for any containers that define it as a port
  acorn run -p 80 .

  # Publish container "myapp" using the hostname app.example.com
  acorn run --publish app.example.com:myapp .

  # Expose port 80 to the rest of the cluster as port 8080
  acorn run --expose 8080:80/http .

# Labels and Annotations Syntax
  # Add a label to all resources created by the app
  acorn run --label key=value .

  # Add a label to resources created for all containers
  acorn run --label containers:key=value .

  # Add a label to the resources created for the volume named "myvolume"
  acorn run --label volumes:myvolume:key=value .

# Link Syntax
  # Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
  acorn run --link mydatabase:db .

# Secret Syntax
  # Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
  acorn run --secret mycredentials:creds .

# Volume Syntax
  # Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
  acorn run --volume mydata,size=5G,class=fast .

  # Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
  acorn run --volume mydata:data .

# Automatic upgrades
  # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.

  # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
  # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
  acorn run myorg/hello-world:v#.#.#

  # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
  # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
  acorn run myorg/hello-world:*

  # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
  # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
  acorn run myorg/hello-world:v#.#-**

  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
  acorn run "myorg/hello-world:v#.#-**"

  # Automatic upgrades can be configured explicitly via a flag.
  # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
  acorn run --auto-upgrade myorg/hello-world:latest

  # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
  acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
  # To proceed with an upgrade you've been notified of:
  acorn update --confirm-upgrade myapp


Flags:
      --annotation strings        Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
      --auto-upgrade              Enabled automatic upgrades.
  -b, --bidirectional-sync        In interactive mode download changes in addition to uploading
      --compute-class strings     Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
  -i, --dev                       Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
  -e, --env strings               Environment variables to set on running containers
      --expose strings            In cluster expose ports of an application (format [public:]private) (ex 81:80)
  -f, --file string               Name of the build file (default "DIRECTORY/Acornfile")
  -h, --help                      help for run
      --interval string           If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
  -l, --label strings             Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
      --link strings              Link external app as a service in the current app (format app-name:container-name)
  -m, --memory strings            Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
  -n, --name string               Name of app to create
      --notify-upgrade            If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
  -o, --output string             Output API request without creating app (json, yaml)
      --profile strings           Profile to assign default values
  -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
  -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
  -q, --quiet                     Do not print status
  -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
      --target-namespace string   The name of the namespace to be created and deleted for the application resources
  -u, --update                    Update the app if it already exists
  -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
      --wait                      Wait for app to become ready before command exiting (default true)

Global Flags:
  -A, --all-projects        Use all known projects
      --debug               Enable debug logging
      --debug-level int     Debug log level (valid 0-9) (default 7)
      --kubeconfig string   Explicitly use kubeconfig file, overriding current project
  -j, --project string      Project to work in
```
  
</p>
</details> 
<details><summary>old: acorn update -h</summary>
<p>

```
Update a deployed app

Usage:
  acorn update [flags] APP_NAME [deploy flags]

Flags:
      --annotation strings        Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
      --auto-upgrade              Enabled automatic upgrades.
      --compute-class strings     Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
      --confirm-upgrade           When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade.
  -e, --env strings               Environment variables to set on running containers
      --expose strings            In cluster expose ports of an application (format [public:]private) (ex 81:80)
  -f, --file string               Name of the build file (default "DIRECTORY/Acornfile")
  -h, --help                      help for update
      --image string              
      --interval string           If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
  -l, --label strings             Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
      --link strings              Link external app as a service in the current app (format app-name:container-name)
  -m, --memory strings            Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
  -n, --name string               Name of app to create
      --notify-upgrade            If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
  -o, --output string             Output API request without creating app (json, yaml)
      --profile strings           Profile to assign default values
  -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
  -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
      --pull                      Re-pull the app's image, which will cause the app to re-deploy if the image has changed
      --replace                   Toggle replacing update, resetting undefined fields to default values
  -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
      --target-namespace string   The name of the namespace to be created and deleted for the application resources
  -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)

Global Flags:
  -A, --all-projects        Use all known projects
      --debug               Enable debug logging
      --debug-level int     Debug log level (valid 0-9) (default 7)
      --kubeconfig string   Explicitly use kubeconfig file, overriding current project
  -j, --project string      Project to work in

```
  
</p>
</details> 

<details><summary>new: acorn run -h</summary>
<p>

```
Run an app from an image or Acornfile

Usage:
  acorn run [flags] IMAGE|DIRECTORY [acorn args]

Examples:

# Build and run from a directory
  acorn run .
# Run from an image
  acorn run ghcr.io/acorn-io/library/hello-world

# Automatic upgrades
  # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.

  # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
  # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
  acorn run myorg/hello-world:v#.#.#

  # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
  # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
  acorn run myorg/hello-world:*

  # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
  # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
  acorn run myorg/hello-world:v#.#-**

  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
  acorn run "myorg/hello-world:v#.#-**"

  # Automatic upgrades can be configured explicitly via a flag.
  # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
  acorn run --auto-upgrade myorg/hello-world:latest

  # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
  acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
  # To proceed with an upgrade you've been notified of:
  acorn update --confirm-upgrade myapp

Flags:
      --auto-upgrade      Enabled automatic upgrades.
  -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
  -h, --help              help for run
      --help-advanced     Show verbose help text
  -n, --name string       Name of app to create or update
      --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
  -o, --output string     Output API request without creating app (json, yaml)
      --profile strings   Profile to assign default values
  -q, --quiet             Do not print status
      --replace           Replace the app with only defined values, resetting undefined fields to default values
  -u, --update            Update the app if it already exists
      --wait              Wait for app to become ready before command exiting (default true)

Global Flags:
  -A, --all-projects        Use all known projects
      --debug               Enable debug logging
      --debug-level int     Debug log level (valid 0-9) (default 7)
      --kubeconfig string   Explicitly use kubeconfig file, overriding current project
  -j, --project string      Project to work in

```
  
</p>
</details> 


<details><summary>new: acorn run --help-advanced </summary>
<p>

```
Run an app from an image or Acornfile

Usage:
  acorn run [flags] IMAGE|DIRECTORY [acorn args]

Examples:

# Build and run from a directory
  acorn run .
# Run from an image
  acorn run ghcr.io/acorn-io/library/hello-world

# Automatic upgrades
  # Automatic upgrade for an app will be enabled if '#', '*', or '**' appears in the image's tag. Tags will sorted according to the rules for these special characters described below. The newest tag will be selected for upgrade.

  # '#' denotes a segment of the image tag that should be sorted numerically when finding the newest tag.
  # This example deploys the hello-world app with auto-upgrade enabled and matching all major, minor, and patch versions:
  acorn run myorg/hello-world:v#.#.#

  # '*' denotes a segment of the image tag that should sorted alphabetically when finding the latest tag.
  # In this example, if you had a tag named alpha and a tag named zeta, zeta would be recognized as the newest:
  acorn run myorg/hello-world:*

  # '**' denotes a wildcard. This segment of the image tag won't be considered when sorting. This is useful if your tags have a segment that is unpredictable.
  # This example would sort numerically according to major and minor version (ie v1.2) and ignore anything following the "-":
  acorn run myorg/hello-world:v#.#-**

  # NOTE: Depending on your shell, you may see errors when using '*' and '**'. Using quotes will tell the shell to ignore them so Acorn can parse them:
  acorn run "myorg/hello-world:v#.#-**"

  # Automatic upgrades can be configured explicitly via a flag.
  # In this example, the tag will always be "latest", but acorn will periodically check to see if new content has been pushed to that tag:
  acorn run --auto-upgrade myorg/hello-world:latest

  # To have acorn notify you that an app has an upgrade available and require confirmation before proceeding, set the notify-upgrade flag:
  acorn run --notify-upgrade myorg/hello-world:v#.#.# myapp
  # To proceed with an upgrade you've been notified of:
  acorn update --confirm-upgrade myapp

Flags:
      --annotation strings        Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
      --auto-upgrade              Enabled automatic upgrades.
  -b, --bidirectional-sync        In interactive mode download changes in addition to uploading
      --compute-class strings     Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)
      --dangerous                 Automatically approve all privileges requested by the application
  -i, --dev                       Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
  -e, --env strings               Environment variables to set on running containers
  -f, --file string               Name of the build file (default "DIRECTORY/Acornfile")
  -h, --help                      help for run
      --help-advanced             Show verbose help text
      --image string              
      --interval string           If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)
  -l, --label strings             Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)
      --link strings              Link external app as a service in the current app (format app-name:container-name)
  -m, --memory strings            Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)
  -n, --name string               Name of app to create or update
      --notify-upgrade            If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
  -o, --output string             Output API request without creating app (json, yaml)
      --profile strings           Profile to assign default values
  -p, --publish strings           Publish port of application (format [public:]private) (ex 81:80)
  -P, --publish-all               Publish all (true) or none (false) of the defined ports of application
  -q, --quiet                     Do not print status
      --region string             Region in which to deploy the app, immutable
      --replace                   Replace the app with only defined values, resetting undefined fields to default values
  -s, --secret strings            Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)
      --target-namespace string   The name of the namespace to be created and deleted for the application resources
  -u, --update                    Update the app if it already exists
  -v, --volume stringArray        Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)
      --wait                      Wait for app to become ready before command exiting (default true)

Global Flags:
  -A, --all-projects        Use all known projects
      --debug               Enable debug logging
      --debug-level int     Debug log level (valid 0-9) (default 7)
      --kubeconfig string   Explicitly use kubeconfig file, overriding current project
  -j, --project string      Project to work in


    More Usages:
    # Publish and Expose Port Syntax

    - Publish port 80 for any containers that define it as a port
        acorn run -p 80 .

    - Publish container "myapp" using the hostname app.example.com
        acorn run --publish app.example.com:myapp .

    - Expose port 80 to the rest of the cluster as port 8080
        acorn run --expose 8080:80/http .

    # Labels and Annotations Syntax
    - Add a label to all resources created by the app
        acorn run --label key=value .

    - Add a label to resources created for all containers
        acorn run --label containers:key=value .

    - Add a label to the resources created for the volume named "myvolume"
        acorn run --label volumes:myvolume:key=value .

    # Link Syntax
    - Link the running acorn application named "mydatabase" into the current app, replacing the container named "db"
        acorn run --link mydatabase:db .

    # Secret Syntax
        - Bind the acorn secret named "mycredentials" into the current app, replacing the secret named "creds". See "acorn secrets --help" for more info
        acorn run --secret mycredentials:creds .

    # Volume Syntax
        - Create the volume named "mydata" with a size of 5 gigabyes and using the "fast" storage class
        acorn run --volume mydata,size=5G,class=fast .
    - Bind the acorn volume named "mydata" into the current app, replacing the volume named "data", See "acorn volumes --help for more info"
        acorn run --volume mydata:data .


```
  
</p>
</details> 



<details><summary>new: acorn update -h</summary>
<p>

```
Update a deployed app

Usage:
  acorn update [flags] APP_NAME [deploy flags]

Flags:
      --auto-upgrade      Enabled automatic upgrades.
      --confirm-upgrade   When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade.
  -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
  -h, --help              help for update
  -n, --name string       Name of app to create or update
      --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
  -o, --output string     Output API request without creating app (json, yaml)
      --profile strings   Profile to assign default values
      --pull              Re-pull the app's image, which will cause the app to re-deploy if the image has changed

Global Flags:
  -A, --all-projects        Use all known projects
      --debug               Enable debug logging
      --debug-level int     Debug log level (valid 0-9) (default 7)
      --kubeconfig string   Explicitly use kubeconfig file, overriding current project
  -j, --project string      Project to work in

```
  
</p>
</details> 