### PR TITLE
Revert "remove nightly staging upgraded"

### DIFF
--- a/.github/workflows/staging-upgrade.yml
+++ b/.github/workflows/staging-upgrade.yml
@@ -2,6 +2,8 @@ name: Update Staging
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '00 10 * * *'   # time in UTC
 
 jobs:
   copy-main-to-staging:


### PR DESCRIPTION
This reverts commit 7c42126745519516b7fb1023ab3b897c033f202c.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

