### PR TITLE
Create NetworkPolicies for builders

### DIFF
--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -325,10 +325,8 @@ func PolicyForService(req router.Request, resp router.Response) error {
 // It also only allows outgoing traffic to CoreDNS, the Acorn registry, and the Internet.
 func PolicyForBuilder(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
-	if err != nil {
+	if err != nil || !*cfg.NetworkPolicies {
 		return err
-	} else if !*cfg.NetworkPolicies {
-		return nil
 	}
 
 	deployment := req.Object.(*appsv1.Deployment)

--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -27,9 +27,9 @@ const (
 	awsEC2cidrV6 = "fd00:ec2::254/64"
 )
 
-// PolicyForApp creates a single Kubernetes NetworkPolicy that restricts incoming network traffic
+// ForApp creates a single Kubernetes NetworkPolicy that restricts incoming network traffic
 // to all pods in an app, so that they cannot be reached by pods from other projects.
-func PolicyForApp(req router.Request, resp router.Response) error {
+func ForApp(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil {
 		return err
@@ -98,10 +98,10 @@ func PolicyForApp(req router.Request, resp router.Response) error {
 	return nil
 }
 
-// PolicyForIngress creates Kubernetes NetworkPolicies to allow traffic to exposed HTTP ports on
+// ForIngress creates Kubernetes NetworkPolicies to allow traffic to exposed HTTP ports on
 // Acorn apps from the ingress controller. If the ingress controller namespace is not defined, traffic from
 // all namespaces will be allowed instead.
-func PolicyForIngress(req router.Request, resp router.Response) error {
+func ForIngress(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil {
 		return err
@@ -236,9 +236,9 @@ func PolicyForIngress(req router.Request, resp router.Response) error {
 	return nil
 }
 
-// PolicyForService creates a Kubernetes NetworkPolicy to allow traffic to published TCP/UDP ports
+// ForService creates a Kubernetes NetworkPolicy to allow traffic to published TCP/UDP ports
 // on Acorn apps that are exposed with LoadBalancer Services.
-func PolicyForService(req router.Request, resp router.Response) error {
+func ForService(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil {
 		return err
@@ -321,9 +321,9 @@ func PolicyForService(req router.Request, resp router.Response) error {
 	return nil
 }
 
-// PolicyForBuilder creates a Kubernetes NetworkPolicy to allow traffic to the buildkitd pods from the acorn-api only.
+// ForBuilder creates a Kubernetes NetworkPolicy to allow traffic to the buildkitd pods from the acorn-api only.
 // It also only allows outgoing traffic to CoreDNS, the Acorn registry, and the Internet.
-func PolicyForBuilder(req router.Request, resp router.Response) error {
+func ForBuilder(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil || !*cfg.NetworkPolicies {
 		return err

--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -8,9 +8,11 @@ import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/config"
 	"github.com/acorn-io/acorn/pkg/labels"
+	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/baaah/pkg/name"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -25,9 +27,9 @@ const (
 	awsEC2cidrV6 = "fd00:ec2::254/64"
 )
 
-// NetworkPolicyForApp creates a single Kubernetes NetworkPolicy that restricts incoming network traffic
+// PolicyForApp creates a single Kubernetes NetworkPolicy that restricts incoming network traffic
 // to all pods in an app, so that they cannot be reached by pods from other projects.
-func NetworkPolicyForApp(req router.Request, resp router.Response) error {
+func PolicyForApp(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil {
 		return err
@@ -96,10 +98,10 @@ func NetworkPolicyForApp(req router.Request, resp router.Response) error {
 	return nil
 }
 
-// NetworkPolicyForIngress creates Kubernetes NetworkPolicies to allow traffic to exposed HTTP ports on
+// PolicyForIngress creates Kubernetes NetworkPolicies to allow traffic to exposed HTTP ports on
 // Acorn apps from the ingress controller. If the ingress controller namespace is not defined, traffic from
 // all namespaces will be allowed instead.
-func NetworkPolicyForIngress(req router.Request, resp router.Response) error {
+func PolicyForIngress(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil {
 		return err
@@ -234,9 +236,9 @@ func NetworkPolicyForIngress(req router.Request, resp router.Response) error {
 	return nil
 }
 
-// NetworkPolicyForService creates a Kubernetes NetworkPolicy to allow traffic to published TCP/UDP ports
+// PolicyForService creates a Kubernetes NetworkPolicy to allow traffic to published TCP/UDP ports
 // on Acorn apps that are exposed with LoadBalancer Services.
-func NetworkPolicyForService(req router.Request, resp router.Response) error {
+func PolicyForService(req router.Request, resp router.Response) error {
 	cfg, err := config.Get(req.Ctx, req.Client)
 	if err != nil {
 		return err
@@ -261,20 +263,9 @@ func NetworkPolicyForService(req router.Request, resp router.Response) error {
 	}
 
 	// build the ipBlock for the NetPol
-	ipBlock := networkingv1.IPBlock{
-		CIDR: "0.0.0.0/0",
-	}
-	// get pod CIDRs from the nodes so that we can only allow traffic from IP addresses outside the cluster
-	nodes := corev1.NodeList{}
-	if err = req.Client.List(req.Ctx, &nodes); err != nil {
-		return fmt.Errorf("failed to list nodes: %w", err)
-	}
-	for _, node := range nodes.Items {
-		for _, cidr := range node.Spec.PodCIDRs {
-			if !slices.Contains(ipBlock.Except, cidr) {
-				ipBlock.Except = append(ipBlock.Except, cidr)
-			}
-		}
+	ipBlock, err := buildExternalIPBlock(req)
+	if err != nil {
+		return err
 	}
 
 	// build the port slice for the NetPol
@@ -304,7 +295,7 @@ func NetworkPolicyForService(req router.Request, resp router.Response) error {
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{
 					{
-						IPBlock: &ipBlock,
+						IPBlock: ipBlock,
 					},
 					{
 						NamespaceSelector: &metav1.LabelSelector{
@@ -328,4 +319,112 @@ func NetworkPolicyForService(req router.Request, resp router.Response) error {
 	})
 
 	return nil
+}
+
+// PolicyForBuilder creates a Kubernetes NetworkPolicy to allow traffic to the buildkitd pods from the acorn-api only.
+// It also only allows outgoing traffic to CoreDNS, the Acorn registry, and the Internet.
+func PolicyForBuilder(req router.Request, resp router.Response) error {
+	cfg, err := config.Get(req.Ctx, req.Client)
+	if err != nil {
+		return err
+	} else if !*cfg.NetworkPolicies {
+		return nil
+	}
+
+	deployment := req.Object.(*appsv1.Deployment)
+	if deployment.Name != "buildkitd" && !strings.HasPrefix(deployment.Name, "bld-") {
+		// this is not a builder deployment
+		return nil
+	}
+
+	podLabels := deployment.Spec.Template.ObjectMeta.Labels
+	externalIPBlock, err := buildExternalIPBlock(req)
+	if err != nil {
+		return err
+	}
+
+	// build the NetPol
+	resp.Objects(&networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment.Name,
+			Namespace: deployment.Namespace,
+			Labels: map[string]string{
+				labels.AcornManaged: "true",
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					// allow access from the acorn-apiserver
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": system.Namespace,
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": system.APIServerName,
+						},
+					},
+				}},
+			}},
+			Egress: []networkingv1.NetworkPolicyEgressRule{{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						IPBlock: externalIPBlock, // allow traffic to the Internet
+					},
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							// allow traffic to kube-system for CoreDNS
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							},
+						},
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"k8s-app": "kube-dns",
+							},
+						},
+					},
+					{
+						PodSelector: &metav1.LabelSelector{
+							// allow traffic to the registry for pushing images
+							MatchLabels: map[string]string{
+								"app": system.RegistryName,
+							},
+						},
+					},
+				},
+			}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	})
+
+	return nil
+}
+
+// buildExternalIPBlock creates a NetworkPolicy IPBlock with the CIDR set to 0.0.0.0/0
+// and the Except set to the pod CIDRs of the nodes.
+func buildExternalIPBlock(req router.Request) (*networkingv1.IPBlock, error) {
+	ipBlock := networkingv1.IPBlock{
+		CIDR: "0.0.0.0/0",
+	}
+
+	// get pod CIDRs from the nodes so that we can only allow IP addresses outside the cluster
+	nodes := corev1.NodeList{}
+	if err := req.Client.List(req.Ctx, &nodes); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+	for _, node := range nodes.Items {
+		for _, cidr := range node.Spec.PodCIDRs {
+			if !slices.Contains(ipBlock.Except, cidr) {
+				ipBlock.Except = append(ipBlock.Except, cidr)
+			}
+		}
+	}
+
+	return &ipBlock, nil
 }

--- a/pkg/controller/networkpolicy/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_test.go
@@ -8,17 +8,17 @@ import (
 )
 
 func TestNetworkPolicyForApp(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/appinstance", NetworkPolicyForApp)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/appinstance", PolicyForApp)
 }
 
 func TestNetworkPolicyForIngress(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/ingress", NetworkPolicyForIngress)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/ingress", PolicyForIngress)
 }
 
 func TestNetworkPolicyForIngressExternalName(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/externalname", NetworkPolicyForIngress)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/externalname", PolicyForIngress)
 }
 
 func TestNetworkPolicyForService(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/service", NetworkPolicyForService)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/service", PolicyForService)
 }

--- a/pkg/controller/networkpolicy/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_test.go
@@ -8,21 +8,21 @@ import (
 )
 
 func TestNetworkPolicyForApp(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/appinstance", PolicyForApp)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/appinstance", ForApp)
 }
 
 func TestNetworkPolicyForIngress(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/ingress", PolicyForIngress)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/ingress", ForIngress)
 }
 
 func TestNetworkPolicyForIngressExternalName(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/externalname", PolicyForIngress)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/externalname", ForIngress)
 }
 
 func TestNetworkPolicyForService(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/service", PolicyForService)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/service", ForService)
 }
 
 func TestNetworkPolicyForBuilder(t *testing.T) {
-	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/builder", PolicyForBuilder)
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/builder", ForBuilder)
 }

--- a/pkg/controller/networkpolicy/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_test.go
@@ -22,3 +22,7 @@ func TestNetworkPolicyForIngressExternalName(t *testing.T) {
 func TestNetworkPolicyForService(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/service", PolicyForService)
 }
+
+func TestNetworkPolicyForBuilder(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/networkpolicy/builder", PolicyForBuilder)
+}

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/builder/existing.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/builder/existing.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: existing-node
+spec:
+  podCIDR: 10.42.0.0/24
+  podCIDRs:
+    - 10.42.0.0/24

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/builder/expected.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/builder/expected.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: buildkitd
+  namespace: acorn-image-system
+  labels:
+    acorn.io/managed: "true"
+spec:
+  podSelector:
+    matchLabels:
+      app: buildkitd
+      another: label
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: acorn-system
+          podSelector:
+            matchLabels:
+              app: acorn-api
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.42.0.0/24
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+        - podSelector:
+            matchLabels:
+              app: registry
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/builder/input.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/builder/input.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildkitd
+  namespace: acorn-image-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: buildkitd
+        another: label

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -65,7 +65,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	appRouter.HandlerFunc(appstatus.VolumeStatus)
 	appRouter.HandlerFunc(appstatus.AcornStatus)
 	appRouter.HandlerFunc(appstatus.ReadyStatus)
-	appRouter.HandlerFunc(networkpolicy.NetworkPolicyForApp)
+	appRouter.HandlerFunc(networkpolicy.PolicyForApp)
 	appRouter.HandlerFunc(appdefinition.AddAcornProjectLabel)
 	appRouter.HandlerFunc(appdefinition.UpdateObservedFields)
 
@@ -94,8 +94,9 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).Middleware(ingress.RequireLBs).Handler(ingress.NewDNSHandler())
 	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, including the on-acorn.io wildcard cert
 	router.Type(&storagev1.StorageClass{}).HandlerFunc(volume.SyncVolumeClasses)
-	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(networkpolicy.NetworkPolicyForService)
-	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(networkpolicy.NetworkPolicyForIngress)
+	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(networkpolicy.PolicyForService)
+	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(networkpolicy.PolicyForIngress)
+	router.Type(&appsv1.Deployment{}).Namespace(system.ImagesNamespace).HandlerFunc(networkpolicy.PolicyForBuilder)
 	router.Type(&netv1.NetworkPolicy{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)
 
 	configRouter := router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName)

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -65,7 +65,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	appRouter.HandlerFunc(appstatus.VolumeStatus)
 	appRouter.HandlerFunc(appstatus.AcornStatus)
 	appRouter.HandlerFunc(appstatus.ReadyStatus)
-	appRouter.HandlerFunc(networkpolicy.PolicyForApp)
+	appRouter.HandlerFunc(networkpolicy.ForApp)
 	appRouter.HandlerFunc(appdefinition.AddAcornProjectLabel)
 	appRouter.HandlerFunc(appdefinition.UpdateObservedFields)
 
@@ -94,9 +94,9 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).Middleware(ingress.RequireLBs).Handler(ingress.NewDNSHandler())
 	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, including the on-acorn.io wildcard cert
 	router.Type(&storagev1.StorageClass{}).HandlerFunc(volume.SyncVolumeClasses)
-	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(networkpolicy.PolicyForService)
-	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(networkpolicy.PolicyForIngress)
-	router.Type(&appsv1.Deployment{}).Namespace(system.ImagesNamespace).HandlerFunc(networkpolicy.PolicyForBuilder)
+	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(networkpolicy.ForService)
+	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(networkpolicy.ForIngress)
+	router.Type(&appsv1.Deployment{}).Namespace(system.ImagesNamespace).HandlerFunc(networkpolicy.ForBuilder)
 	router.Type(&netv1.NetworkPolicy{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)
 
 	configRouter := router.Type(&corev1.ConfigMap{}).Namespace(system.Namespace).Name(system.ConfigName)


### PR DESCRIPTION
This PR adds a new handler that creates a NetworkPolicy for each builder. This is what the NetworkPolicy does:

- Allow traffic **only** from the acorn-apiserver, which is responsible for proxying traffic to the builders.
- Allow traffic **only** to the following locations:
  - The Acorn internal image registry
  - CoreDNS
  - Any IP address outside of the cluster (the Internet)

I also renamed the other NetworkPolicy handlers to make the names shorter/less redundant.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

