### PR TITLE
Handle edge-cases around auto-upgrade patterns (#1377)

### DIFF
--- a/pkg/autoupgrade/tags.go
+++ b/pkg/autoupgrade/tags.go
@@ -49,8 +49,8 @@ func findLatestTagForImageWithPattern(ctx context.Context, c daemonClient, curre
 	}
 	newImage := strings.TrimPrefix(ref.Context().Tag(newTag).Name(), defaultNoReg+"/")
 	for len(tags) > 0 {
-		nTag, err := FindLatest(current, pattern, tags)
-		if err != nil || nTag == current {
+		nTag, err := FindLatest(newTag, pattern, tags)
+		if err != nil || nTag == newTag {
 			// resorting to current tag, so stop trying (we don't want to loop forever)
 			break
 		}
@@ -97,7 +97,7 @@ func FindLatest(current, pattern string, tags []string) (string, error) {
 
 	// ** denotes a part of the tag that should be completely ignored for both matching and sorting. Replace it with
 	// a regexp expression that matches all valid tag characters
-	pattern = strings.ReplaceAll(pattern, "**", `([0-9A-Za-z_.-]+)`)
+	pattern = strings.ReplaceAll(pattern, "**", `([0-9A-Za-z_.-]{0,})`)
 
 	index := 0
 	var namedMatchingGroups []namedMatchingGroup

--- a/pkg/autoupgrade/tags_test.go
+++ b/pkg/autoupgrade/tags_test.go
@@ -28,6 +28,9 @@ func TestTags(t *testing.T) {
 	// I don't care about the "pre-release" part, just give me the latest 1.x
 	test(t, "v#.#-**", 1, []string{"v1.0-a", "v1.1-b", "v1.0-c", "v1.0-z"})
 
+	// I don't care about the anything other than the numerical version, just give me the latest 1.x
+	test(t, "v#.#**", 2, []string{"v1.0-a", "v1.1-b", "v1.2", "v1.0-c", "v1.0-z"})
+
 	// an alpha sort segment, followed by a dot, followed by a numeric sort segment
 	test(t, "v#.#-*.#", 2, []string{"v1.1-a.9", "v1.1-b.1", "v1.1-b.2", "v1.1-b.0"})
 


### PR DESCRIPTION
There were a few cases where auto-upgrade patterns failed to do the expected thing.

1. When using an auto-upgrade pattern that did not match any existing tags, the digest for existing tags would be pulled and used to start the app. This is incorrect when no tag matched the pattern.
2. When using the auto-upgrade pattern of only '*', the matching would fail to match any tag that was not "latest".
3. Using an auto-upgrade pattern ending with '**' implicitly expected that the '**' would match something. So, if the pattern was 'v1.#**' and the existing tags were 'v1.1-rc1' and 'v1.2', then the first tag would match even though the second tag was "better" according to the '#'.

These issues are fixed here.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issues:
https://github.com/acorn-io/acorn/issues/1394
https://github.com/acorn-io/acorn/issues/1377
https://github.com/acorn-io/acorn/issues/1474