### PR TITLE
Explicitly callout dev profiles being used in dev mode

### DIFF
--- a/docs/docs/38-authoring/07-args-and-profiles.md
+++ b/docs/docs/38-authoring/07-args-and-profiles.md
@@ -73,7 +73,7 @@ The config file can then be passed to the Acorn using
 
 ### Built-in
 
-To prevent the author from having to create a profile, Acorn provides the `args.dev` boolean value. It is set to `true` when running in dev mode (`acorn run -i`). Acorn authors can use this boolean with `if` statements to change dev vs. production runtime behaviors.
+To prevent the author from having to create a profile, Acorn provides the `args.dev` boolean value. It is set to `true` when running in dev mode (`acorn dev` or `acorn run -i`). Acorn authors can use this boolean with `if` statements to change dev vs. production runtime behaviors.
 
 ```acorn
 containers: {
@@ -104,6 +104,10 @@ profiles: {
     }
 }
 ```
+
+:::note
+Acorn automatically uses the `dev` profile when when running in dev mode (`acorn dev` or `acorn run -i`).
+:::
 
 In this case when an Acorn consumer deploys the Acorn in production, 3 replicas will be deployed. When the developer working on this app runs it locally with `acorn run --profile dev .` there will only be a single replica deployed by default.
 

--- a/docs/docs/50-running/70-dev.md
+++ b/docs/docs/50-running/70-dev.md
@@ -17,4 +17,6 @@ The interactive dev mode offers a convenient way to test and debug your project 
     acorn dev -n [APP_NAME]
     ```
 
-
+:::note
+When using `acorn dev` the `dev` profile will be automatically used. This behavior is the same when using `acorn run -i`.
+:::


### PR DESCRIPTION
### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

