### PR TITLE
remove project validation checks from client (#1212 #1069)

### DIFF
--- a/integration/projectconfig/projectconfig_test.go
+++ b/integration/projectconfig/projectconfig_test.go
@@ -118,8 +118,6 @@ func TestCLIConfig(t *testing.T) {
 			wantRestConfigHost: "https://foo.example.com",
 			wantNamespace:      "bar",
 			wantToken:          "pass",
-			wantErr:            fmt.Errorf("project \"example.com/foo/bar\" does not exist within the current context"),
-			wantError:          true,
 		},
 		{
 			name: "Project arg overrides current project",
@@ -166,8 +164,6 @@ func TestCLIConfig(t *testing.T) {
 			wantProject:        "example.com/foo/bar",
 			wantNamespace:      "bar",
 			wantToken:          "pass",
-			wantError:          true,
-			wantErr:            fmt.Errorf("project \"example.com/foo/bar\" does not exist within the current context"),
 		},
 		{
 			name:          "Use alias",

--- a/pkg/cli/acorn_test.go
+++ b/pkg/cli/acorn_test.go
@@ -94,26 +94,6 @@ func TestAcornProject(t *testing.T) {
 		commandContext CommandContext
 	}{
 		{
-			name: "acorn image -j noproject",
-			fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
-			},
-			args: args{
-				args:   []string{"image", "-j", "noproject"},
-				client: &testdata.MockClient{},
-			},
-			wantErr: true,
-			wantOut: "project \"noproject\" does not exist within the current context",
-		},
-		{
 			name: "acorn image -j 12.badname",
 			fields: fields{
 				All:    false,
@@ -131,27 +111,7 @@ func TestAcornProject(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: true,
-			wantOut: "project \"12.badname\" does not exist within the current context",
-		},
-		{
-			name: "acorn image -j badname/projectname/here",
-			fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{},
-				StdOut:        w,
-				StdErr:        w,
-				StdIn:         strings.NewReader(""),
-			},
-			args: args{
-				args:   []string{"image", "-j", "badname/projectname/here"},
-				client: &testdata.MockClient{},
-			},
-			wantErr: true,
-			wantOut: "project \"badname/projectname/here\" does not exist within the current context",
+			wantOut: "invalid project name [12.badname]: can not contain \".\"",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -15,7 +16,13 @@ func RunAndHandleError(ctx context.Context, cmd *cobra.Command) {
 	cmd.SilenceErrors = true
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {
-		pterm.Error.Println(err)
+		errString := err.Error()
+		//If user uses --project/-j flag that does not exist k8s returns namespace error.
+		//Replace namespace with project in error message to make it more user friendly.
+		if cmd.Flag("project").Value.String() != "" {
+			errString = strings.Replace(errString, "namespace", "project", 1)
+		}
+		pterm.Error.Println(errString)
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/pkg/project/client.go
+++ b/pkg/project/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/baaah/pkg/restconfig"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/strings/slices"
 )
 
 var (
@@ -25,7 +24,6 @@ type Options struct {
 	Kubeconfig  string
 	ContextEnv  string
 	AllProjects bool
-	Create      bool
 	CLIConfig   *config.CLIConfig
 }
 
@@ -204,11 +202,8 @@ func getClient(ctx context.Context, cfg *config.CLIConfig, opts Options, project
 }
 
 func getDesiredProjects(ctx context.Context, cfg *config.CLIConfig, opts Options) (result []string, err error) {
-	projects, _, err := List(ctx, opts.WithCLIConfig(cfg))
-	if err != nil {
-		return nil, err
-	}
 	if opts.AllProjects {
+		projects, _, err := List(ctx, opts.WithCLIConfig(cfg))
 		return projects, err
 	}
 	p := strings.TrimSpace(opts.Project)
@@ -217,9 +212,6 @@ func getDesiredProjects(ctx context.Context, cfg *config.CLIConfig, opts Options
 	}
 	if strings.TrimSpace(p) == "" {
 		return nil, nil
-	}
-	if !opts.Create && len(projects) != 0 && !slices.Contains(projects, p) {
-		return nil, fmt.Errorf("project \"%s\" does not exist within the current context", p)
 	}
 	for _, project := range csvSplit.Split(p, -1) {
 		if target := cfg.ProjectAliases[project]; target == "" {

--- a/pkg/project/operations.go
+++ b/pkg/project/operations.go
@@ -24,7 +24,6 @@ func lastPart(s string) string {
 
 func Create(ctx context.Context, opts Options, name, defaultRegion string, supportedRegions []string) error {
 	opts.Project = name
-	opts.Create = true
 	c, err := Client(ctx, opts)
 	if err != nil {
 		return err
@@ -79,7 +78,6 @@ func Exists(ctx context.Context, opts Options, name string) error {
 
 func Update(ctx context.Context, opts Options, project DetailProject, defaultRegion string, supportedRegions []string) error {
 	opts.Project = project.FullName
-	opts.Create = false
 	c, err := Client(ctx, opts)
 	if err != nil {
 		return err

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -147,9 +147,14 @@ var (
 					"clustervolumeclasses",
 					"projectcomputeclasses",
 					"clustercomputeclasses",
-					"imageallowrules",
 				},
 				APIGroups: []string{admin_acorn_io.Group},
+			},
+			{
+				Verbs: []string{"*"},
+				Resources: []string{
+					"imageallowrules",
+				},
 			},
 		},
 	}
@@ -200,7 +205,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Admin,
 			},
-			Rules: concat(View, ViewLogs, Edit, Build),
+			Rules: concat(View, ViewLogs, Edit, Build, Admin),
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)
#1212 #1069
This pr removes project validation checks from the client and sets up using rbac for that validation. Additionally this adds a change to error messaging around projects and namespaces
