### PR TITLE
Linked services: add label to resulting ExternalName Service

### DIFF
--- a/pkg/controller/appdefinition/testdata/depends-ready/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/depends-ready/expected.yaml.d/service.yaml
@@ -12,3 +12,5 @@ spec:
   external: foo
   appName: app-name
   appNamespace: app-namespace
+  labels:
+    acorn.io/link-name: foo

--- a/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/depends/expected.yaml.d/service.yaml
@@ -12,3 +12,5 @@ spec:
   appName: app-name
   appNamespace: app-namespace
   external: foo
+  labels:
+    acorn.io/link-name: foo

--- a/pkg/controller/appdefinition/testdata/link/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/link/expected.yaml.d/service.yaml
@@ -12,3 +12,5 @@ spec:
   appName: app-name
   appNamespace: app-namespace
   external: con-link
+  labels:
+    acorn.io/link-name: con-link

--- a/pkg/services/acorn.go
+++ b/pkg/services/acorn.go
@@ -187,6 +187,9 @@ func forLinkedServices(app *v1.AppInstance) (result []kclient.Object) {
 				PublishMode:  publishMode(app),
 				Publish:      ports2.PortPublishForService(link.Target, app.Spec.Publish),
 				External:     link.Service,
+				Labels: map[string]string{
+					labels.AcornLinkName: link.Service,
+				},
 			},
 		}
 		result = append(result, newService)


### PR DESCRIPTION
I'm working on fixing a bug in acorn-istio-plugin relating to ExternalName Services that are created for linked apps in Acorn. Due to Go module incompatibilities (which I tried to fix for quite some time before giving up), I unfortunately cannot use the Acorn API in the plugin, so I can't just watch Acorn ServiceInstances and must instead watch k8s Services.

I need a way to distinguish ExternalName Services that were created specifically for linked apps from ExternalName Services that were created for other things. By putting this label on the resulting ExternalName Service (and not just on the ServiceInstance), I will be able to tell them apart.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

