### PR TITLE
Add back appImage.ID field

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -78,7 +78,7 @@ func TestSimilarBuilds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.NotEqual(t, image.Name, image2.Name)
+	assert.NotEqual(t, image.ID, image2.ID)
 }
 
 func TestJobBuild(t *testing.T) {

--- a/integration/client/apps/update_test.go
+++ b/integration/client/apps/update_test.go
@@ -36,10 +36,10 @@ func TestUpdatePull(t *testing.T) {
 	}
 
 	app = helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
-		return obj.Status.AppImage.Name == imageID
+		return obj.Status.AppImage.ID == imageID
 	})
 	assert.NotEmpty(t, app.Status.Namespace)
-	assert.Equal(t, app.Status.AppImage.Name, imageID)
+	assert.Equal(t, app.Status.AppImage.ID, imageID)
 
 	imageID2 := client2.NewImage2(t, ns.Name)
 	err = c.ImageTag(ctx, imageID2, "foo:latest")
@@ -53,7 +53,7 @@ func TestUpdatePull(t *testing.T) {
 	}
 
 	app = helper.WaitForObject(t, helper.Watcher(t, c), &apiv1.AppList{}, app, func(obj *apiv1.App) bool {
-		return obj.Status.AppImage.Name == imageID2
+		return obj.Status.AppImage.ID == imageID2
 	})
-	assert.Equal(t, app.Status.AppImage.Name, imageID2)
+	assert.Equal(t, app.Status.AppImage.ID, imageID2)
 }

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -17,7 +17,7 @@ func NewImageWithSidecar(t *testing.T, namespace string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.Name
+	return image.ID
 }
 
 func NewImage2(t *testing.T, namespace string) string {
@@ -30,7 +30,7 @@ func NewImage2(t *testing.T, namespace string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.Name
+	return image.ID
 }
 
 func NewImage(t *testing.T, namespace string) string {
@@ -43,5 +43,5 @@ func NewImage(t *testing.T, namespace string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.Name
+	return image.ID
 }

--- a/integration/client/client_test.go
+++ b/integration/client/client_test.go
@@ -45,7 +45,7 @@ func TestAppsSSA(t *testing.T) {
 			Namespace: ns.Name,
 		},
 		Spec: v1.AppInstanceSpec{
-			Image: image.Name,
+			Image: image.ID,
 		},
 	})
 	if err != nil {
@@ -66,7 +66,7 @@ func TestAppsSSA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, image.Name, app.Spec.Image)
+	assert.Equal(t, image.ID, app.Spec.Image)
 }
 
 func TestFriendlyNameInContainer(t *testing.T) {
@@ -96,7 +96,7 @@ func TestFriendlyNameInContainer(t *testing.T) {
 			},
 		},
 		Spec: v1.AppInstanceSpec{
-			Image: image.Name,
+			Image: image.ID,
 		},
 	}
 

--- a/integration/client/depends_test.go
+++ b/integration/client/depends_test.go
@@ -26,7 +26,7 @@ func depImage(t *testing.T, c client.Client) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return image.Name
+	return image.ID
 }
 
 func toRevision(t *testing.T, obj kclient.Object) int {

--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -75,7 +75,7 @@ func TestImageTagMove(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.ImageTag(ctx, image2.Name, "foo:latest")
+	err = c.ImageTag(ctx, image2.ID, "foo:latest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestImageTagMove(t *testing.T) {
 	for _, image := range images {
 		if image.Name == imageID {
 			assert.Equal(t, []string([]string(nil)), image.Tags)
-		} else if image.Name == image2.Name {
+		} else if image.Name == image2.ID {
 			assert.Equal(t, "foo:latest", image.Tags[0])
 		} else {
 			t.Fatal(err, "invalid image")

--- a/integration/log/log_test.go
+++ b/integration/log/log_test.go
@@ -34,7 +34,7 @@ func TestLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.Name, &client.AppRunOptions{
+	app, err := c.AppRun(context.Background(), image.ID, &client.AppRunOptions{
 		/* When running this test with the acorn-linkerd-plugin installed, the app inits too quickly, and
 		   the acorn controller does not have enough time to propagate the injection annotation to the
 		   test namespace before the app is created, so linkerd does not end up injecting the sidecar.
@@ -92,7 +92,7 @@ func TestContainerLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.Name, nil)
+	app, err := c.AppRun(context.Background(), image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestSidecarContainerLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.Name, nil)
+	app, err := c.AppRun(context.Background(), image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -46,7 +46,7 @@ func TestVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
+	app, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Volume: pv.Name,
@@ -108,7 +108,7 @@ func TestVolumeBadClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, nil)
+	_, err = c.AppRun(ctx, image.ID, nil)
 	if err == nil {
 		t.Fatal("expected app with bad volume class to error on run")
 	}
@@ -149,7 +149,7 @@ func TestVolumeBadClassInImageBoundToGoodClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, &client.AppRunOptions{
+	app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -209,7 +209,7 @@ func TestVolumeBoundBadClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
+	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -250,7 +250,7 @@ func TestVolumeClassInactive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, nil)
+	_, err = c.AppRun(ctx, image.ID, nil)
 	if err == nil {
 		t.Fatal("expected app with inactive volume class to error on run")
 	}
@@ -287,7 +287,7 @@ func TestVolumeClassSizeTooSmall(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
+	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -331,7 +331,7 @@ func TestVolumeClassSizeTooLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{
+	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{
 		Volumes: []v1.VolumeBinding{
 			{
 				Target: "my-data",
@@ -379,7 +379,7 @@ func TestVolumeClassRemoved(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func TestClusterVolumeClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func TestClusterVolumeClassValuesInAcornfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -573,7 +573,7 @@ func TestProjectVolumeClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestProjectVolumeClassDefaultSizeValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +703,7 @@ func TestProjectVolumeClassDefaultSizeBadValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, nil)
+	_, err = c.AppRun(ctx, image.ID, nil)
 	if err == nil {
 		t.Fatal("expected app with size too large for volume class to error on run")
 	}
@@ -750,7 +750,7 @@ func TestProjectVolumeClassValuesInAcornfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,7 +782,7 @@ func TestImageNameAnnotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -821,7 +821,7 @@ func TestSimple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -862,7 +862,7 @@ func TestDeployParam(t *testing.T) {
 			Namespace: ns.Name,
 		},
 		Spec: v1.AppInstanceSpec{
-			Image: image.Name,
+			Image: image.ID,
 			DeployArgs: map[string]any{
 				"someInt": 5,
 			},
@@ -1109,7 +1109,7 @@ func TestUsingComputeClasses(t *testing.T) {
 				}
 
 				// Assign a name for the test case so no collisions occur
-				app, err := c.AppRun(ctx, image.Name, &client.AppRunOptions{Name: testcase})
+				app, err := c.AppRun(ctx, image.ID, &client.AppRunOptions{Name: testcase})
 				if err != nil {
 					if tt.fail {
 						return
@@ -1152,7 +1152,7 @@ func TestAppWithBadRegion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, &client.AppRunOptions{Region: "does-not-exist"})
+	_, err = c.AppRun(ctx, image.ID, &client.AppRunOptions{Region: "does-not-exist"})
 	if err == nil || !strings.Contains(err.Error(), "is not supported for project") {
 		t.Fatalf("expected an invalid region error, got %v", err)
 	}
@@ -1197,7 +1197,7 @@ func TestAppWithBadDefaultRegion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppRun(ctx, image.Name, nil)
+	_, err = c.AppRun(ctx, image.ID, nil)
 	if err == nil || !strings.Contains(err.Error(), "is not a valid volume class") {
 		t.Fatalf("expected an invalid region error, got %v", err)
 	}
@@ -1276,7 +1276,7 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while building image:", err)
 	}
-	fooApp, err := proj1Client.AppRun(ctx, fooImage.Name, &client.AppRunOptions{
+	fooApp, err := proj1Client.AppRun(ctx, fooImage.ID, &client.AppRunOptions{
 		Name:            "foo",
 		TargetNamespace: proj1.Namespace,
 	})
@@ -1288,7 +1288,7 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while building image:", err)
 	}
-	barApp, err := proj2Client.AppRun(ctx, barImage.Name, &client.AppRunOptions{
+	barApp, err := proj2Client.AppRun(ctx, barImage.ID, &client.AppRunOptions{
 		Name:            "bar",
 		TargetNamespace: proj2.Namespace,
 	})
@@ -1329,14 +1329,14 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 			name:          "curl-foo-proj1",
 			client:        proj1Client,
 			podIP:         fooIP,
-			imageID:       curlImage1.Name,
+			imageID:       curlImage1.ID,
 			expectFailure: false,
 		},
 		{
 			name:    "curl-bar-proj1",
 			client:  proj1Client,
 			podIP:   barIP,
-			imageID: curlImage1.Name,
+			imageID: curlImage1.ID,
 			// even though bar has port 80 published, it should not be reachable from anything outside
 			// proj2 except for the ingress controller, so failure is expected here
 			expectFailure: true,
@@ -1345,14 +1345,14 @@ func TestCrossProjectNetworkConnection(t *testing.T) {
 			name:          "curl-foo-proj2",
 			client:        proj2Client,
 			podIP:         fooIP,
-			imageID:       curlImage2.Name,
+			imageID:       curlImage2.ID,
 			expectFailure: true,
 		},
 		{
 			name:          "curl-bar-proj2",
 			client:        proj2Client,
 			podIP:         barIP,
-			imageID:       curlImage2.Name,
+			imageID:       curlImage2.ID,
 			expectFailure: false,
 		},
 	}

--- a/integration/secrets/secret_test.go
+++ b/integration/secrets/secret_test.go
@@ -35,7 +35,7 @@ func TestText(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.Name, nil)
+	app, err := c.AppRun(context.Background(), image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestIssue552(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(context.Background(), image.Name, nil)
+	app, err := c.AppRun(context.Background(), image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestEncryptionEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c1.AppRun(context.Background(), image.Name, &client.AppRunOptions{
+	app, err := c1.AppRun(context.Background(), image.ID, &client.AppRunOptions{
 		DeployArgs: map[string]any{
 			"encdata": output,
 		},
@@ -199,7 +199,7 @@ func TestNamespacedDecryption(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c2.AppRun(context.Background(), image.Name, &client.AppRunOptions{
+	app, err := c2.AppRun(context.Background(), image.ID, &client.AppRunOptions{
 		DeployArgs: map[string]any{
 			"encdata": encdata,
 		},
@@ -235,7 +235,7 @@ func TestMultiKeyDecryptionEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c1.AppRun(context.Background(), image.Name, &client.AppRunOptions{
+	app, err := c1.AppRun(context.Background(), image.ID, &client.AppRunOptions{
 		DeployArgs: map[string]any{
 			"encdata": encdata,
 		},

--- a/integration/services/services_test.go
+++ b/integration/services/services_test.go
@@ -21,7 +21,7 @@ func TestServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app, err := c.AppRun(ctx, image.Name, nil)
+	app, err := c.AppRun(ctx, image.ID, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/apis/internal.acorn.io/v1/appimage.go
+++ b/pkg/apis/internal.acorn.io/v1/appimage.go
@@ -1,6 +1,10 @@
 package v1
 
 type AppImage struct {
+	// ID is the "image ID" that Name resolves to, which might be the same as Name or a string matching
+	// ImageInstance.Name
+	ID string `json:"id,omitempty"`
+	// Name is the image name requested by the user of any format
 	Name      string     `json:"name,omitempty"`
 	Digest    string     `json:"digest,omitempty"`
 	Acornfile string     `json:"acornfile,omitempty"`

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -105,7 +105,7 @@ func build(ctx *buildContext) (*v1.AppImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to finalize app image: %w", err)
 	}
-	appImage.Name = id
+	appImage.ID = id
 	appImage.Digest = "sha256:" + id
 
 	return appImage, nil

--- a/pkg/buildserver/server.go
+++ b/pkg/buildserver/server.go
@@ -91,7 +91,7 @@ func (s *Server) serveHTTP(rw http.ResponseWriter, req *http.Request) error {
 		_ = m.Send(&buildclient.Message{
 			AppImage: image,
 		})
-		logrus.Infof("Build succeeded [%s/%s] [%s]: %v", token.Build.Namespace, token.Build.Name, token.Build.UID, image.Name)
+		logrus.Infof("Build succeeded [%s/%s] [%s]: %v", token.Build.Namespace, token.Build.Name, token.Build.UID, image.ID)
 	} else {
 		_ = m.Send(&buildclient.Message{
 			Error: err.Error(),
@@ -175,7 +175,7 @@ func (s *Server) recordBuild(ctx context.Context, recordRepo string, build *v1.A
 	}
 	err := apply.New(s.client).Ensure(ctx, &v1.ImageInstance{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      image.Name,
+			Name:      image.ID,
 			Namespace: build.Namespace,
 		},
 		Repo:   recordRepo,

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -302,7 +302,7 @@ func (s *Run) update(ctx context.Context, c client.Client, imageSource imagesour
 
 	if !imageSource.IsImageSet() {
 		// If there is no image set, then lookup the existing app and use the image of the current app
-		imageSource = imageSource.WithImage(app.Status.AppImage.Name)
+		imageSource = imageSource.WithImage(app.Status.AppImage.ID)
 	}
 
 	image, deployArgs, err := imageSource.GetImageAndDeployArgs(ctx, c)

--- a/pkg/cli/testdata/MockClient.go
+++ b/pkg/cli/testdata/MockClient.go
@@ -606,7 +606,7 @@ func (m *MockClient) ImageTag(ctx context.Context, image, tag string) error {
 
 func (m *MockClient) ImageDetails(ctx context.Context, imageName string, opts *client.ImageDetailsOptions) (*client.ImageDetails, error) {
 	return &client.ImageDetails{
-		AppImage: v1.AppImage{Name: imageName, ImageData: v1.ImagesData{
+		AppImage: v1.AppImage{ID: imageName, ImageData: v1.ImagesData{
 			Containers: map[string]v1.ContainerData{"test-image-running-container": v1.ContainerData{
 				Image:    "test-image-running-container",
 				Sidecars: nil,

--- a/pkg/controller/appdefinition/deploy.go
+++ b/pkg/controller/appdefinition/deploy.go
@@ -78,7 +78,7 @@ func DeploySpec(req router.Request, resp router.Response) (err error) {
 		}
 	}()
 
-	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.Name)
+	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/appdefinition/imagepulled.go
+++ b/pkg/controller/appdefinition/imagepulled.go
@@ -8,7 +8,7 @@ import (
 func ImagePulled(h router.Handler) router.Handler {
 	return router.HandlerFunc(func(req router.Request, resp router.Response) error {
 		appInstance := req.Object.(*v1.AppInstance)
-		if appInstance.Status.AppImage.Name == "" {
+		if appInstance.Status.AppImage.ID == "" {
 			return nil
 		}
 		return h.Handle(req, resp)

--- a/pkg/controller/appdefinition/parse_test.go
+++ b/pkg/controller/appdefinition/parse_test.go
@@ -23,7 +23,7 @@ func TestParseAppImageBug(t *testing.T) {
 			Containers: map[string]v1.ContainerData{},
 		},
 		Acornfile: "",
-		Name:      "",
+		ID:        "",
 	}
 	app, err := appdefinition.FromAppImage(appImage)
 	if err != nil {

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -39,7 +39,7 @@ func PullAppImage(transport http.RoundTripper) router.HandlerFunc {
 			cond.Error(err)
 			return nil
 		}
-		appImage.Name = resolvedImage
+		appImage.Name = targetImage
 		appInstance.Status.AvailableAppImage = ""
 		appInstance.Status.ConfirmUpgradeAppImage = ""
 		appInstance.Status.AppImage = *appImage
@@ -61,7 +61,7 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string) {
 			} else {
 				// ConfirmUpgradeAppImage is not blank. Normally, we shouldn't get the desiredImage from it. That should
 				// be done explicitly by the user via the apps/confirmupgrade subresource (which would set it to the
-				// AvailableAppImage field). But if AppImage.Name is blank, this app has never had an image pulled. So, do the initial pull.
+				// AvailableAppImage field). But if AppImage.ID is blank, this app has never had an image pulled. So, do the initial pull.
 				if appInstance.Status.AppImage.Name == "" {
 					return appInstance.Status.ConfirmUpgradeAppImage, ""
 				} else {

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -62,6 +62,7 @@ func app(specImage, statusImageID, statusAvailableImage, statusConfirmUpgradeIma
 		},
 		Status: v1.AppInstanceStatus{
 			AppImage: v1.AppImage{
+				ID:   statusImageID,
 				Name: statusImageID,
 			},
 			AvailableAppImage:      statusAvailableImage,

--- a/pkg/controller/appdefinition/secret_test.go
+++ b/pkg/controller/appdefinition/secret_test.go
@@ -18,7 +18,7 @@ func TestSecretDirsToMounts(t *testing.T) {
 		},
 		Status: v1.AppInstanceStatus{
 			AppImage: v1.AppImage{
-				Name: "test",
+				ID: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Containers: map[string]v1.Container{

--- a/pkg/controller/appdefinition/status.go
+++ b/pkg/controller/appdefinition/status.go
@@ -99,7 +99,7 @@ func ReadyStatus(req router.Request, resp router.Response) error {
 	}
 
 	cond.Success()
-	app.Status.Ready = ready && app.Status.AppImage.Name != "" &&
+	app.Status.Ready = ready && app.Status.AppImage.ID != "" &&
 		app.Generation == app.Status.ObservedGeneration &&
 		app.Status.Condition(v1.AppInstanceConditionParsed).Success &&
 		app.Status.Condition(v1.AppInstanceConditionContainers).Success &&

--- a/pkg/controller/appdefinition/testdata/acorn/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/labels/expected.yaml.d/appinstance.yaml
@@ -167,7 +167,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: foo
+    id: foo
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/acorn/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/labels/input.yaml
@@ -55,7 +55,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: foo
+    id: foo
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml.d/appinstance.yaml
@@ -43,7 +43,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
@@ -43,7 +43,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.yaml.d/appinstance.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/input.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/container/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/container/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/input.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/expected.yaml.d/appinstance.yaml
@@ -51,7 +51,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/different-computeclass/input.yaml
@@ -51,7 +51,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/input.yaml
@@ -41,7 +41,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
@@ -41,7 +41,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/sidecar/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/sidecar/expected.yaml.d/appinstance.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/sidecar/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/sidecar/input.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/expected.yaml.d/appinstance.yaml
@@ -36,7 +36,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/two-containers/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/two-containers/input.yaml
@@ -36,7 +36,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.yaml.d/appinstance.yaml
@@ -39,7 +39,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/input.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/input.yaml
@@ -39,7 +39,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
@@ -62,7 +62,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/cronjob/input.yaml
+++ b/pkg/controller/appdefinition/testdata/cronjob/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/depends-ready/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/depends-ready/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: "image-name"
+    id: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/depends-ready/input.yaml
+++ b/pkg/controller/appdefinition/testdata/depends-ready/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: "image-name"
+    id: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: "image-name"
+    id: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/depends/input.yaml
+++ b/pkg/controller/appdefinition/testdata/depends/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: "image-name"
+    id: "image-name"
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/expected.yaml
@@ -166,7 +166,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels-namespace/input.yaml
@@ -91,7 +91,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/appinstance.yaml
@@ -39,7 +39,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       allowed.io: test-allowed-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/input.yaml
@@ -91,7 +91,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels-namespace/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/appinstance.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels-namespace/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/input.yaml
@@ -57,7 +57,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     annotations:
       appSpecAnn: test-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/scale/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/scale/expected.yaml
@@ -145,7 +145,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/scale/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/scale/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/stop/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/stop/expected.yaml
@@ -148,7 +148,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/deployspec/stop/input.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/stop/input.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files-bug/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/files-bug/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files-bug/input.yaml
+++ b/pkg/controller/appdefinition/testdata/files-bug/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/files/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/files/input.yaml
+++ b/pkg/controller/appdefinition/testdata/files/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/globalenv/input.yaml
+++ b/pkg/controller/appdefinition/testdata/globalenv/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/expected.yaml.d/appinstance.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/basic/input.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/ingress/labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels-namespace/input.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/appinstance.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/input.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/expected.yaml.d/appinstance.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       app1:

--- a/pkg/controller/appdefinition/testdata/ingress/letsencrypt/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/letsencrypt/input.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       app1:

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/appinstance.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/appinstance.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/input.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/appdefinition/testdata/interpolation/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/interpolation/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/interpolation/input.yaml
+++ b/pkg/controller/appdefinition/testdata/interpolation/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
@@ -68,7 +68,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/job/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/basic/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/job/labels-namespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels-namespace/input.yaml
@@ -59,7 +59,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/appinstance.yaml
@@ -59,7 +59,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/job/labels/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels/input.yaml
@@ -59,7 +59,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       global2: "value"

--- a/pkg/controller/appdefinition/testdata/link/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/link/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       con:

--- a/pkg/controller/appdefinition/testdata/link/input.yaml
+++ b/pkg/controller/appdefinition/testdata/link/input.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       con:

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.yaml.d/appinstance.yaml
@@ -31,7 +31,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/input.yaml
@@ -31,7 +31,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/all-set/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/expected.yaml.d/appinstance.yaml
@@ -30,7 +30,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/all-set/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/input.yaml
@@ -30,7 +30,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/container/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/container/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/container/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/container/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/job/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/two-containers/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/two-containers/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/two-containers/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/two-containers/input.yaml
@@ -26,7 +26,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.yaml.d/appinstance.yaml
@@ -24,7 +24,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/input.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/input.yaml
@@ -24,7 +24,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/appinstance.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/both/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/both/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/input.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/container/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/container/expected.yaml.d/appinstance.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/container/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/container/input.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.yaml.d/appinstance.yaml
@@ -34,7 +34,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/input.yaml
@@ -34,7 +34,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/differentpermissions/expected.yaml.d/appinstance.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/differentpermissions/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/differentpermissions/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/job/expected.yaml.d/appinstance.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/job/input.yaml
@@ -25,7 +25,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/expected.yaml.d/appinstance.yaml
@@ -41,7 +41,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplecontainers/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/appinstance.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/input.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/input.yaml
@@ -40,7 +40,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/probes/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/probes/expected.yaml
@@ -140,7 +140,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       nodefault:

--- a/pkg/controller/appdefinition/testdata/probes/input.yaml
+++ b/pkg/controller/appdefinition/testdata/probes/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       nodefault:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/custom/expected.yaml.d/appinstance.yaml
@@ -14,7 +14,7 @@ status:
       success: true
   namespace: app-created-namespace
   appImage:
-    name: foo.io/test
+    id: foo.io/test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/custom/input.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/custom/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: foo.io/test
+    id: foo.io/test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/default/expected.yaml.d/appinstance.yaml
@@ -14,7 +14,7 @@ status:
       success: true
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/pullsecrets/default/input.yaml
+++ b/pkg/controller/appdefinition/testdata/pullsecrets/default/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/router/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/router/expected.yaml.d/appinstance.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     routers:
       router-name:

--- a/pkg/controller/appdefinition/testdata/router/input.yaml
+++ b/pkg/controller/appdefinition/testdata/router/input.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     routers:
       router-name:

--- a/pkg/controller/appdefinition/testdata/secret/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/secret/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/secret/input.yaml
+++ b/pkg/controller/appdefinition/testdata/secret/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/service/alias/expected.yaml.d/appinstance.yaml
@@ -26,7 +26,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       con1:

--- a/pkg/controller/appdefinition/testdata/service/alias/input.yaml
+++ b/pkg/controller/appdefinition/testdata/service/alias/input.yaml
@@ -26,7 +26,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       con1:

--- a/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/service/basic/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/service/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/service/basic/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/appdefinition/testdata/template/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/template/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/template/input.yaml
+++ b/pkg/controller/appdefinition/testdata/template/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/expected.yaml
@@ -127,7 +127,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/cluster-default-with-bind-combos/input.yaml
@@ -16,7 +16,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/expected.yaml
@@ -99,7 +99,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/configure-but-no-bind/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/contextdir/expected.yaml
@@ -82,7 +82,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/contextdir/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/contextdir/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/defaults/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/defaults/expected.yaml
@@ -95,7 +95,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/defaults/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/defaults/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/expected.yaml
@@ -93,7 +93,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/empty/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/empty/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/expected.yaml
@@ -108,7 +108,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral-bound/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral/expected.yaml
@@ -84,7 +84,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/ephemeral/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/ephemeral/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/inactive-class/expected.yaml
@@ -95,7 +95,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/inactive-class/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/inactive-class/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/expected.yaml
@@ -99,7 +99,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named-bound/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named-bound/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named/expected.yaml
@@ -95,7 +95,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/named/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/named/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/no-default-class/expected.yaml
@@ -87,7 +87,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/testdata/volumes/no-default-class/input.yaml
+++ b/pkg/controller/appdefinition/testdata/volumes/no-default-class/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/appdefinition/volume_test.go
+++ b/pkg/controller/appdefinition/volume_test.go
@@ -80,7 +80,7 @@ func TestVolumeLabelsAnnotations(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				Name: "image",
+				ID: "image",
 			},
 			AppSpec: v1.AppSpec{
 				Labels: map[string]string{

--- a/pkg/controller/defaults/testdata/memory/all-set-overwrite/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set-overwrite/expected.yaml
@@ -19,7 +19,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/all-set-overwrite/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set-overwrite/input.yaml
@@ -13,7 +13,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/all-set/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/all-set/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/all-set/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/container/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/container/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/container/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/container/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/job/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/job/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/job/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/job/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/overwrite-acornfile-memory/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/same-generation/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/same-generation/expected.yaml
@@ -16,7 +16,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/same-generation/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/same-generation/input.yaml
@@ -16,7 +16,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/sidecar/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/sidecar/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/sidecar/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/sidecar/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/expected.yaml
@@ -14,7 +14,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-ccc-defaults-should-error/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-containers/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-containers/expected.yaml
@@ -18,7 +18,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-containers/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-containers/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/expected.yaml
@@ -14,7 +14,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/two-pcc-defaults-should-error/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/with-acornfile-memory/expected.yaml
+++ b/pkg/controller/defaults/testdata/memory/with-acornfile-memory/expected.yaml
@@ -16,7 +16,7 @@ status:
     region: local
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/memory/with-acornfile-memory/input.yaml
+++ b/pkg/controller/defaults/testdata/memory/with-acornfile-memory/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/defaults/testdata/region/default/expected.yaml
+++ b/pkg/controller/defaults/testdata/region/default/expected.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/default/input.yaml
+++ b/pkg/controller/defaults/testdata/region/default/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/project-default-status/expected.yaml
+++ b/pkg/controller/defaults/testdata/region/project-default-status/expected.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/project-default-status/input.yaml
+++ b/pkg/controller/defaults/testdata/region/project-default-status/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/region-on-spec/expected.yaml
+++ b/pkg/controller/defaults/testdata/region/region-on-spec/expected.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/region/region-on-spec/input.yaml
+++ b/pkg/controller/defaults/testdata/region/region-on-spec/input.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/expected.yaml.d/appinstance.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/cluster-and-project-class-same-name/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/expected.yaml.d/appinstance.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-defaults-same-gen/input.yaml
@@ -11,7 +11,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/expected.yaml.d/appinstance.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-cluster-default/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/expected.yaml.d/appinstance.yaml
@@ -12,7 +12,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults-with-bind/input.yaml
@@ -13,7 +13,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-defaults/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-project-default/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/expected.yaml.d/appinstance.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-fill-size/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/expected.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/expected.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-cluster-defaults/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/expected.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/expected.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/input.yaml
+++ b/pkg/controller/defaults/testdata/volumeclass/volume-class-two-project-defaults/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       container-name:

--- a/pkg/controller/images/images.go
+++ b/pkg/controller/images/images.go
@@ -14,7 +14,7 @@ import (
 
 func CreateImages(req router.Request, resp router.Response) error {
 	app := req.Object.(*v1.AppInstance)
-	if app.Status.AppImage.Name == "" || app.Status.AppImage.Digest == "" {
+	if app.Status.AppImage.ID == "" || app.Status.AppImage.Digest == "" {
 		return nil
 	}
 
@@ -61,7 +61,7 @@ func createImageForSelf(req router.Request, app *v1.AppInstance) (*v1.ImageInsta
 	var (
 		digest    = app.Status.AppImage.Digest
 		digestHex = strings.TrimPrefix(digest, "sha256:")
-		imageName = app.Status.AppImage.Name
+		imageName = app.Status.AppImage.ID
 		// update == false means create
 		update = true
 		image  = &v1.ImageInstance{}

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/appinstance/input.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/appinstance/input.yaml
@@ -9,7 +9,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       containerOne:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml
@@ -46,7 +46,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set-overwrite-computeclass/input.yaml
@@ -18,7 +18,7 @@ status:
       oneimage:  2097152 # 2Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set/expected.yaml
@@ -47,7 +47,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/all-set/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/all-set/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/container/expected.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/container/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/container/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     defaults:
   appSpec:
     containers:

--- a/pkg/controller/scheduling/testdata/computeclass/different-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-computeclass/expected.yaml
@@ -57,7 +57,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/different-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/different-computeclass/input.yaml
@@ -18,7 +18,7 @@ status:
       twoimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/job/expected.yaml
@@ -44,7 +44,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/job/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/job/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml
@@ -44,7 +44,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/overwrite-acornfile-computeclass/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/same-generation/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/same-generation/expected.yaml
@@ -40,7 +40,7 @@ status:
       left: 1048576 # 1Mi
       oneimage: 1048576 # 1Mi
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/same-generation/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/same-generation/input.yaml
@@ -42,7 +42,7 @@ status:
           memory: 10Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     defaults:
   appSpec:
     containers:

--- a/pkg/controller/scheduling/testdata/computeclass/sidecar/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/sidecar/expected.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   scheduling:
     oneimage:
       tolerations:

--- a/pkg/controller/scheduling/testdata/computeclass/sidecar/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/sidecar/input.yaml
@@ -14,7 +14,7 @@ status:
       left: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/expected.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-ccc-defaults-should-error/input.yaml
@@ -17,7 +17,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-containers/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-containers/expected.yaml
@@ -42,7 +42,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-containers/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-containers/input.yaml
@@ -17,7 +17,7 @@ status:
       twoimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/expected.yaml
@@ -17,7 +17,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/two-pcc-defaults-should-error/input.yaml
@@ -17,7 +17,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/expected.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/expected.yaml
@@ -42,7 +42,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/input.yaml
+++ b/pkg/controller/scheduling/testdata/computeclass/with-acornfile-computeclass/input.yaml
@@ -15,7 +15,7 @@ status:
       oneimage: 1048576 # 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set-overwrite/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set-overwrite/expected.yaml
@@ -34,7 +34,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set-overwrite/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set-overwrite/input.yaml
@@ -18,7 +18,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set/expected.yaml
@@ -33,7 +33,7 @@ status:
           memory: 1Mi
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/all-set/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/all-set/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/container/expected.yaml
@@ -29,7 +29,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/container/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/container/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/job/expected.yaml
@@ -29,7 +29,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/job/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/job/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/expected.yaml
@@ -29,7 +29,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/overwrite-acornfile-memory/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/same-generation/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/same-generation/expected.yaml
@@ -25,7 +25,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/same-generation/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/same-generation/input.yaml
@@ -27,7 +27,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/sidecar/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/sidecar/expected.yaml
@@ -24,7 +24,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/sidecar/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/sidecar/input.yaml
@@ -12,7 +12,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/two-containers/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/two-containers/expected.yaml
@@ -32,7 +32,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/two-containers/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/two-containers/input.yaml
@@ -17,7 +17,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/expected.yaml
+++ b/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/expected.yaml
@@ -27,7 +27,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/input.yaml
+++ b/pkg/controller/scheduling/testdata/memory/with-acornfile-memory/input.yaml
@@ -15,7 +15,7 @@ status:
       oneimage: 0
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/tolerations/container/expected.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/container/expected.yaml
@@ -17,7 +17,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/scheduling/testdata/tolerations/container/input.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/container/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     defaults:
   appSpec:
     containers:

--- a/pkg/controller/scheduling/testdata/tolerations/job/expected.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/job/expected.yaml
@@ -17,7 +17,7 @@ status:
       requirements: {}
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     jobs:
       oneimage:

--- a/pkg/controller/scheduling/testdata/tolerations/job/input.yaml
+++ b/pkg/controller/scheduling/testdata/tolerations/job/input.yaml
@@ -10,7 +10,7 @@ status:
   observedGeneration: 1
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     defaults:
   appSpec:
     jobs:

--- a/pkg/controller/secrets/secret_test.go
+++ b/pkg/controller/secrets/secret_test.go
@@ -40,7 +40,7 @@ func TestOpaque_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				Name: "test",
+				ID: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -82,7 +82,7 @@ func TestBasic_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				Name: "test",
+				ID: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -139,7 +139,7 @@ func TestTemplateTokenMissing_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				Name: "image",
+				ID: "image",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -179,7 +179,7 @@ func TestTemplateToken_Gen(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				Name: "image",
+				ID: "image",
 			},
 			AppSpec: v1.AppSpec{
 				Secrets: map[string]v1.Secret{
@@ -285,7 +285,7 @@ func TestSecretLabelsAnnotations(t *testing.T) {
 		Status: v1.AppInstanceStatus{
 			Namespace: "app-target-ns",
 			AppImage: v1.AppImage{
-				Name: "test",
+				ID: "test",
 			},
 			AppSpec: v1.AppSpec{
 				Labels: map[string]string{

--- a/pkg/controller/secrets/testdata/secret-encrypted/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/secrets/testdata/secret-encrypted/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     imageData:
       images:
         foo:

--- a/pkg/controller/secrets/testdata/secret-encrypted/input.yaml
+++ b/pkg/controller/secrets/testdata/secret-encrypted/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     imageData:
       images:
         foo:

--- a/pkg/controller/secrets/testdata/secret-image/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/secrets/testdata/secret-image/expected.yaml.d/appinstance.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     imageData:
       images:
         foo:

--- a/pkg/controller/secrets/testdata/secret-image/input.yaml
+++ b/pkg/controller/secrets/testdata/secret-image/input.yaml
@@ -13,7 +13,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
     imageData:
       images:
         foo:

--- a/pkg/controller/service/testdata/ingress/clusterdomainport/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/clusterdomainport/existing.yaml
@@ -18,7 +18,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     containers:
       oneimage:

--- a/pkg/controller/service/testdata/ingress/labels-namespace/input.yaml
+++ b/pkg/controller/service/testdata/ingress/labels-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/labels/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/labels/existing.yaml
@@ -35,7 +35,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-1-namespace/input.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-1-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-1/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-1/existing.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-2-namespace/input.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-2-namespace/input.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-2/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-2/existing.yaml
@@ -37,7 +37,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     labels:
       globall2: "value"

--- a/pkg/controller/service/testdata/router/existing.yaml
+++ b/pkg/controller/service/testdata/router/existing.yaml
@@ -10,7 +10,7 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test
   appSpec:
     routers:
       router-name:

--- a/pkg/controller/service/testdata/service/bind-no-protocol/existing.yaml
+++ b/pkg/controller/service/testdata/service/bind-no-protocol/existing.yaml
@@ -12,4 +12,4 @@ spec:
 status:
   namespace: app-created-namespace
   appImage:
-    name: test
+    id: test

--- a/pkg/images/operations.go
+++ b/pkg/images/operations.go
@@ -71,6 +71,7 @@ func PullAppImage(ctx context.Context, c client.Reader, namespace, image string,
 		return nil, err
 	}
 
+	appImage.ID = image
 	return appImage, nil
 }
 
@@ -89,7 +90,7 @@ func ParseReferenceNoDefault(name string) (imagename.Reference, error) {
 }
 
 func ResolveTagForApp(ctx context.Context, c client.Client, app *v1.AppInstance, image string) (string, error) {
-	tag, err := GetRuntimePullableImageReference(ctx, c, app.Namespace, app.Status.AppImage.Name)
+	tag, err := GetRuntimePullableImageReference(ctx, c, app.Namespace, app.Status.AppImage.ID)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/imagesource/helper.go
+++ b/pkg/imagesource/helper.go
@@ -189,7 +189,7 @@ func (i ImageSource) GetImageAndDeployArgs(ctx context.Context, c client.Client)
 		if err != nil {
 			return "", nil, err
 		}
-		i.Image = image.Name
+		i.Image = image.ID
 	}
 
 	_, deployArgs, err := i.GetAppDefinition(ctx, c)

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -4555,10 +4555,18 @@ func schema_pkg_apis_internalacornio_v1_AppImage(ref common.ReferenceCallback) c
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"id": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ID is the \"image ID\" that Name resolves to, which might be the same as Name or a string matching ImageInstance.Name",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Name is the image name requested by the user of any format",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"digest": {

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -147,10 +147,10 @@ func (i *Interpolator) resolveApp(keyName string) (string, bool, error) {
 	case "namespace":
 		return i.app.Namespace, true, nil
 	case "image":
-		if tags.IsLocalReference(i.app.Status.AppImage.Name) {
-			return i.app.Status.AppImage.Name, true, nil
-		} else if i.app.Status.AppImage.Name != "" && i.app.Status.AppImage.Digest != "" {
-			tag, err := name.NewTag(i.app.Status.AppImage.Name)
+		if tags.IsLocalReference(i.app.Status.AppImage.ID) {
+			return i.app.Status.AppImage.ID, true, nil
+		} else if i.app.Status.AppImage.ID != "" && i.app.Status.AppImage.Digest != "" {
+			tag, err := name.NewTag(i.app.Status.AppImage.ID)
 			if err != nil {
 				return "", false, err
 			}

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -141,7 +141,7 @@ func generateTemplate(secrets map[string]*corev1.Secret, req router.Request, app
 		Type: v1.SecretTypeTemplate,
 	}
 
-	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.Name)
+	tag, err := images.GetRuntimePullableImageReference(req.Ctx, req.Client, appInstance.Namespace, appInstance.Status.AppImage.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -128,7 +128,7 @@ var (
 
 	Build = [][]string{
 		{"Name", "Name"},
-		{"Image", "Status.AppImage.Name"},
+		{"Image", "Status.AppImage.ID"},
 		{"Message", "Status.BuildError"},
 	}
 	BuildConverter = MustConverter(Build)


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

