### PR TITLE
Adding acorn version as command (#1569)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn.md
+++ b/docs/docs/100-reference/01-command-line/acorn.md
@@ -55,6 +55,7 @@ acorn [flags]
 * [acorn tag](acorn_tag.md)	 - Tag an image
 * [acorn uninstall](acorn_uninstall.md)	 - Uninstall acorn and associated resources
 * [acorn update](acorn_update.md)	 - Update a deployed app
+* [acorn version](acorn_version.md)	 - Version information for acorn
 * [acorn volume](acorn_volume.md)	 - Manage volumes
 * [acorn wait](acorn_wait.md)	 - Wait an app to be ready then exit with status code 0
 

--- a/docs/docs/100-reference/01-command-line/acorn_version.md
+++ b/docs/docs/100-reference/01-command-line/acorn_version.md
@@ -1,0 +1,37 @@
+---
+title: "acorn version"
+---
+## acorn version
+
+Version information for acorn
+
+```
+acorn version [flags]
+```
+
+### Examples
+
+```
+acorn version
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+  -A, --all-projects        Use all known projects
+      --debug               Enable debug logging
+      --debug-level int     Debug log level (valid 0-9) (default 7)
+      --kubeconfig string   Explicitly use kubeconfig file, overriding current project
+  -j, --project string      Project to work in
+```
+
+### SEE ALSO
+
+* [acorn](acorn.md)	 - 
+

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	acorn "github.com/acorn-io/acorn/pkg/cli"
-	"github.com/acorn-io/acorn/pkg/version"
 	"github.com/rancher/wrangler/pkg/signals"
 
 	// Include cloud auth clients
@@ -11,8 +10,6 @@ import (
 
 func main() {
 	cmd := acorn.New()
-	cmd.Version = version.Get().String()
-	cmd.InitDefaultVersionFlag()
 
 	ctx := signals.SetupSignalContext()
 	acorn.RunAndHandleError(ctx, cmd)

--- a/pkg/cli/acorn.go
+++ b/pkg/cli/acorn.go
@@ -67,6 +67,7 @@ func New() *cobra.Command {
 		NewTag(cmdContext),
 		NewVolume(cmdContext),
 		NewWait(cmdContext),
+		NewVersion(cmdContext),
 	)
 	// This will produce an error if the project flag doesn't exist or a completion function has already
 	// been registered for this flag. Not returning the error since neither of these is likely occur.

--- a/pkg/cli/testdata/acorn/acorn_test_info.txt
+++ b/pkg/cli/testdata/acorn/acorn_test_info.txt
@@ -35,6 +35,7 @@ Available Commands:
   tag          Tag an image
   uninstall    Uninstall acorn and associated resources
   update       Update a deployed app
+  version      Version information for acorn
   volume       Manage volumes
   wait         Wait an app to be ready then exit with status code 0
 

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -17,6 +17,6 @@ func NewVersion(c CommandContext) *cobra.Command {
 		},
 		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
 	}
-	cmd.PersistentFlags().BoolP("verbose", "v", false, "Print verbose output")
+
 	return cmd
 }

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -15,7 +15,7 @@ func NewVersion(c CommandContext) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("acorn version %s\n", version.Get().String())
 		},
-		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
+		Args: cobra.NoArgs,
 	}
 
 	return cmd

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/acorn-io/acorn/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func NewVersion(c CommandContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   "version for acorn",
+		Example: "acorn version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("acorn version %s\n", version.Get().String())
+		},
+		ValidArgsFunction: newCompletion(c.ClientFactory, appsCompletion).withShouldCompleteOptions(onlyNumArgs(1)).complete,
+	}
+	cmd.PersistentFlags().BoolP("verbose", "v", false, "Print verbose output")
+	return cmd
+}

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -10,7 +10,7 @@ import (
 func NewVersion(c CommandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
-		Short:   "version for acorn",
+		Short:   "Version information for acorn",
 		Example: "acorn version",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("acorn version %s\n", version.Get().String())


### PR DESCRIPTION
### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

