### PR TITLE
fix: only consider current image when checking appinstance against imageAllowRules (#1428)

### DIFF
--- a/pkg/controller/appdefinition/checkimageallowed.go
+++ b/pkg/controller/appdefinition/checkimageallowed.go
@@ -4,30 +4,39 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
-	"github.com/acorn-io/acorn/pkg/autoupgrade"
 	"github.com/acorn-io/acorn/pkg/condition"
 	"github.com/acorn-io/acorn/pkg/imageallowrules"
 	"github.com/acorn-io/baaah/pkg/router"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sirupsen/logrus"
 )
 
 // CheckImageAllowedHandler is a router handler that checks if the image is allowed by the image allow rules and sets a status field accordingly
+// This is only working on the currently specified image, referenced by digest, to avoid false positives (alerts) if the remote image has been updated
 func CheckImageAllowedHandler(transport http.RoundTripper) router.HandlerFunc {
 	return func(req router.Request, resp router.Response) error {
 		appInstance := req.Object.(*v1.AppInstance)
 		cond := condition.Setter(appInstance, resp, v1.AppInstanceConditionImageAllowed)
 
-		targetImage := appInstance.Status.AppImage.Name
-
-		if targetImage == "" {
-			if _, pattern := autoupgrade.AutoUpgradePattern(appInstance.Spec.Image); pattern {
-				return nil
-			}
-			targetImage = appInstance.Spec.Image
+		// We're only checking against the currently used image, so if the image name or digest is empty, we can't check
+		if appInstance.Status.AppImage.Name == "" || appInstance.Status.AppImage.Digest == "" {
+			cond.Unknown("")
+			return nil
 		}
+
+		ref, err := name.ParseReference(appInstance.Status.AppImage.Name, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
+		if err != nil {
+			e := fmt.Errorf("failed to parse image name: %w", err)
+			logrus.Error(e)
+			cond.Error(e)
+			return nil
+		}
+
+		targetImage := ref.Context().Digest(strings.TrimPrefix(appInstance.Status.AppImage.Digest, "sha256:")).Name()
 
 		if err := imageallowrules.CheckImageAllowed(req.Ctx, req.Client, appInstance.Namespace, targetImage, remote.WithTransport(transport)); err != nil {
 			if errors.Is(err, &imageallowrules.ErrImageNotAllowed{}) {

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -50,12 +50,17 @@ func EnsureReferences(ctx context.Context, c client.Reader, img string, opts *Ve
 		return fmt.Errorf("failed to parse image %s: %w", img, err)
 	}
 
-	imgDigest, err := crane.Digest(imgRef.Name(), opts.CraneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
-	if err != nil {
-		return fmt.Errorf("failed to resolve image digest: %w", err)
-	}
+	// in the best case, we have a digest ref already, so we don't need to do any external request
+	if imgDigest, ok := imgRef.(name.Digest); ok {
+		opts.ImageRef = imgDigest
+	} else {
+		imgDigest, err := crane.Digest(imgRef.Name(), opts.CraneOpts...) // this uses HEAD to determine the digest, but falls back to GET if HEAD fails
+		if err != nil {
+			return fmt.Errorf("failed to resolve image digest: %w", err)
+		}
 
-	opts.ImageRef = imgRef.Context().Digest(imgDigest)
+		opts.ImageRef = imgRef.Context().Digest(imgDigest)
+	}
 
 	signatureRef, err := ensureSignatureArtifact(ctx, c, opts.Namespace, opts.ImageRef, opts.NoCache, opts.OciRemoteOpts, opts.CraneOpts)
 	if err != nil {


### PR DESCRIPTION
Before, it could check the updated (but same tagged) remote image and thus throw an error into the status field, even though the current image is still allowed.

Also, now we pass the digest through earlier to enable skipping a call to the external registry

Ref #1428

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

…ageallowrules

Signed-off-by: Thorsten Klein <tk@thklein.io>