### PR TITLE
Only add default toleration when it is empty

### DIFF
--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -79,11 +79,13 @@ func addScheduling(req router.Request, appInstance *v1.AppInstance, workloads ma
 		}
 
 		// Add default toleration to taints.acorn.io/workload. This is so that when worker nodes are tainted
-		// with taints.acorn.io/workload, user app can still tolerate.
-		tolerations = append(tolerations, corev1.Toleration{
-			Key:      tl.WorkloadTolerationKey,
-			Operator: corev1.TolerationOpExists,
-		})
+		// with taints.acorn.io/workload, user app can still tolerate. Only add default toleration when toleration is not set
+		if len(tolerations) == 0 {
+			tolerations = append(tolerations, corev1.Toleration{
+				Key:      tl.WorkloadTolerationKey,
+				Operator: corev1.TolerationOpExists,
+			})
+		}
 
 		appInstance.Status.Scheduling[name] = v1.Scheduling{
 			Requirements: *requirements,


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

We only want to add default toleration to acorn app if no toleration is set. If toleration is set(from computeclass) we don't wa nt to add default toleration to cause unexpected behavior. 

