### PR TITLE
Determine app readiness based on deployment spec.Replicas rather than status.Replicas

### DIFF
--- a/pkg/controller/appstatus/status.go
+++ b/pkg/controller/appstatus/status.go
@@ -484,7 +484,7 @@ func AppStatus(req router.Request, resp router.Response) error {
 		if dep.Spec.Replicas != nil {
 			status.ReadyDesired = *dep.Spec.Replicas
 		} else {
-			status.ReadyDesired = 0
+			status.ReadyDesired = 1
 		}
 		status.UpToDate = dep.Status.UpdatedReplicas
 		status.Created = true

--- a/pkg/controller/appstatus/status.go
+++ b/pkg/controller/appstatus/status.go
@@ -481,7 +481,11 @@ func AppStatus(req router.Request, resp router.Response) error {
 
 		status := container[containerName]
 		status.Ready = dep.Status.ReadyReplicas
-		status.ReadyDesired = dep.Status.Replicas
+		if dep.Spec.Replicas != nil {
+			status.ReadyDesired = *dep.Spec.Replicas
+		} else {
+			status.ReadyDesired = 0
+		}
 		status.UpToDate = dep.Status.UpdatedReplicas
 		status.Created = true
 		container[containerName] = status


### PR DESCRIPTION
Before this change, we were checking for app readiness by ensuring that the app's Deployment had matching `status.Replicas` and `status.ReadyReplicas`. If for some reason the Deployment fails to create any replicas (such as a mutating webhook that fails, if Istiod is down for example), then both `status.Replicas` and `status.ReadyReplicas` are set to 0, and Acorn thinks the app is ready even though it is not running at all.

With this change, we look at the Deployment spec instead to see the desired number of replicas.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

