### PR TITLE
Print extra data field in info

### DIFF
--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -61,7 +61,10 @@ func (s *Info) Run(cmd *cobra.Command, _ []string) error {
 	// Format data from info response into map of project name to info response
 	for _, subInfo := range info {
 		// Remove unset fields in the config and userConfig
-		regionInfo := make(map[string]any, len(subInfo.Regions))
+		regionInfo := make(map[string]any, len(subInfo.Regions)+1)
+		if len(subInfo.ExtraData) > 0 {
+			regionInfo["extraData"] = subInfo.ExtraData
+		}
 		for region, spec := range subInfo.Regions {
 			specMap, err := removeUnsetFields(spec, "config", "userConfig")
 			if err != nil {


### PR DESCRIPTION
A previous change moved the extra data field on the Info. This led to the field not being printed when using the acorn info command. This change ensures the field is printed.


