### PR TITLE
Revert "Use Go's built-in DNS resolver to avoid DNS issues when building Acorns"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,8 +21,6 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
-    flags:
-      - -tags netgo
     ldflags:
       - -s
       - -w

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	CGO_ENABLED=0 go build -o bin/acorn -ldflags "-s -w" -tags netgo .
+	CGO_ENABLED=0 go build -o bin/acorn -ldflags "-s -w" .
 
 tidy:
 	go mod tidy


### PR DESCRIPTION
Reverts acorn-io/acorn#1518