### PR TITLE
Prefer remote digest for autoupgrade

### DIFF
--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -216,9 +216,11 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 				if current.Context().RegistryStr() != defaultNoReg {
 					digest, pullErr = d.client.imageDigest(ctx, app.Namespace, imageKey.image)
 				}
-				// Whether or not we got a digest from a remote registry, check to see if there is a version of this tag locally
-				if localDigest, ok, _ := d.client.resolveLocalTag(ctx, app.Namespace, imageKey.image); ok && localDigest != "" {
-					digest = localDigest
+				// If we did not find the digest remotely, check to see if there is a version of this tag locally
+				if digest == "" {
+					if localDigest, ok, _ := d.client.resolveLocalTag(ctx, app.Namespace, imageKey.image); ok && localDigest != "" {
+						digest = localDigest
+					}
 				}
 				if digest == "" && pullErr != nil {
 					logrus.Errorf("Problem getting updated digest for image %v from remote. Error: %v", imageKey.image, pullErr)


### PR DESCRIPTION
For autoupgrade, if an image exists both locally (like built via acorn built) and remotely (like in docker hub), we were preferring the locally built image.

This is no longer the desired behavior. We want to prefer the remote
image.

Signed-off-by: Craig Jellick <craig@acorn.io>

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

