### PR TITLE
fix: leftover trimPrefix on digest was breaking imageAllowRules check (#1482)

### DIFF
--- a/pkg/controller/appdefinition/checkimageallowed.go
+++ b/pkg/controller/appdefinition/checkimageallowed.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/condition"
@@ -36,7 +35,7 @@ func CheckImageAllowedHandler(transport http.RoundTripper) router.HandlerFunc {
 			return nil
 		}
 
-		targetImage := ref.Context().Digest(strings.TrimPrefix(appInstance.Status.AppImage.Digest, "sha256:")).Name()
+		targetImage := ref.Context().Digest(appInstance.Status.AppImage.Digest).Name()
 
 		if err := imageallowrules.CheckImageAllowed(req.Ctx, req.Client, appInstance.Namespace, targetImage, remote.WithTransport(transport)); err != nil {
 			if errors.Is(err, &imageallowrules.ErrImageNotAllowed{}) {


### PR DESCRIPTION
Ref #1482

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section -> None
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description -> None
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change) -> extremely minor fix that was breaking app deployment if imageAllowRules are present

