### PR TITLE
Create local image records for images used by acorns

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   main-release:
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-32vcpu-ubuntu-2204
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ replace (
 require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/acorn-io/aml v0.0.0-20230413014233-c548a151d191
+	github.com/acorn-io/aml v0.0.0-20230414143651-b12ed6334260
 	github.com/acorn-io/baaah v0.0.0-20230410050548-f08516abc5c3
 	github.com/acorn-io/mink v0.0.0-20230408054940-c2216a3c8f8d
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/acorn-io/aml v0.0.0-20230413014233-c548a151d191 h1:agfmZc0N5wkuXJgm/dBF3V100lZrN9omqvZkvGEJcv4=
-github.com/acorn-io/aml v0.0.0-20230413014233-c548a151d191/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
+github.com/acorn-io/aml v0.0.0-20230414143651-b12ed6334260 h1:ZM6AMfDrsMn2f7SgV6U3f7mz9q0qKO1MKw9Tehq/RUY=
+github.com/acorn-io/aml v0.0.0-20230414143651-b12ed6334260/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
 github.com/acorn-io/apiserver v0.25.2-ot-2 h1:drxKtiHh2dGnKlhVYxgPCKkFXRvMFxdflCZ5fHpVp8E=
 github.com/acorn-io/apiserver v0.25.2-ot-2/go.mod h1:qRxmYneSxb8B1FYvgQf6mPeWuwugIzYKN3TeMmL4FVo=
 github.com/acorn-io/baaah v0.0.0-20230410050548-f08516abc5c3 h1:GQZOLkMwPTWlZgIcPs8hMClk4GRcQPMlwuax/IXq5hA=

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -78,7 +78,7 @@ func TestSimilarBuilds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.NotEqual(t, image.ID, image2.ID)
+	assert.NotEqual(t, image.Name, image2.Name)
 }
 
 func TestJobBuild(t *testing.T) {

--- a/integration/client/apps/update_test.go
+++ b/integration/client/apps/update_test.go
@@ -36,10 +36,10 @@ func TestUpdatePull(t *testing.T) {
 	}
 
 	app = helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
-		return obj.Status.AppImage.ID == imageID
+		return obj.Status.AppImage.Name == imageID
 	})
 	assert.NotEmpty(t, app.Status.Namespace)
-	assert.Equal(t, app.Status.AppImage.ID, imageID)
+	assert.Equal(t, app.Status.AppImage.Name, imageID)
 
 	imageID2 := client2.NewImage2(t, ns.Name)
 	err = c.ImageTag(ctx, imageID2, "foo:latest")
@@ -53,7 +53,7 @@ func TestUpdatePull(t *testing.T) {
 	}
 
 	app = helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
-		return obj.Status.AppImage.ID == imageID2
+		return obj.Status.AppImage.Name == imageID2
 	})
-	assert.Equal(t, app.Status.AppImage.ID, imageID2)
+	assert.Equal(t, app.Status.AppImage.Name, imageID2)
 }

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -17,7 +17,7 @@ func NewImageWithSidecar(t *testing.T, namespace string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.ID
+	return image.Name
 }
 
 func NewImage2(t *testing.T, namespace string) string {
@@ -30,7 +30,7 @@ func NewImage2(t *testing.T, namespace string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.ID
+	return image.Name
 }
 
 func NewImage(t *testing.T, namespace string) string {
@@ -43,5 +43,5 @@ func NewImage(t *testing.T, namespace string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.ID
+	return image.Name
 }

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -45,7 +45,7 @@ func TestAppsSSA(t *testing.T) {
 			Namespace: ns.Name,
 		},
 		Spec: v1.AppInstanceSpec{
-			Image: image.ID,
+			Image: image.Name,
 		},
 	})
 	if err != nil {
@@ -66,7 +66,7 @@ func TestAppsSSA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, image.ID, app.Spec.Image)
+	assert.Equal(t, image.Name, app.Spec.Image)
 }
 
 func TestFriendlyNameInContainer(t *testing.T) {
@@ -96,7 +96,7 @@ func TestFriendlyNameInContainer(t *testing.T) {
 			},
 		},
 		Spec: v1.AppInstanceSpec{
-			Image: image.ID,
+			Image: image.Name,
 		},
 	}
 

--- a/integration/client/depends_test.go
+++ b/integration/client/depends_test.go
@@ -26,7 +26,7 @@ func depImage(t *testing.T, c client.Client) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.ID
+	return image.Name
 }
 
 func toRevision(t *testing.T, obj kclient.Object) int {

--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -75,7 +75,7 @@ func TestImageTagMove(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.ImageTag(ctx, image2.ID, "foo:latest")
+	err = c.ImageTag(ctx, image2.Name, "foo:latest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestImageTagMove(t *testing.T) {
 	for _, image := range images {
 		if image.Name == imageID {
 			assert.Equal(t, []string([]string(nil)), image.Tags)
-		} else if image.Name == image2.ID {
+		} else if image.Name == image2.Name {
 			assert.Equal(t, "foo:latest", image.Tags[0])
 		} else {
 			t.Fatal(err, "invalid image")

--- a/integration/log/log_test.go
+++ b/integration/log/log_test.go
@@ -34,7 +34,7 @@ func TestLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.ID, &client.AppRunOptions{
+	app, err := c.AppRun(context.Background(), image.Name, &client.AppRunOptions{
 		/* When running this test with the acorn-linkerd-plugin installed, the app inits too quickly, and
 		   the acorn controller does not have enough time to propagate the injection annotation to the
 		   test namespace before the app is created, so linkerd does not end up injecting the sidecar.
@@ -92,7 +92,7 @@ func TestContainerLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.ID, nil)
+	app, err := c.AppRun(context.Background(), image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestSidecarContainerLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.ID, nil)
+	app, err := c.AppRun(context.Background(), image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -46,7 +46,7 @@ func TestVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
+	app, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Volume: pv.Name,
@@ -108,7 +108,7 @@ func TestVolumeBadClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, nil)
+	_, err = c.AppRun(ctx, image.Name, nil)
 	if err == nil {
 		t.Fatal("expected app with bad volume class to error on run")
 	}
@@ -149,7 +149,7 @@ func TestVolumeBadClassInImageBoundToGoodClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{
+	app, err := c.AppRun(ctx, image.Name, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -209,7 +209,7 @@ func TestVolumeBoundBadClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
+	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -250,7 +250,7 @@ func TestVolumeClassInactive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, nil)
+	_, err = c.AppRun(ctx, image.Name, nil)
 	if err == nil {
 		t.Fatal("expected app with inactive volume class to error on run")
 	}
@@ -287,7 +287,7 @@ func TestVolumeClassSizeTooSmall(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
+	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -331,7 +331,7 @@ func TestVolumeClassSizeTooLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
+	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -379,7 +379,7 @@ func TestVolumeClassRemoved(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func TestClusterVolumeClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func TestClusterVolumeClassValuesInAcornfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -573,7 +573,7 @@ func TestProjectVolumeClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestProjectVolumeClassDefaultSizeValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +703,7 @@ func TestProjectVolumeClassDefaultSizeBadValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, nil)
+	_, err = c.AppRun(ctx, image.Name, nil)
 	if err == nil {
 		t.Fatal("expected app with size too large for volume class to error on run")
 	}
@@ -750,7 +750,7 @@ func TestProjectVolumeClassValuesInAcornfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,7 +782,7 @@ func TestImageNameAnnotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -821,7 +821,7 @@ func TestSimple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -862,7 +862,7 @@ func TestDeployParam(t *testing.T) {
 			Namespace: ns.Name,
 		},
 		Spec: v1.AppInstanceSpec{
-			Image: image.ID,
+			Image: image.Name,
 			DeployArgs: map[string]any{
 				"someInt": 5,
 			},
@@ -1109,7 +1109,7 @@ func TestUsingComputeClasses(t *testing.T) {
 				}
 
 				// Assign a name for the test case so no collisions occur
-				app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{Name: testcase})
+				app, err := c.AppRun(ctx, image.Name, &client.AppRunOptions{Name: testcase})
 				if err != nil {
 					if tt.fail {
 						return
@@ -1152,7 +1152,7 @@ func TestAppWithBadRegion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{Region: "does-not-exist"})
+	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{Region: "does-not-exist"})
 	if err == nil || !strings.Contains(err.Error(), "is not supported for project") {
 		t.Fatalf("expected an invalid region error, got %v", err)
 	}
@@ -1197,7 +1197,7 @@ func TestAppWithBadDefaultRegion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.ID, nil)
+	_, err = c.AppRun(ctx, image.Name, nil)
 	if err == nil || !strings.Contains(err.Error(), "is not a valid volume class") {
 		t.Fatalf("expected an invalid region error, got %v", err)
 	}
@@ -1276,7 +1276,7 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while building image:", err)
 	}
-	fooApp, err := proj1Client.AppRun(ctx, fooImage.ID, &client.AppRunOptions{
+	fooApp, err := proj1Client.AppRun(ctx, fooImage.Name, &client.AppRunOptions{
 		Name:            "foo",
 		TargetNamespace: proj1.Namespace,
 	})
@@ -1288,7 +1288,7 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while building image:", err)
 	}
-	barApp, err := proj2Client.AppRun(ctx, barImage.ID, &client.AppRunOptions{
+	barApp, err := proj2Client.AppRun(ctx, barImage.Name, &client.AppRunOptions{
 		Name:            "bar",
 		TargetNamespace: proj2.Namespace,
 	})
@@ -1329,14 +1329,14 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 			name:          "curl-foo-proj1",
 			client:        proj1Client,
 			podIP:         fooIP,
-			imageID:       curlImage1.ID,
+			imageID:       curlImage1.Name,
 			expectFailure: false,
 		},
 		{
 			name:    "curl-bar-proj1",
 			client:  proj1Client,
 			podIP:   barIP,
-			imageID: curlImage1.ID,
+			imageID: curlImage1.Name,
 			// even though bar has port 80 published, it should not be reachable from anything outside
 			// proj2 except for the ingress controller, so failure is expected here
 			expectFailure: true,
@@ -1345,14 +1345,14 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 			name:          "curl-foo-proj2",
 			client:        proj2Client,
 			podIP:         fooIP,
-			imageID:       curlImage2.ID,
+			imageID:       curlImage2.Name,
 			expectFailure: true,
 		},
 		{
 			name:          "curl-bar-proj2",
 			client:        proj2Client,
 			podIP:         barIP,
-			imageID:       curlImage2.ID,
+			imageID:       curlImage2.Name,
 			expectFailure: false,
 		},
 	}

--- a/integration/secrets/secret_test.go
+++ b/integration/secrets/secret_test.go
@@ -35,7 +35,7 @@ func TestText(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.ID, nil)
+	app, err := c.AppRun(context.Background(), image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.ID, nil)
+	app, err := c.AppRun(ctx, image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestIssue552(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.ID, nil)
+	app, err := c.AppRun(context.Background(), image.Name, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestEncryptionEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c1.AppRun(context.Background(), image.ID, &client.AppRunOptions{
+	app, err := c1.AppRun(context.Background(), image.Name, &client.AppRunOptions{
 		DeployArgs: map[string]any{
 			"encdata": output,
 		},
@@ -199,7 +199,7 @@ func TestNamespacedDecryption(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c2.AppRun(context.Background(), image.ID, &client.AppRunOptions{
+	app, err := c2.AppRun(context.Background(), image.Name, &client.AppRunOptions{
 		DeployArgs: map[string]any{
 			"encdata": encdata,
 		},
@@ -235,7 +235,7 @@ func TestMultiKeyDecryptionEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c1.AppRun(context.Background(), image.ID, &client.AppRunOptions{
+	app, err := c1.AppRun(context.Background(), image.Name, &client.AppRunOptions{
 		DeployArgs: map[string]any{
 			"encdata": encdata,
 		},

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -116,6 +116,7 @@ type Image struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
+	Remote bool     `json:"remote,omitempty"`
 	Repo   string   `json:"repo,omitempty"`
 	Digest string   `json:"digest,omitempty"`
 	Tags   []string `json:"tags,omitempty"`

--- a/pkg/apis/internal.acorn.io/v1/appimage.go
+++ b/pkg/apis/internal.acorn.io/v1/appimage.go
@@ -1,7 +1,6 @@
 package v1
 
 type AppImage struct {
-	ID        string     `json:"id,omitempty"`
 	Name      string     `json:"name,omitempty"`
 	Digest    string     `json:"digest,omitempty"`
 	Acornfile string     `json:"acornfile,omitempty"`

--- a/pkg/apis/internal.acorn.io/v1/appspec.go
+++ b/pkg/apis/internal.acorn.io/v1/appspec.go
@@ -81,7 +81,13 @@ type PortBinding struct {
 	Protocol Protocol `json:"protocol,omitempty"`
 	Hostname string   `json:"hostname,omitempty"`
 	// Deprecated Use Hostname instead
-	ZZ_ServiceName    string `json:"serviceName,omitempty"`
+	ZZ_ServiceName string `json:"serviceName,omitempty"`
+	// Deprecated Has no meaning, publish=true is always assumed
+	Publish bool `json:"publish,omitempty"`
+	// Deprecated Has no meaning, all ports are exposed by default, if this is true
+	// The binding is ignored unless publish is also set to true (which is also deprecated)
+	Expose bool `json:"expose,omitempty"`
+	// Deprecated All ports are exposed by default
 	TargetPort        int32  `json:"targetPort,omitempty"`
 	TargetServiceName string `json:"targetServiceName,omitempty"`
 }

--- a/pkg/apis/internal.acorn.io/v1/imageinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/imageinstance.go
@@ -34,6 +34,10 @@ type ImageInstance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
+	// Remote indicates that this image has not been locally cached to the internal registry
+	// meaning that it may not exist at the location recorded in the Repo field if the user
+	// has deleted the image after the fact
+	Remote bool     `json:"remote,omitempty"`
 	Repo   string   `json:"repo,omitempty"`
 	Digest string   `json:"digest,omitempty"`
 	Tags   []string `json:"tags,omitempty"`

--- a/pkg/apis/internal.acorn.io/v1/unmarshal.go
+++ b/pkg/apis/internal.acorn.io/v1/unmarshal.go
@@ -273,6 +273,9 @@ func (in *VolumeBinding) UnmarshalJSON(data []byte) error {
 
 func impliedSecretsForContainer(app *AppSpec, container Container) {
 	for _, env := range container.Environment {
+		if strings.Contains(env.Secret.Name, ".") {
+			continue
+		}
 		if _, ok := app.Secrets[env.Secret.Name]; env.Secret.Name != "" && !ok {
 			app.Secrets[env.Secret.Name] = Secret{
 				Type: "opaque",

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -105,7 +105,7 @@ func build(ctx *buildContext) (*v1.AppImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to finalize app image: %w", err)
 	}
-	appImage.ID = id
+	appImage.Name = id
 	appImage.Digest = "sha256:" + id
 
 	return appImage, nil

--- a/pkg/buildserver/server.go
+++ b/pkg/buildserver/server.go
@@ -91,7 +91,7 @@ func (s *Server) serveHTTP(rw http.ResponseWriter, req *http.Request) error {
 		_ = m.Send(&buildclient.Message{
 			AppImage: image,
 		})
-		logrus.Infof("Build succeeded [%s/%s] [%s]: %v", token.Build.Namespace, token.Build.Name, token.Build.UID, image.ID)
+		logrus.Infof("Build succeeded [%s/%s] [%s]: %v", token.Build.Namespace, token.Build.Name, token.Build.UID, image.Name)
 	} else {
 		_ = m.Send(&buildclient.Message{
 			Error: err.Error(),
@@ -175,7 +175,7 @@ func (s *Server) recordBuild(ctx context.Context, recordRepo string, build *v1.A
 	}
 	err := apply.New(s.client).Ensure(ctx, &v1.ImageInstance{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      image.ID,
+			Name:      image.Name,
 			Namespace: build.Namespace,
 		},
 		Repo:   recordRepo,

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -302,7 +302,7 @@ func (s *Run) update(ctx context.Context, c client.Client, imageSource imagesour
 
 	if !imageSource.IsImageSet() {
 		// If there is no image set, then lookup the existing app and use the image of the current app
-		imageSource = imageSource.WithImage(app.Status.AppImage.ID)
+		imageSource = imageSource.WithImage(app.Status.AppImage.Name)
 	}
 
 	image, deployArgs, err := imageSource.GetImageAndDeployArgs(ctx, c)

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -606,7 +606,7 @@ func (m *MockClient) ImageTag(ctx context.Context, image, tag string) error {
 
 func (m *MockClient) ImageDetails(ctx context.Context, imageName string, opts *client.ImageDetailsOptions) (*client.ImageDetails, error) {
 	return &client.ImageDetails{
-		AppImage: v1.AppImage{ID: imageName, ImageData: v1.ImagesData{
+		AppImage: v1.AppImage{Name: imageName, ImageData: v1.ImagesData{
 			Containers: map[string]v1.ContainerData{"test-image-running-container": v1.ContainerData{
 				Image:    "test-image-running-container",
 				Sidecars: nil,

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"path"
 	"strings"
@@ -63,9 +64,14 @@ func DeploySpec(req router.Request, resp router.Response) (err error) {
 			// yet to be created
 			interpolatorErr := interpolator.Err()
 			if interpolatorErr == nil {
-				status.Success()
+				missing := interpolator.Missing()
+				if len(missing) == 0 {
+					status.Success()
+				} else {
+					status.Unknown(fmt.Sprintf("waiting on missing secrets %v", missing))
+				}
 			} else {
-				status.Error(err)
+				status.Error(interpolatorErr)
 			}
 		} else {
 			status.Error(err)
@@ -234,7 +240,7 @@ func toMounts(app *v1.AppInstance, container v1.Container, interpolation *secret
 		} else {
 			// file pointing to secret
 			result = append(result, corev1.VolumeMount{
-				Name:      "secret--" + entry.Value.Secret.Name + suffix,
+				Name:      secretPodVolName(entry.Value.Secret.Name + suffix),
 				MountPath: path.Join("/", entry.Key),
 				SubPath:   entry.Value.Secret.Key,
 			})
@@ -260,7 +266,7 @@ func toMounts(app *v1.AppInstance, container v1.Container, interpolation *secret
 			})
 		} else {
 			result = append(result, corev1.VolumeMount{
-				Name:      "secret--" + mount.Secret.Name,
+				Name:      secretPodVolName(mount.Secret.Name),
 				MountPath: path.Join("/", mountPath),
 			})
 		}

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -72,7 +72,7 @@ func DeploySpec(req router.Request, resp router.Response) (err error) {
 		}
 	}()
 
-	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.ID)
+	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/appdefinition/imagepulled.go
+++ b/pkg/controller/appdefinition/imagepulled.go
@@ -8,7 +8,7 @@ import (
 func ImagePulled(h router.Handler) router.Handler {
 	return router.HandlerFunc(func(req router.Request, resp router.Response) error {
 		appInstance := req.Object.(*v1.AppInstance)
-		if appInstance.Status.AppImage.ID == "" {
+		if appInstance.Status.AppImage.Name == "" {
 			return nil
 		}
 		return h.Handle(req, resp)

--- a/pkg/controller/appdefinition/parse_test.go
+++ b/pkg/controller/appdefinition/parse_test.go
@@ -23,7 +23,7 @@ func TestParseAppImageBug(t *testing.T) {
 			Containers: map[string]v1.ContainerData{},
 		},
 		Acornfile: "",
-		ID:        "",
+		Name:      "",
 	}
 	app, err := appdefinition.FromAppImage(appImage)
 	if err != nil {

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -39,7 +39,7 @@ func PullAppImage(transport http.RoundTripper) router.HandlerFunc {
 			cond.Error(err)
 			return nil
 		}
-		appImage.Name = targetImage
+		appImage.Name = resolvedImage
 		appInstance.Status.AvailableAppImage = ""
 		appInstance.Status.ConfirmUpgradeAppImage = ""
 		appInstance.Status.AppImage = *appImage
@@ -61,7 +61,7 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string) {
 			} else {
 				// ConfirmUpgradeAppImage is not blank. Normally, we shouldn't get the desiredImage from it. That should
 				// be done explicitly by the user via the apps/confirmupgrade subresource (which would set it to the
-				// AvailableAppImage field). But if AppImage.ID is blank, this app has never had an image pulled. So, do the initial pull.
+				// AvailableAppImage field). But if AppImage.Name is blank, this app has never had an image pulled. So, do the initial pull.
 				if appInstance.Status.AppImage.Name == "" {
 					return appInstance.Status.ConfirmUpgradeAppImage, ""
 				} else {

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -62,7 +62,6 @@ func app(specImage, statusImageID, statusAvailableImage, statusConfirmUpgradeIma
 		},
 		Status: v1.AppInstanceStatus{
 			AppImage: v1.AppImage{
-				ID:   statusImageID,
 				Name: statusImageID,
 			},
 			AvailableAppImage:      statusAvailableImage,

--- a/pkg/controller/appdefinition/secret_test.go
+++ b/pkg/controller/appdefinition/secret_test.go
@@ -18,7 +18,7 @@ func TestSecretDirsToMounts(t *testing.T) {
 		},
 		Status: v1.AppInstanceStatus{
 			AppImage: v1.AppImage{
-				ID: "test",
+				Name: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Containers: map[string]v1.Container{

--- a/pkg/controller/appdefinition/status.go
+++ b/pkg/controller/appdefinition/status.go
@@ -99,7 +99,7 @@ func ReadyStatus(req router.Request, resp router.Response) error {
 	}
 
 	cond.Success()
-	app.Status.Ready = ready && app.Status.AppImage.ID != "" &&
+	app.Status.Ready = ready && app.Status.AppImage.Name != "" &&
 		app.Generation == app.Status.ObservedGeneration &&
 		app.Status.Condition(v1.AppInstanceConditionParsed).Success &&
 		app.Status.Condition(v1.AppInstanceConditionContainers).Success &&

--- a/pkg/controller/appdefinition/testdata/acorn/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/labels/expected.yaml.d/appinstance.yaml
@@ -167,7 +167,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: foo
+    name: foo
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/acorn/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/labels/input.yaml
@@ -55,7 +55,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: foo
+    name: foo
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml.d/appinstance.yaml
@@ -43,7 +43,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
@@ -43,7 +43,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.yaml.d/appinstance.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/input.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/container/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/container/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/input.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.yaml.d/appinstance.yaml
@@ -51,7 +51,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/input.yaml
@@ -51,7 +51,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/input.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
@@ -41,7 +41,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/sidecar/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/sidecar/expected.yaml.d/appinstance.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/sidecar/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/sidecar/input.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.yaml.d/appinstance.yaml
@@ -36,7 +36,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/input.yaml
@@ -36,7 +36,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.yaml.d/appinstance.yaml
@@ -39,7 +39,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/input.yaml
@@ -39,7 +39,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
@@ -62,7 +62,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/cronjob/input.yaml
+++ b/pkg/controller/appdefinition/testdata/cronjob/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/depends-ready/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/depends-ready/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: "image-name"
+    name: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/depends-ready/input.yaml
+++ b/pkg/controller/appdefinition/testdata/depends-ready/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: "image-name"
+    name: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: "image-name"
+    name: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/depends/input.yaml
+++ b/pkg/controller/appdefinition/testdata/depends/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: "image-name"
+    name: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/expected.yaml
@@ -166,7 +166,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels-namespace/input.yaml
@@ -91,7 +91,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/appinstance.yaml
@@ -39,7 +39,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       allowed.io: test-allowed-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/input.yaml
@@ -91,7 +91,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels-namespace/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/appinstance.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels-namespace/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/scale/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/scale/expected.yaml
@@ -145,7 +145,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/scale/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/scale/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/stop/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/stop/expected.yaml
@@ -148,7 +148,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/stop/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/stop/input.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files-bug/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/files-bug/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files-bug/input.yaml
+++ b/pkg/controller/appdefinition/testdata/files-bug/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/files/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files/input.yaml
+++ b/pkg/controller/appdefinition/testdata/files/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/globalenv/input.yaml
+++ b/pkg/controller/appdefinition/testdata/globalenv/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/appinstance.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/input.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels-namespace/input.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/appinstance.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/input.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.yaml.d/appinstance.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       app1:

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/input.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       app1:

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/appinstance.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/appinstance.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/interpolation/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/interpolation/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/interpolation/input.yaml
+++ b/pkg/controller/appdefinition/testdata/interpolation/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
@@ -68,7 +68,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/job/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/basic/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/job/labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels-namespace/input.yaml
@@ -59,7 +59,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/appinstance.yaml
@@ -59,7 +59,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/job/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels/input.yaml
@@ -59,7 +59,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/link/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/link/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       con:

--- a/pkg/controller/appdefinition/testdata/link/input.yaml
+++ b/pkg/controller/appdefinition/testdata/link/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       con:

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.yaml.d/appinstance.yaml
@@ -31,7 +31,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/input.yaml
@@ -31,7 +31,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/all-set/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/expected.yaml.d/appinstance.yaml
@@ -30,7 +30,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/all-set/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/input.yaml
@@ -30,7 +30,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/container/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/container/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/container/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/container/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/job/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/two-containers/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/two-containers/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/two-containers/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/two-containers/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.yaml.d/appinstance.yaml
@@ -24,7 +24,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/input.yaml
@@ -24,7 +24,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/networkpolicy/appinstance/input.yaml
+++ b/pkg/controller/appdefinition/testdata/networkpolicy/appinstance/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       containerOne:

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/appinstance.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/both/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/both/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/input.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/container/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/container/expected.yaml.d/appinstance.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/container/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/container/input.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.yaml.d/appinstance.yaml
@@ -34,7 +34,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/input.yaml
@@ -34,7 +34,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.yaml.d/appinstance.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/differentpermissions/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/differentpermissions/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/job/expected.yaml.d/appinstance.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/job/input.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/appinstance.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/probes/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/probes/expected.yaml
@@ -140,7 +140,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       nodefault:

--- a/pkg/controller/appdefinition/testdata/probes/input.yaml
+++ b/pkg/controller/appdefinition/testdata/probes/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       nodefault:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.yaml.d/appinstance.yaml
@@ -14,7 +14,7 @@ status:
       success: true
   namespace: app-created-namespace
   appImage:
-    id: foo.io/test
+    name: foo.io/test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/custom/input.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/custom/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: foo.io/test
+    name: foo.io/test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.yaml.d/appinstance.yaml
@@ -14,7 +14,7 @@ status:
       success: true
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/default/input.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/default/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/router/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/router/expected.yaml.d/appinstance.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     routers:
       router-name:

--- a/pkg/controller/appdefinition/testdata/router/input.yaml
+++ b/pkg/controller/appdefinition/testdata/router/input.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     routers:
       router-name:

--- a/pkg/controller/appdefinition/testdata/secret/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/secret/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/secret/input.yaml
+++ b/pkg/controller/appdefinition/testdata/secret/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       con1:

--- a/pkg/controller/appdefinition/testdata/service/alias/input.yaml
+++ b/pkg/controller/appdefinition/testdata/service/alias/input.yaml
@@ -26,7 +26,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       con1:

--- a/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/service/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/service/basic/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/template/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/template/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/template/input.yaml
+++ b/pkg/controller/appdefinition/testdata/template/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.yaml
@@ -127,7 +127,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/input.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
@@ -99,7 +99,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.yaml
@@ -82,7 +82,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/contextdir/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/contextdir/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/defaults/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/defaults/expected.yaml
@@ -95,7 +95,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/defaults/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/defaults/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
@@ -93,7 +93,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/empty/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
@@ -108,7 +108,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.yaml
@@ -84,7 +84,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.yaml
@@ -95,7 +95,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/inactive-class/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/inactive-class/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
@@ -99,7 +99,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
@@ -95,7 +95,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.yaml
@@ -87,7 +87,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/no-default-class/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/no-default-class/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/volume.go
+++ b/pkg/controller/appdefinition/volume.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/acorn-io/acorn/pkg/publicname"
 	"github.com/acorn-io/acorn/pkg/secrets"
+	"github.com/acorn-io/baaah/pkg/name"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/labels"
@@ -317,6 +318,10 @@ func addFilesFileModesForContainer(fileModes map[string]bool, container v1.Conta
 	}
 }
 
+func secretPodVolName(secretName string) string {
+	return strings.ReplaceAll(name.SafeConcatName("secret-", secretName), ".", "-")
+}
+
 func toVolumes(appInstance *v1.AppInstance, container v1.Container, interpolator *secrets.Interpolator) (result []corev1.Volume, _ error) {
 	volumeReferences := map[volumeReference]bool{}
 	addVolumeReferencesForContainer(appInstance, volumeReferences, container)
@@ -331,7 +336,7 @@ func toVolumes(appInstance *v1.AppInstance, container v1.Container, interpolator
 				return nil, err
 			}
 			result = append(result, corev1.Volume{
-				Name: "secret--" + volume.secretName + volume.Suffix(),
+				Name: secretPodVolName(volume.secretName + volume.Suffix()),
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName:  volume.secretName,

--- a/pkg/controller/appdefinition/volume_test.go
+++ b/pkg/controller/appdefinition/volume_test.go
@@ -80,7 +80,7 @@ func TestVolumeLabelsAnnotations(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				ID: "image",
+				Name: "image",
 			},
 			AppSpec: v1.AppSpec{
 				Labels: map[string]string{

--- a/pkg/controller/defaults/testdata/memory/all-set-overwrite/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set-overwrite/expected.yaml
@@ -19,7 +19,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/all-set-overwrite/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set-overwrite/input.yaml
@@ -13,7 +13,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/all-set/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/all-set/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/container/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/container/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/container/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/container/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/job/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/job/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/job/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/job/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/same-generation/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/same-generation/expected.yaml
@@ -16,7 +16,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/same-generation/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/same-generation/input.yaml
@@ -16,7 +16,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/sidecar/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/sidecar/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/sidecar/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/sidecar/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/expected.yaml
@@ -14,7 +14,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-containers/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-containers/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-containers/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-containers/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/expected.yaml
@@ -14,7 +14,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/with-acornfile-memory/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/with-acornfile-memory/expected.yaml
@@ -16,7 +16,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/with-acornfile-memory/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/with-acornfile-memory/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/region/default/expected.yaml
+++ b/pkg/controller/defaults/testdata/region/default/expected.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/default/input.yaml
+++ b/pkg/controller/defaults/testdata/region/default/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/project-default-status/expected.yaml
+++ b/pkg/controller/defaults/testdata/region/project-default-status/expected.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/project-default-status/input.yaml
+++ b/pkg/controller/defaults/testdata/region/project-default-status/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/region-on-spec/expected.yaml
+++ b/pkg/controller/defaults/testdata/region/region-on-spec/expected.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/region-on-spec/input.yaml
+++ b/pkg/controller/defaults/testdata/region/region-on-spec/input.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/expected.yaml.d/appinstance.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/expected.yaml.d/appinstance.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/input.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/expected.yaml.d/appinstance.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/input.yaml
@@ -13,7 +13,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/expected.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/expected.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/expected.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/expected.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/images/images.go
+++ b/pkg/controller/images/images.go
@@ -1,0 +1,172 @@
+package images
+
+import (
+	"strings"
+
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/tags"
+	"github.com/acorn-io/baaah/pkg/router"
+	"github.com/google/go-containerregistry/pkg/name"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateImages(req router.Request, resp router.Response) error {
+	app := req.Object.(*v1.AppInstance)
+	if app.Status.AppImage.Name == "" || app.Status.AppImage.Digest == "" {
+		return nil
+	}
+
+	self, err := createImageForSelf(req, app)
+	if err != nil {
+		return nil
+	}
+
+	return createNestedReferences(req, app, self)
+}
+
+func createNestedReferences(req router.Request, app *v1.AppInstance, self *v1.ImageInstance) error {
+	for _, imageData := range app.Status.AppImage.ImageData.Acorns {
+		if !tags.IsLocalReference(imageData.Image) {
+			continue
+		}
+		imageName := strings.TrimPrefix(imageData.Image, "sha256:")
+		nestedImage := &v1.ImageInstance{}
+		err := req.Get(nestedImage, app.Namespace, imageName)
+		if err == nil {
+			continue
+		}
+
+		if apierror.IsNotFound(err) {
+			err = req.Client.Create(req.Ctx, &v1.ImageInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      imageName,
+					Namespace: app.Namespace,
+				},
+				Remote: self.Remote,
+				Repo:   self.Repo,
+				Digest: "sha256:" + imageName,
+			})
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createImageForSelf(req router.Request, app *v1.AppInstance) (*v1.ImageInstance, error) {
+	var (
+		digest    = app.Status.AppImage.Digest
+		digestHex = strings.TrimPrefix(digest, "sha256:")
+		imageName = app.Status.AppImage.Name
+		// update == false means create
+		update = true
+		image  = &v1.ImageInstance{}
+	)
+
+	if tags.IsLocalReference(imageName) {
+		return image, req.Get(image, app.Namespace, imageName)
+	}
+
+	ref, err := name.ParseReference(imageName, name.WithDefaultTag(""))
+	if err != nil {
+		return nil, err
+	}
+
+	hasTag := true
+	// if reference is a digest just store the repo
+	if d, ok := ref.(name.Digest); ok {
+		imageName = d.Context().String()
+		hasTag = false
+	} else if t, ok := ref.(name.Tag); ok {
+		hasTag = t.TagStr() != ""
+	}
+
+	err = req.Get(image, app.Namespace, digestHex)
+	if err != nil && !apierror.IsNotFound(err) {
+		return nil, err
+	} else if apierror.IsNotFound(err) {
+		update = false
+	}
+
+	if update {
+		for _, tag := range image.Tags {
+			if tag == imageName {
+				// We found the existing image and the tag is there, no need to do anything
+				return image, nil
+			} else if !hasTag && strings.HasPrefix(tag, imageName+":") {
+				// We found a close enough match
+				return image, nil
+			}
+		}
+	}
+
+	// remove tag from existing images
+	if err := removeTag(req, app, imageName); err != nil {
+		return nil, err
+	}
+
+	if update {
+		tags := []string{imageName}
+		for _, tag := range image.Tags {
+			if tag == ref.Context().String() {
+				// remove the "repo only" tag
+				continue
+			}
+			tags = append(tags, tag)
+		}
+		image.Tags = tags
+		return image, req.Client.Update(req.Ctx, image)
+	}
+
+	image = &v1.ImageInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      digestHex,
+			Namespace: app.Namespace,
+		},
+		Remote: true,
+		Repo:   ref.Context().String(),
+		Digest: digest,
+		Tags: []string{
+			imageName,
+		},
+	}
+
+	return image, req.Client.Create(req.Ctx, image)
+}
+
+func removeTag(req router.Request, app *v1.AppInstance, tag string) error {
+	images := &v1.ImageInstanceList{}
+	err := req.List(images, &kclient.ListOptions{
+		Namespace: app.Namespace,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images.Items {
+		if len(image.Tags) == 0 {
+			continue
+		}
+
+		newTags := make([]string, 0, len(image.Tags))
+		for _, existingTag := range image.Tags {
+			if existingTag == tag {
+				continue
+			}
+			newTags = append(newTags, existingTag)
+		}
+
+		if len(newTags) != len(image.Tags) {
+			image.Tags = newTags
+			if err := req.Client.Update(req.Ctx, &image); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -3,8 +3,6 @@ package controller
 import (
 	"net/http"
 
-	policyv1 "k8s.io/api/policy/v1"
-
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/controller/acornimagebuildinstance"
 	"github.com/acorn-io/acorn/pkg/controller/appdefinition"
@@ -12,6 +10,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/controller/config"
 	"github.com/acorn-io/acorn/pkg/controller/defaults"
 	"github.com/acorn-io/acorn/pkg/controller/gc"
+	"github.com/acorn-io/acorn/pkg/controller/images"
 	"github.com/acorn-io/acorn/pkg/controller/ingress"
 	"github.com/acorn-io/acorn/pkg/controller/namespace"
 	"github.com/acorn-io/acorn/pkg/controller/pvc"
@@ -26,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -42,7 +42,8 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 
 	router.HandleFunc(&v1.AppInstance{}, appdefinition.AssignNamespace)
 	router.HandleFunc(&v1.AppInstance{}, appdefinition.CheckImageAllowedHandler(registryTransport))
-	router.Type(&v1.AppInstance{}).HandlerFunc(appdefinition.PullAppImage(registryTransport))
+	router.HandleFunc(&v1.AppInstance{}, appdefinition.PullAppImage(registryTransport))
+	router.HandleFunc(&v1.AppInstance{}, images.CreateImages)
 	router.HandleFunc(&v1.AppInstance{}, appdefinition.ParseAppImage)
 	router.HandleFunc(&v1.AppInstance{}, tls.ProvisionCerts) // Provision TLS certificates for port bindings with user-defined (valid) domains
 	router.Type(&v1.AppInstance{}).Middleware(appdefinition.FilterLabelsAndAnnotationsConfig).HandlerFunc(namespace.AddNamespace)

--- a/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml
@@ -46,7 +46,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
@@ -18,7 +18,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set/expected.yaml
@@ -47,7 +47,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/container/expected.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/container/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/container/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     defaults:
   appSpec:
     containers:

--- a/pkg/controller/scheduling/testdata/computeclass/different-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-computeclass/expected.yaml
@@ -57,7 +57,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/different-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-computeclass/input.yaml
@@ -18,7 +18,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/job/expected.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/job/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/job/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml
@@ -44,7 +44,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/same-generation/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/same-generation/expected.yaml
@@ -40,7 +40,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/same-generation/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/same-generation/input.yaml
@@ -42,7 +42,7 @@ status:
           memory: 10Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     defaults:
   appSpec:
     containers:

--- a/pkg/controller/scheduling/testdata/computeclass/sidecar/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/sidecar/expected.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   scheduling:
     oneimage:
       tolerations:

--- a/pkg/controller/scheduling/testdata/computeclass/sidecar/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/sidecar/input.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/expected.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/input.yaml
@@ -17,7 +17,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-containers/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-containers/expected.yaml
@@ -42,7 +42,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-containers/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-containers/input.yaml
@@ -17,7 +17,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/expected.yaml
@@ -17,7 +17,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/input.yaml
@@ -17,7 +17,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/expected.yaml
@@ -42,7 +42,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/input.yaml
@@ -15,7 +15,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set-overwrite/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set-overwrite/expected.yaml
@@ -34,7 +34,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set-overwrite/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set-overwrite/input.yaml
@@ -18,7 +18,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set/expected.yaml
@@ -33,7 +33,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/container/expected.yaml
@@ -29,7 +29,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/container/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/container/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/job/expected.yaml
@@ -29,7 +29,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/job/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/job/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/expected.yaml
@@ -29,7 +29,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/same-generation/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/same-generation/expected.yaml
@@ -25,7 +25,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/same-generation/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/same-generation/input.yaml
@@ -27,7 +27,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/sidecar/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/sidecar/expected.yaml
@@ -24,7 +24,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/sidecar/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/sidecar/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/two-containers/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/two-containers/expected.yaml
@@ -32,7 +32,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/two-containers/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/two-containers/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/expected.yaml
@@ -27,7 +27,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/input.yaml
@@ -15,7 +15,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/tolerations/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/container/expected.yaml
@@ -17,7 +17,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/tolerations/container/input.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/container/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     defaults:
   appSpec:
     containers:

--- a/pkg/controller/scheduling/testdata/tolerations/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/job/expected.yaml
@@ -17,7 +17,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/tolerations/job/input.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/job/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     defaults:
   appSpec:
     jobs:

--- a/pkg/controller/secrets/secret.go
+++ b/pkg/controller/secrets/secret.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/condition"
+	"github.com/acorn-io/acorn/pkg/jobs"
 	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/secrets"
 	"github.com/acorn-io/baaah/pkg/router"
@@ -97,7 +98,7 @@ func CreateSecrets(req router.Request, resp router.Response) (err error) {
 		} else if apiError := apierrors.APIStatus(nil); errors.As(err, &apiError) {
 			cond.Error(err)
 			return err
-		} else if errors.Is(err, secrets.ErrJobNotDone) {
+		} else if errors.Is(err, jobs.ErrJobNotDone) || errors.Is(err, jobs.ErrJobNoOutput) {
 			waiting = append(waiting, fmt.Sprintf("%s: %v", secretName, err))
 			continue
 		} else if err != nil {

--- a/pkg/controller/secrets/secret_test.go
+++ b/pkg/controller/secrets/secret_test.go
@@ -40,7 +40,7 @@ func TestOpaque_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				ID: "test",
+				Name: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -82,7 +82,7 @@ func TestBasic_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				ID: "test",
+				Name: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -139,7 +139,7 @@ func TestTemplateTokenMissing_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				ID: "image",
+				Name: "image",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -179,7 +179,7 @@ func TestTemplateToken_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				ID: "image",
+				Name: "image",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -285,7 +285,7 @@ func TestSecretLabelsAnnotations(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				ID: "test",
+				Name: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Labels: map[string]string{

--- a/pkg/controller/secrets/testdata/secret-encrypted/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/secrets/testdata/secret-encrypted/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     imageData:
       images:
         foo:

--- a/pkg/controller/secrets/testdata/secret-encrypted/input.yaml
+++ b/pkg/controller/secrets/testdata/secret-encrypted/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     imageData:
       images:
         foo:

--- a/pkg/controller/secrets/testdata/secret-image/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/secrets/testdata/secret-image/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     imageData:
       images:
         foo:

--- a/pkg/controller/secrets/testdata/secret-image/input.yaml
+++ b/pkg/controller/secrets/testdata/secret-image/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
     imageData:
       images:
         foo:

--- a/pkg/controller/service/testdata/ingress/clusterdomainport/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/clusterdomainport/existing.yaml
@@ -18,7 +18,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/service/testdata/ingress/labels-namespace/input.yaml
+++ b/pkg/controller/service/testdata/ingress/labels-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/labels/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/labels/existing.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-1-namespace/input.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-1-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-1/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-1/existing.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-2-namespace/input.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-2-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-2/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-2/existing.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/router/existing.yaml
+++ b/pkg/controller/service/testdata/router/existing.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test
   appSpec:
     routers:
       router-name:

--- a/pkg/controller/service/testdata/service/bind-no-protocol/existing.yaml
+++ b/pkg/controller/service/testdata/service/bind-no-protocol/existing.yaml
@@ -12,4 +12,4 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    id: test
+    name: test

--- a/pkg/images/operations.go
+++ b/pkg/images/operations.go
@@ -71,7 +71,6 @@ func PullAppImage(ctx context.Context, c client.Reader, namespace, image string,
 		return nil, err
 	}
 
-	appImage.ID = image
 	return appImage, nil
 }
 
@@ -90,7 +89,7 @@ func ParseReferenceNoDefault(name string) (imagename.Reference, error) {
 }
 
 func ResolveTagForApp(ctx context.Context, c client.Client, app *v1.AppInstance, image string) (string, error) {
-	tag, err := GetRuntimePullableImageReference(ctx, c, app.Namespace, app.Status.AppImage.ID)
+	tag, err := GetRuntimePullableImageReference(ctx, c, app.Namespace, app.Status.AppImage.Name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/imagesource/helper.go
+++ b/pkg/imagesource/helper.go
@@ -189,7 +189,7 @@ func (i ImageSource) GetImageAndDeployArgs(ctx context.Context, c client.Client)
 		if err != nil {
 			return "", nil, err
 		}
-		i.Image = image.ID
+		i.Image = image.Name
 	}
 
 	_, deployArgs, err := i.GetAppDefinition(ctx, c)

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -27,6 +27,12 @@ var (
 
 // GetOutputFor obj must be acorn internal v1.Secret, v1.Service, or string
 func GetOutputFor(ctx context.Context, c kclient.Client, appInstance *v1.AppInstance, name, serviceName string, obj interface{}) (job *batchv1.Job, err error) {
+	defer func() {
+		if err != nil && !errors.Is(err, ErrJobNoOutput) && !errors.Is(err, ErrJobNotDone) {
+			err = errors.Join(err, ErrJobNotDone)
+		}
+	}()
+
 	job, data, err := GetOutput(ctx, c, appInstance, name)
 	if err != nil {
 		return nil, err

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -6939,10 +6939,25 @@ func schema_pkg_apis_internalacornio_v1_PortBinding(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"publish": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated Has no meaning, publish=true is always assumed",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"expose": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated Has no meaning, all ports are exposed by default, if this is true The binding is ignored unless publish is also set to true (which is also deprecated)",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"targetPort": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "Deprecated All ports are exposed by default",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"targetServiceName": {

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -2357,6 +2357,12 @@ func schema_pkg_apis_apiacornio_v1_Image(ref common.ReferenceCallback) common.Op
 							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
+					"remote": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"repo": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -4550,12 +4556,6 @@ func schema_pkg_apis_internalacornio_v1_AppImage(ref common.ReferenceCallback) c
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"id": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -6430,6 +6430,13 @@ func schema_pkg_apis_internalacornio_v1_ImageInstance(ref common.ReferenceCallba
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
 							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+						},
+					},
+					"remote": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Remote indicates that this image has not been locally cached to the internal registry meaning that it may not exist at the location recorded in the Repo field if the user has deleted the image after the fact",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"repo": {

--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -160,6 +160,10 @@ func portMatches(binding v1.PortPublish, port v1.PortDef) bool {
 }
 
 func serviceMatches(serviceName string, binding v1.PortBinding) bool {
+	// deal with deprecated fields
+	if binding.Expose && !binding.Publish {
+		return false
+	}
 	return binding.TargetServiceName == "" || binding.TargetServiceName == serviceName
 }
 

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -35,7 +35,12 @@ var (
 		"hostname",
 		"port",
 		"ports",
-		"data")
+		"data",
+		"secrets",
+		"secret",
+		"endpoint",
+		"host",
+		"hostname")
 )
 
 type Interpolator struct {
@@ -188,15 +193,18 @@ func (i *Interpolator) serviceProperty(svc *v1.ServiceInstance, prop string, ext
 	case "secrets":
 		fallthrough
 	case "secret":
+		if len(extra) != 2 {
+			return "", fmt.Errorf("invalid secret lookup on service [%s] key must be at least two parts, go %v", svc.Name, extra)
+		}
 		secret := &corev1.Secret{}
-		err := ref.Lookup(i.ctx, i.client, secret, svc.Namespace, prop)
+		err := ref.Lookup(i.ctx, i.client, secret, svc.Namespace, extra[0])
 		if apierrors.IsNotFound(err) {
-			i.missing[i.serviceName] = append(i.missing[i.serviceName], prop)
+			i.missing[i.serviceName] = append(i.missing[i.serviceName], extra[0])
 			return "", nil
 		} else if err != nil {
 			return "", err
 		}
-		return string(secret.Data[strings.Join(extra, ".")]), nil
+		return string(secret.Data[extra[1]]), nil
 	case "endpoint":
 		if len(svc.Status.Endpoints) > 0 {
 			return svc.Status.Endpoints[0].Address, nil

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -142,10 +142,10 @@ func (i *Interpolator) resolveApp(keyName string) (string, bool, error) {
 	case "namespace":
 		return i.app.Namespace, true, nil
 	case "image":
-		if tags.IsLocalReference(i.app.Status.AppImage.ID) {
-			return i.app.Status.AppImage.ID, true, nil
-		} else if i.app.Status.AppImage.ID != "" && i.app.Status.AppImage.Digest != "" {
-			tag, err := name.NewTag(i.app.Status.AppImage.ID)
+		if tags.IsLocalReference(i.app.Status.AppImage.Name) {
+			return i.app.Status.AppImage.Name, true, nil
+		} else if i.app.Status.AppImage.Name != "" && i.app.Status.AppImage.Digest != "" {
+			tag, err := name.NewTag(i.app.Status.AppImage.Name)
 			if err != nil {
 				return "", false, err
 			}

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -114,7 +114,7 @@ func generateTemplate(secrets map[string]*corev1.Secret, req router.Request, app
 		Type: v1.SecretTypeTemplate,
 	}
 
-	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.ID)
+	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/registry/apigroups/acorn/images/storage.go
+++ b/pkg/server/registry/apigroups/acorn/images/storage.go
@@ -19,7 +19,7 @@ func NewStorage(c kclient.WithWatch) rest.Storage {
 		WithGet(strategy).
 		WithUpdate(remoteResource).
 		WithList(remoteResource).
-		WithDelete(remoteResource).
+		WithDelete(strategy).
 		WithWatch(remoteResource).
 		WithValidateUpdate(strategy).
 		WithTableConverter(tables.ImageConverter).

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -128,7 +128,7 @@ var (
 
 	Build = [][]string{
 		{"Name", "Name"},
-		{"Image", "Status.AppImage.ID"},
+		{"Image", "Status.AppImage.Name"},
 		{"Message", "Status.BuildError"},
 	}
 	BuildConverter = MustConverter(Build)


### PR DESCRIPTION
- Don't fail on old publish/expose fields in app.spec.ports
- Create local image records for images used by acorns

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

