### PR TITLE
fix: handling untagged images when tagging and removing (#1511 + #1512)

### DIFF
--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -31,7 +31,7 @@ func (a *ImageDelete) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, image := range args {
-		deleted, err := c.ImageDelete(cmd.Context(), args[0], &client.ImageDeleteOptions{Force: a.Force})
+		deleted, err := c.ImageDelete(cmd.Context(), image, &client.ImageDeleteOptions{Force: a.Force})
 		if err != nil {
 			return fmt.Errorf("deleting %s: %w", image, err)
 		}

--- a/pkg/cli/images_rm.go
+++ b/pkg/cli/images_rm.go
@@ -2,12 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
-	"github.com/acorn-io/acorn/pkg/tags"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
 
@@ -34,18 +31,7 @@ func (a *ImageDelete) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, image := range args {
-		opts := []name.Option{name.WithDefaultRegistry("")}
-
-		if strings.HasPrefix("sha256:", image) || tags.SHAPermissivePrefixPattern.MatchString(image) {
-			opts = append(opts, name.WithDefaultTag(""))
-		}
-
-		// normalize image name (adding :latest if no tag is specified and it's not a digest or potential ID)
-		ref, err := name.ParseReference(image, opts...)
-		if err != nil {
-			return err
-		}
-		deleted, err := c.ImageDelete(cmd.Context(), strings.TrimSuffix(ref.Name(), ":"), &client.ImageDeleteOptions{Force: a.Force})
+		deleted, err := c.ImageDelete(cmd.Context(), args[0], &client.ImageDeleteOptions{Force: a.Force})
 		if err != nil {
 			return fmt.Errorf("deleting %s: %w", image, err)
 		}

--- a/pkg/server/registry/apigroups/acorn/images/storage_test.go
+++ b/pkg/server/registry/apigroups/acorn/images/storage_test.go
@@ -17,6 +17,9 @@ func TestFindMatchingImage(t *testing.T) {
 		},
 		{
 			Digest: "sha256:123409876",
+			Tags: []string{
+				"foo/bar",
+			},
 		},
 		{
 			Digest: "sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb",
@@ -49,4 +52,7 @@ func TestFindMatchingImage(t *testing.T) {
 	_, _, err = findImageMatch(il, "ghcr.io/acorn-io/library/hello-world@sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb")
 	assert.Error(t, err)
 	assert.Equal(t, "images.api.acorn.io \"ghcr.io/acorn-io/library/hello-world@sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb\" not found", err.Error())
+
+	_, _, err = findImageMatch(il, "foo/bar")
+	assert.Error(t, err)
 }

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -191,7 +191,7 @@ func (s *Strategy) findImage(ctx context.Context, namespace, imageName string) (
 // - tag name (with default): <registry>/<repo> or <repo> -> Will be matched against the default tag (:latest)
 //   - Note: if we get some string here, that matches the SHAPermissivePrefixPattern, it could be both a digest or a name without a tag
 //     so we will try to match it against the default tag (:latest) first and if that fails, we treat it as a digest(-prefix)
-func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, string, error) {
+func findImageMatch(images apiv1.ImageList, search string) (*apiv1.Image, string, error) {
 	var (
 		repoDigest     name.Digest
 		digest         string
@@ -200,16 +200,16 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 		tagNameDefault string
 		canBeMultiple  bool // if true, we will not return on first match
 	)
-	if strings.HasPrefix(imageName, "sha256:") {
-		digest = imageName
-	} else if tags2.SHAPattern.MatchString(imageName) {
-		digest = "sha256:" + imageName
-		tagNameDefault = imageName // this could as well be some name without registry/repo path and tag
-	} else if tags2.SHAPermissivePrefixPattern.MatchString(imageName) {
-		digestPrefix = "sha256:" + imageName
-		tagNameDefault = imageName // this could as well be some name without registry/repo path and tag
+	if strings.HasPrefix(search, "sha256:") {
+		digest = search
+	} else if tags2.SHAPattern.MatchString(search) {
+		digest = "sha256:" + search
+		tagNameDefault = search // this could as well be some name without registry/repo path and tag
+	} else if tags2.SHAPermissivePrefixPattern.MatchString(search) {
+		digestPrefix = "sha256:" + search
+		tagNameDefault = search // this could as well be some name without registry/repo path and tag
 	} else {
-		ref, err := name.ParseReference(imageName, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
+		ref, err := name.ParseReference(search, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
 		if err != nil {
 			return nil, "", err
 		}
@@ -239,7 +239,7 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 		if tagNameDefault != "" {
 			for _, tag := range image.Tags {
 				if tag == tagNameDefault {
-					return &image, "", nil
+					return &image, tag, nil
 				}
 			}
 		}
@@ -249,7 +249,7 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 			return &image, "", nil
 		} else if digestPrefix != "" && strings.HasPrefix(image.Digest, digestPrefix) {
 			if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-				return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", imageName))
+				return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
 			}
 			matchedImage = image
 		}
@@ -270,16 +270,16 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 		}
 
 		// >>> match by tag name
-		for i, tag := range image.Tags {
-			if tag == imageName {
+		for _, tag := range image.Tags {
+			if tag == search {
 				if !canBeMultiple {
-					return &image, image.Tags[i], nil
+					return &image, tag, nil
 				} else {
 					if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-						return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", imageName))
+						return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
 					}
 					matchedImage = image
-					matchedTag = image.Tags[i]
+					matchedTag = tag
 				}
 			} else if tag != "" {
 				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""), name.WithDefaultTag("")) // no default here, as we also have repo-only tag items
@@ -291,7 +291,7 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 						return &image, tag, nil
 					} else {
 						if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-							return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", imageName))
+							return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
 						}
 						matchedImage = image
 						matchedTag = tag
@@ -308,5 +308,5 @@ func findImageMatch(images apiv1.ImageList, imageName string) (*apiv1.Image, str
 	return nil, "", apierrors.NewNotFound(schema.GroupResource{
 		Group:    api.Group,
 		Resource: "images",
-	}, imageName)
+	}, search)
 }

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -274,13 +274,12 @@ func findImageMatch(images apiv1.ImageList, search string) (*apiv1.Image, string
 			if tag == search {
 				if !canBeMultiple {
 					return &image, tag, nil
-				} else {
-					if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-						return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
-					}
-					matchedImage = image
-					matchedTag = tag
 				}
+				if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
+					return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
+				}
+				matchedImage = image
+				matchedTag = tag
 			} else if tag != "" {
 				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""), name.WithDefaultTag("")) // no default here, as we also have repo-only tag items
 				if err != nil {
@@ -289,13 +288,12 @@ func findImageMatch(images apiv1.ImageList, search string) (*apiv1.Image, string
 				if imageParsedTag.Name() == tagName {
 					if !canBeMultiple {
 						return &image, tag, nil
-					} else {
-						if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-							return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
-						}
-						matchedImage = image
-						matchedTag = tag
 					}
+					if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
+						return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
+					}
+					matchedImage = image
+					matchedTag = tag
 				}
 			}
 		}


### PR DESCRIPTION
Ref #1511 & #1512

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

