### PR TITLE
Prevent users from logging in to 'gchr.io' (#1375)

### DIFF
--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -61,6 +61,9 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 
 	if serverAddress == "" {
 		return cmd.Help()
+	} else if strings.HasPrefix(serverAddress, "gchr.io") {
+		// protect users from this typo
+		return fmt.Errorf("blocking login attempt to gchr.io (did you mean to type ghcr.io?)")
 	}
 
 	if a.PasswordStdin {


### PR DESCRIPTION
re: #1375

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
  - This isn't really worthy of adding a test
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

