### PR TITLE
Add functionality to observe changes in ImageDigests 

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -185,6 +185,7 @@ type AppColumns struct {
 
 type AppInstanceStatus struct {
 	ObservedGeneration     int64                      `json:"observedGeneration,omitempty"`
+	ObservedImageDigest    string                     `json:"observedImageDigest,omitempty"`
 	Columns                AppColumns                 `json:"columns,omitempty"`
 	ContainerStatus        map[string]ContainerStatus `json:"containerStatus,omitempty"`
 	JobsStatus             map[string]JobStatus       `json:"jobsStatus,omitempty"`

--- a/pkg/controller/appdefinition/generation.go
+++ b/pkg/controller/appdefinition/generation.go
@@ -5,8 +5,9 @@ import (
 	"github.com/acorn-io/baaah/pkg/router"
 )
 
-func UpdateGeneration(req router.Request, resp router.Response) error {
+func UpdateObservedFields(req router.Request, resp router.Response) error {
 	app := req.Object.(*v1.AppInstance)
+	app.Status.ObservedImageDigest = app.Status.AppImage.Digest
 	app.Status.ObservedGeneration = app.Generation
 	return nil
 }

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -63,7 +63,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	appRouter.HandlerFunc(appdefinition.ReadyStatus)
 	appRouter.HandlerFunc(appdefinition.NetworkPolicyForApp)
 	appRouter.HandlerFunc(appdefinition.AddAcornProjectLabel)
-	appRouter.HandlerFunc(appdefinition.UpdateGeneration)
+	appRouter.HandlerFunc(appdefinition.UpdateObservedFields)
 
 	router.Type(&v1.AppInstance{}).HandlerFunc(appdefinition.CLIStatus)
 

--- a/pkg/controller/scheduling/computeclass_test.go
+++ b/pkg/controller/scheduling/computeclass_test.go
@@ -45,6 +45,14 @@ func TestSameGenerationComputeClass(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/same-generation", Calculate)
 }
 
+func TestSameDigestGenerationComputeClass(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/same-digest-generation", Calculate)
+}
+
+func TestDifferentDigestGenerationComputeClass(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/computeclass/different-digest-generation", Calculate)
+}
+
 func TestTwoCCCDefaultsShouldError(t *testing.T) {
 	harness, input, err := tester.FromDir(scheme.Scheme, "testdata/computeclass/two-ccc-defaults-should-error")
 	if err != nil {

--- a/pkg/controller/scheduling/scheduling.go
+++ b/pkg/controller/scheduling/scheduling.go
@@ -23,8 +23,9 @@ import (
 func Calculate(req router.Request, resp router.Response) error {
 	appInstance := req.Object.(*v1.AppInstance)
 	status := condition.Setter(appInstance, resp, v1.AppInstanceConditionScheduling)
-	// Only recalculate scheduling when a change is detected in generation
-	if appInstance.Generation != appInstance.Status.ObservedGeneration {
+
+	// Only recalculate scheduling when a change is detected in generation or image digest.
+	if appInstance.Generation != appInstance.Status.ObservedGeneration || appInstance.Status.AppImage.Digest != appInstance.Status.ObservedImageDigest {
 		if err := calculate(req, appInstance); err != nil {
 			status.Error(err)
 			resp.DisablePrune()

--- a/pkg/controller/scheduling/testdata/computeclass/different-digest-generation/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-digest-generation/existing.yaml
@@ -1,0 +1,20 @@
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar

--- a/pkg/controller/scheduling/testdata/computeclass/different-digest-generation/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-digest-generation/expected.yaml
@@ -1,0 +1,71 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  computeClass:
+    oneimage: sample-compute-class
+status:
+  observedImageDigest: foo
+  scheduling:
+    left:
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          cpu: 1m
+          memory: 1Mi
+    oneimage:
+      tolerations:
+        - key: taints.acorn.io/workload
+          operator: "Exists"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: foo
+                operator: In
+                values:
+                - bar
+      requirements:
+        limits:
+          memory: 1Mi
+        requests:
+          cpu: 1m
+          memory: 1Mi
+  namespace: app-created-namespace
+  defaults:
+    memory:
+      "": 0
+      left: 1048576 # 1Mi
+      oneimage: 1048576 # 1Mi
+  appImage:
+    name: test
+    digest: bar
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  conditions:
+    - type: scheduling
+      reason: Success
+      status: "True"
+      success: true

--- a/pkg/controller/scheduling/testdata/computeclass/different-digest-generation/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-digest-generation/input.yaml
@@ -1,0 +1,39 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  computeClass:
+    oneimage: sample-compute-class
+status:
+  observedImageDigest: foo
+  defaults:
+    memory:
+      "": 0
+      left: 1048576 # 1Mi
+      oneimage: 1048576 # 1Mi
+  namespace: app-created-namespace
+  appImage:
+    name: test
+    digest: bar
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/scheduling/testdata/computeclass/same-digest-generation/existing.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/same-digest-generation/existing.yaml
@@ -1,0 +1,20 @@
+---
+kind: ClusterComputeClassInstance
+apiVersion: internal.admin.acorn.io/v1
+metadata:
+  name: sample-compute-class
+description: Simple description for a simple ComputeClass
+cpuScaler: 0.25
+memory:
+  min: 1Mi # 1Mi
+  max: 2Mi # 2Mi
+  default: 1Mi # 1Mi
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar

--- a/pkg/controller/scheduling/testdata/computeclass/same-digest-generation/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/same-digest-generation/expected.yaml
@@ -1,0 +1,68 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  computeClass:
+    oneimage: sample-compute-class
+status:
+  observedImageDigest: foo
+  scheduling:
+    left:
+      requirements:
+        limits:
+          memory: 10Mi
+        requests:
+          cpu: 10m
+          memory: 10Mi
+    oneimage:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: bar
+                operator: In
+                values:
+                - baz
+      requirements:
+        limits:
+          memory: 10Mi
+        requests:
+          cpu: 10m
+          memory: 10Mi
+  namespace: app-created-namespace
+  defaults:
+    memory:
+      "": 0
+      left: 1048576 # 1Mi
+      oneimage: 1048576 # 1Mi
+  appImage:
+    name: test
+    digest: foo
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  conditions:
+    - type: scheduling
+      reason: Success
+      status: "True"
+      success: true

--- a/pkg/controller/scheduling/testdata/computeclass/same-digest-generation/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/same-digest-generation/input.yaml
@@ -1,0 +1,65 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  computeClass:
+    oneimage: sample-compute-class
+status:
+  observedImageDigest: foo
+  defaults:
+    memory:
+      "": 0
+      left: 1048576 # 1Mi
+      oneimage: 1048576 # 1Mi
+  # In this test, scheduling has already been set and should not get recalculated
+  # since the generation is the same.
+  scheduling:
+    left:
+      requirements:
+        limits:
+          memory: 10Mi
+        requests:
+          cpu: 10m
+          memory: 10Mi
+    oneimage:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: bar
+                operator: In
+                values:
+                - baz
+      requirements:
+        limits:
+          memory: 10Mi
+        requests:
+          cpu: 10m
+          memory: 10Mi
+  namespace: app-created-namespace
+  appImage:
+    name: test
+    digest: foo
+  appSpec:
+    containers:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -4942,6 +4942,12 @@ func schema_pkg_apis_internalacornio_v1_AppInstanceStatus(ref common.ReferenceCa
 							Format: "int64",
 						},
 					},
+					"observedImageDigest": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"columns": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},


### PR DESCRIPTION
If we're using an auto-upgrade image, scheduling needs to wait for the image to be pulled. In this case, we're now waiting for the image to be pulled before proceeding with checking scheduling.

~TODO - need to add a test for this.~

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

