### PR TITLE
Fix app and project region validation (#1542)

### DIFF
--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -460,7 +460,10 @@ func (in *Project) NamespaceScoped() bool {
 }
 
 func (in *Project) HasRegion(region string) bool {
-	return region == "" || in.Status.DefaultRegion == region || slices.Contains(in.Spec.SupportedRegions, region)
+	if region == "" || slices.Contains(in.Spec.SupportedRegions, region) {
+		return true
+	}
+	return in.Spec.DefaultRegion == "" && in.Status.DefaultRegion == region
 }
 
 func (in *Project) GetRegion() string {

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -59,7 +59,9 @@ func (in *AppInstance) GetRegion() string {
 
 func (in *AppInstance) SetDefaultRegion(region string) {
 	if in.Spec.Region == "" {
-		in.Status.Defaults.Region = region
+		if in.Status.Defaults.Region == "" {
+			in.Status.Defaults.Region = region
+		}
 	} else {
 		in.Status.Defaults.Region = ""
 	}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/acorn-io/acorn/pkg/imagesource"
 	"github.com/acorn-io/acorn/pkg/rulerequest"
 	"github.com/acorn-io/acorn/pkg/wait"
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -325,10 +324,6 @@ func (s *Run) update(ctx context.Context, c client.Client, imageSource imagesour
 		return nil, false, nil
 	} else if err != nil {
 		return nil, false, err
-	}
-
-	if s.Region != "" && app.GetRegion() != s.Region {
-		pterm.Warning.Println("The region of an app can not be changed, ignoring --region")
 	}
 
 	if !imageSource.IsImageSet() {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/imagesource"
 	"github.com/acorn-io/acorn/pkg/rulerequest"
 	"github.com/acorn-io/acorn/pkg/wait"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -324,6 +325,10 @@ func (s *Run) update(ctx context.Context, c client.Client, imageSource imagesour
 		return nil, false, nil
 	} else if err != nil {
 		return nil, false, err
+	}
+
+	if s.Region != "" && app.GetRegion() != s.Region {
+		pterm.Warning.Println("The region of an app can not be changed, ignoring --region")
 	}
 
 	if !imageSource.IsImageSet() {

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -146,6 +146,9 @@ func ToAppUpdate(ctx context.Context, c Client, name string, opts *AppUpdateOpti
 	if len(opts.ComputeClasses) != 0 {
 		app.Spec.ComputeClasses = opts.ComputeClasses
 	}
+	if opts.Region != "" {
+		app.Spec.Region = opts.Region
+	}
 
 	return app, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -98,6 +98,7 @@ type AppUpdateOptions struct {
 	AutoUpgradeInterval string
 	Memory              v1.MemoryMap
 	ComputeClasses      v1.ComputeClassMap
+	Region              string
 }
 
 type LogOptions apiv1.LogOptions
@@ -145,6 +146,7 @@ func (a AppRunOptions) ToUpdate() AppUpdateOptions {
 		AutoUpgradeInterval: a.AutoUpgradeInterval,
 		Memory:              a.Memory,
 		ComputeClasses:      a.ComputeClasses,
+		Region:              a.Region,
 	}
 }
 

--- a/pkg/install/namespace.yaml
+++ b/pkg/install/namespace.yaml
@@ -17,5 +17,4 @@ metadata:
   labels:
     acorn.io/project: "true"
   annotations:
-    acorn.io/project-default-region: "local"
-    acorn.io/project-supported-regions: "local"
+    acorn.io/calculated-project-default-region: "local"

--- a/pkg/server/registry/apigroups/acorn/projects/storage.go
+++ b/pkg/server/registry/apigroups/acorn/projects/storage.go
@@ -21,7 +21,8 @@ func NewStorage(c kclient.WithWatch) rest.Storage {
 		updater: remoteResource,
 		deleter: remoteResource,
 	}
-	validator := &Validator{apiv1.LocalRegion}
+
+	validator := &Validator{DefaultRegion: apiv1.LocalRegion, Client: c}
 	return stores.NewBuilder(c.Scheme(), &apiv1.Project{}).
 		WithCreate(strategy).
 		WithUpdate(strategy).

--- a/pkg/server/registry/apigroups/acorn/projects/validator.go
+++ b/pkg/server/registry/apigroups/acorn/projects/validator.go
@@ -2,17 +2,22 @@ package projects
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/strings/slices"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Validator struct {
 	DefaultRegion string
+	Client        kclient.Client
 }
 
-func (v *Validator) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (v *Validator) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	var result field.ErrorList
 	project := obj.(*apiv1.Project)
 	if project.Spec.DefaultRegion == "" && len(project.Spec.SupportedRegions) == 0 {
@@ -31,6 +36,46 @@ func (v *Validator) Validate(ctx context.Context, obj runtime.Object) field.Erro
 	return nil
 }
 
-func (v *Validator) ValidateUpdate(ctx context.Context, obj, _ runtime.Object) field.ErrorList {
-	return v.Validate(ctx, obj)
+func (v *Validator) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
+	// Ensure that default region and supported regions are valid.
+	if err := v.Validate(ctx, new); err != nil {
+		return err
+	}
+
+	// If the user is removing a supported region, ensure that there are no apps in that region.
+	oldProject, newProject := old.(*apiv1.Project), new.(*apiv1.Project)
+	var removedRegions []string
+	for _, region := range append(oldProject.Spec.SupportedRegions, oldProject.Status.DefaultRegion) {
+		if !newProject.HasRegion(region) {
+			removedRegions = append(removedRegions, region)
+		}
+	}
+
+	if len(removedRegions) > 0 {
+		var (
+			appList              apiv1.AppList
+			appsInRemovedRegions []string
+		)
+		if err := v.Client.List(ctx, &appList, kclient.InNamespace(newProject.Name)); err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "supportedRegions"), err)}
+		}
+
+		for _, app := range appList.Items {
+			if slices.Contains(removedRegions, app.GetRegion()) {
+				appsInRemovedRegions = append(appsInRemovedRegions, app.Name)
+			}
+		}
+
+		if len(appsInRemovedRegions) > 0 {
+			return field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec", "supportedRegions"),
+					newProject.GetSupportedRegions(),
+					fmt.Sprintf("cannot remove regions %v that have apps: %v", removedRegions, strings.Join(appsInRemovedRegions, ", ")),
+				),
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/server/registry/apigroups/acorn/projects/validator_test.go
+++ b/pkg/server/registry/apigroups/acorn/projects/validator_test.go
@@ -5,11 +5,16 @@ import (
 	"testing"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/scheme"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestProjectCreateValidation(t *testing.T) {
-	validator := &Validator{apiv1.LocalRegion}
+	validator := &Validator{DefaultRegion: apiv1.LocalRegion}
 
 	tests := []struct {
 		name      string
@@ -82,11 +87,12 @@ func TestProjectCreateValidation(t *testing.T) {
 }
 
 func TestProjectUpdateValidation(t *testing.T) {
-	validator := &Validator{apiv1.LocalRegion}
+	validator := &Validator{DefaultRegion: apiv1.LocalRegion}
 	tests := []struct {
-		name       string
-		newProject apiv1.Project
-		wantError  bool
+		name                   string
+		newProject, oldProject apiv1.Project
+		client                 kclient.Client
+		wantError              bool
 	}{
 		{
 			name:      "Update project to have default region, no supported regions",
@@ -99,6 +105,11 @@ func TestProjectUpdateValidation(t *testing.T) {
 		},
 		{
 			name: "Update project to have default region and supported region",
+			oldProject: apiv1.Project{
+				Status: apiv1.ProjectStatus{
+					DefaultRegion: "my-region",
+				},
+			},
 			newProject: apiv1.Project{
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
@@ -108,6 +119,11 @@ func TestProjectUpdateValidation(t *testing.T) {
 		},
 		{
 			name: "Update project to have default region and non-existent supported regions",
+			oldProject: apiv1.Project{
+				Status: apiv1.ProjectStatus{
+					DefaultRegion: "my-region",
+				},
+			},
 			newProject: apiv1.Project{
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
@@ -125,11 +141,149 @@ func TestProjectUpdateValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Update project remove a supported region, no apps",
+			oldProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			newProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region"},
+				},
+			},
+			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+		},
+		{
+			name: "Update project remove a supported region, no apps in project",
+			oldProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			newProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region"},
+				},
+			},
+			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithLists(
+				&apiv1.AppList{
+					Items: []apiv1.App{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "my-app",
+								Namespace: "other-project",
+							},
+							Spec: v1.AppInstanceSpec{
+								Region: "my-region",
+							},
+						},
+					},
+				},
+			).Build(),
+		},
+		{
+			name: "Update project remove a supported region, no apps in removed region",
+			oldProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			newProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region"},
+				},
+			},
+			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithLists(
+				&apiv1.AppList{
+					Items: []apiv1.App{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "my-app",
+							},
+							Spec: v1.AppInstanceSpec{
+								Region: "my-region",
+							},
+						},
+					},
+				},
+			).Build(),
+		},
+		{
+			name:      "Update project remove a supported region with apps in removed region",
+			wantError: true,
+			oldProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			newProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region"},
+				},
+			},
+			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithLists(
+				&apiv1.AppList{
+					Items: []apiv1.App{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "my-app",
+							},
+							Spec: v1.AppInstanceSpec{
+								Region: "my-other-region",
+							},
+						},
+					},
+				},
+			).Build(),
+		},
+		{
+			name:      "Update project remove a supported region with apps defaulted to removed region",
+			wantError: true,
+			oldProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			newProject: apiv1.Project{
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region"},
+				},
+			},
+			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithLists(
+				&apiv1.AppList{
+					Items: []apiv1.App{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "my-app",
+							},
+							Status: v1.AppInstanceStatus{
+								Defaults: v1.Defaults{
+									Region: "my-other-region",
+								},
+							},
+						},
+					},
+				},
+			).Build(),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator.ValidateUpdate(context.Background(), &tt.newProject, nil)
+			validator.Client = tt.client
+			err := validator.ValidateUpdate(context.Background(), &tt.newProject, &tt.oldProject)
 			if !tt.wantError {
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
Previously, when a user removed a supported region from a project, the apps in that region would be in various states. After these changes, a user will be required to ensure that there are no apps running in a region before removing that region as a supported region for the project.

Additionally, if a user tried to change the region of a running app, then the CLI command would silently ignore this. After these changes, a warning message will be produced indicating that changing the region of an app is not supported and the flag will be ignored.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

