### PR TITLE
fix TestProjectUpdate on eks (#1478)

### DIFF
--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1436,32 +1436,48 @@ func TestProjectUpdate(t *testing.T) {
 			t.Logf("failed to delete project '%s': %s", projectName, err)
 		}
 	})
+	latestProject, err := proj1Client.ProjectGet(ctx, projectName)
+	if err != nil {
+		t.Fatal("error while getting project:", err)
+	}
 	// update default
-	updatedProj, err := proj1Client.ProjectUpdate(ctx, proj1, "new-default", []string{"local"})
+	updatedProj, err := proj1Client.ProjectUpdate(ctx, latestProject, "new-default", []string{"local"})
 	if err != nil {
 		t.Fatal("error while updating project:", err)
 	}
 	assert.Equal(t, updatedProj.Spec.DefaultRegion, "new-default")
 	assert.Equal(t, updatedProj.Spec.SupportedRegions, []string{"local", "new-default"})
 
+	latestProject, err = proj1Client.ProjectGet(ctx, projectName)
+	if err != nil {
+		t.Fatal("error while getting project:", err)
+	}
 	// swap default from new-default to local
-	updatedProj, err = proj1Client.ProjectUpdate(ctx, proj1, "local", nil)
+	updatedProj, err = proj1Client.ProjectUpdate(ctx, latestProject, "local", nil)
 	if err != nil {
 		t.Fatal("error while updating project:", err)
 	}
 	assert.Equal(t, updatedProj.Spec.DefaultRegion, "local")
 	assert.Equal(t, updatedProj.Spec.SupportedRegions, []string{"local", "new-default"})
 
+	latestProject, err = proj1Client.ProjectGet(ctx, projectName)
+	if err != nil {
+		t.Fatal("error while getting project:", err)
+	}
 	// remove new-default region
-	updatedProj, err = proj1Client.ProjectUpdate(ctx, proj1, "", []string{"local"})
+	updatedProj, err = proj1Client.ProjectUpdate(ctx, latestProject, "", []string{"local"})
 	if err != nil {
 		t.Fatal("error while updating project:", err)
 	}
 	assert.Equal(t, updatedProj.Spec.DefaultRegion, "local")
 	assert.Equal(t, updatedProj.Spec.SupportedRegions, []string{"local"})
 
+	latestProject, err = proj1Client.ProjectGet(ctx, projectName)
+	if err != nil {
+		t.Fatal("error while getting project:", err)
+	}
 	// set supported regions
-	updatedProj, err = proj1Client.ProjectUpdate(ctx, proj1, "", []string{"local", "local3", "local2"})
+	updatedProj, err = proj1Client.ProjectUpdate(ctx, latestProject, "", []string{"local", "local3", "local2"})
 	if err != nil {
 		t.Fatal("error while updating project:", err)
 	}


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

#1478 