### PR TITLE
Don't fail on old publish/expose fields in app.spec.ports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ replace (
 require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/acorn-io/aml v0.0.0-20230413014233-c548a151d191
+	github.com/acorn-io/aml v0.0.0-20230414143651-b12ed6334260
 	github.com/acorn-io/baaah v0.0.0-20230410050548-f08516abc5c3
 	github.com/acorn-io/mink v0.0.0-20230408054940-c2216a3c8f8d
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/acorn-io/aml v0.0.0-20230413014233-c548a151d191 h1:agfmZc0N5wkuXJgm/dBF3V100lZrN9omqvZkvGEJcv4=
-github.com/acorn-io/aml v0.0.0-20230413014233-c548a151d191/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
+github.com/acorn-io/aml v0.0.0-20230414143651-b12ed6334260 h1:ZM6AMfDrsMn2f7SgV6U3f7mz9q0qKO1MKw9Tehq/RUY=
+github.com/acorn-io/aml v0.0.0-20230414143651-b12ed6334260/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
 github.com/acorn-io/apiserver v0.25.2-ot-2 h1:drxKtiHh2dGnKlhVYxgPCKkFXRvMFxdflCZ5fHpVp8E=
 github.com/acorn-io/apiserver v0.25.2-ot-2/go.mod h1:qRxmYneSxb8B1FYvgQf6mPeWuwugIzYKN3TeMmL4FVo=
 github.com/acorn-io/baaah v0.0.0-20230410050548-f08516abc5c3 h1:GQZOLkMwPTWlZgIcPs8hMClk4GRcQPMlwuax/IXq5hA=

--- a/pkg/apis/internal.acorn.io/v1/appspec.go
+++ b/pkg/apis/internal.acorn.io/v1/appspec.go
@@ -81,7 +81,13 @@ type PortBinding struct {
 	Protocol Protocol `json:"protocol,omitempty"`
 	Hostname string   `json:"hostname,omitempty"`
 	// Deprecated Use Hostname instead
-	ZZ_ServiceName    string `json:"serviceName,omitempty"`
+	ZZ_ServiceName string `json:"serviceName,omitempty"`
+	// Deprecated Has no meaning, publish=true is always assumed
+	Publish bool `json:"publish,omitempty"`
+	// Deprecated Has no meaning, all ports are exposed by default, if this is true
+	// The binding is ignored unless publish is also set to true (which is also deprecated)
+	Expose bool `json:"expose,omitempty"`
+	// Deprecated All ports are exposed by default
 	TargetPort        int32  `json:"targetPort,omitempty"`
 	TargetServiceName string `json:"targetServiceName,omitempty"`
 }

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -6939,10 +6939,25 @@ func schema_pkg_apis_internalacornio_v1_PortBinding(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"publish": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated Has no meaning, publish=true is always assumed",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"expose": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated Has no meaning, all ports are exposed by default, if this is true The binding is ignored unless publish is also set to true (which is also deprecated)",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"targetPort": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "Deprecated All ports are exposed by default",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"targetServiceName": {

--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -160,6 +160,10 @@ func portMatches(binding v1.PortPublish, port v1.PortDef) bool {
 }
 
 func serviceMatches(serviceName string, binding v1.PortBinding) bool {
+	// deal with deprecated fields
+	if binding.Expose && !binding.Publish {
+		return false
+	}
 	return binding.TargetServiceName == "" || binding.TargetServiceName == serviceName
 }
 


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

