### PR TITLE
Block EC2 metadata access for all apps

### DIFF
--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -18,6 +18,10 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
+// This IP address is what workloads running on AWS EC2 instances use to access the instance metadata service.
+// We block it with a NetworkPolicy in each app.
+const awsEC2cidr = "169.254.169.254/32"
+
 // NetworkPolicyForApp creates a single Kubernetes NetworkPolicy that restricts incoming network traffic
 // to all pods in an app, so that they cannot be reached by pods from other projects.
 func NetworkPolicyForApp(req router.Request, resp router.Response) error {
@@ -70,10 +74,8 @@ func NetworkPolicyForApp(req router.Request, resp router.Response) error {
 			Egress: []networkingv1.NetworkPolicyEgressRule{{
 				To: []networkingv1.NetworkPolicyPeer{{
 					IPBlock: &networkingv1.IPBlock{
-						CIDR: "0.0.0.0/0",
-						Except: []string{
-							"169.254.169.254/32",
-						},
+						CIDR:   "0.0.0.0/0",
+						Except: []string{awsEC2cidr},
 					},
 				}},
 			}},

--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -51,6 +51,7 @@ func NetworkPolicyForApp(req router.Request, resp router.Response) error {
 
 	// create the NetworkPolicy for the whole app
 	// this allows traffic only from within the project
+	// it also blocks ec2 metadata traffic with an egress policy
 	resp.Objects(&networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      app.Name,
@@ -66,7 +67,17 @@ func NetworkPolicyForApp(req router.Request, resp router.Response) error {
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: allowedNamespaceSelectors,
 			}},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{{
+				To: []networkingv1.NetworkPolicyPeer{{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR: "0.0.0.0/0",
+						Except: []string{
+							"169.254.169.254/32",
+						},
+					},
+				}},
+			}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		},
 	})
 	return nil

--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
-// These IP addresses iare what workloads running on AWS EC2 instances use to access the instance metadata service.
+// These IP addresses are what workloads running on AWS EC2 instances use to access the instance metadata service.
 // We block them with a NetworkPolicy in each app.
 const (
 	awsEC2cidrV4 = "169.254.169.254/32"

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/appinstance/expected.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/appinstance/expected.yaml
@@ -18,6 +18,10 @@ spec:
             cidr: 0.0.0.0/0
             except:
               - 169.254.169.254/32
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - fd00:ec2::254/64
   podSelector:
     matchLabels:
       acorn.io/app-name: app-name

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/appinstance/expected.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/appinstance/expected.yaml
@@ -12,6 +12,12 @@ spec:
         - namespaceSelector:
             matchLabels:
               acorn.io/app-namespace: app-namespace
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
   podSelector:
     matchLabels:
       acorn.io/app-name: app-name
@@ -19,3 +25,4 @@ spec:
       acorn.io/managed: "true"
   policyTypes:
     - Ingress
+    - Egress


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

