### PR TITLE
change: restructure and re-use image finding logic to make image rm output more concise (#1556 & #1551)

### DIFF
--- a/integration/client/images/images_test.go
+++ b/integration/client/images/images_test.go
@@ -47,7 +47,7 @@ func TestImageListGetDelete(t *testing.T) {
 
 	assert.Equal(t, image.Name, newImage.Name)
 
-	delImage, err := c.ImageDelete(ctx, image.Name, &client.ImageDeleteOptions{Force: false})
+	delImage, _, err := c.ImageDelete(ctx, image.Name, &client.ImageDeleteOptions{Force: false})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,11 +363,11 @@ func TestImageDeleteTwoTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.ImageDelete(ctx, image.Name, &client.ImageDeleteOptions{Force: false})
+	_, _, err = c.ImageDelete(ctx, image.Name, &client.ImageDeleteOptions{Force: false})
 	expectedErr := fmt.Errorf("unable to delete %s (must be forced) - image is referenced in multiple repositories", image.Name)
 	assert.Equal(t, expectedErr, err)
 
-	_, err = c.ImageDelete(ctx, image.Name, &client.ImageDeleteOptions{Force: true})
+	_, _, err = c.ImageDelete(ctx, image.Name, &client.ImageDeleteOptions{Force: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -351,27 +351,6 @@ func TestImage(t *testing.T) {
 			wantOut: "index.docker.io/subdir/test:v1@test-image-running-container\n",
 		},
 		{
-			name: "acorn image rm found-image1234567", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{
-					ImageItem: &apiv1.Image{},
-				},
-				StdOut: w,
-				StdErr: w,
-				StdIn:  strings.NewReader("y\n"),
-			},
-			args: args{
-				args:   []string{"rm", "found-image1234567"},
-				client: &testdata.MockClient{},
-			},
-			wantErr: true,
-			wantOut: "found-image1234567\n",
-		},
-		{
 			name: "acorn image rm dne-image", fields: fields{
 				All:    false,
 				Quiet:  false,
@@ -426,7 +405,26 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "ff12345\n",
+			wantOut: "Untagged testtag1:latest\nUntagged testtag2:latest\nUntagged foo:v1\nUntagged foo:v2\nDeleted ff12345\n",
+		},
+		{
+			name: "acorn image rm foo:v1", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{},
+				StdOut:        w,
+				StdErr:        w,
+				StdIn:         strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"rm", "foo:v1"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "Untagged foo:v1\n",
 		},
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -225,7 +225,7 @@ type Client interface {
 
 	ImageList(ctx context.Context) ([]apiv1.Image, error)
 	ImageGet(ctx context.Context, name string) (*apiv1.Image, error)
-	ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, error)
+	ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, []string, error) // returns the modified/deleted image and a list of deleted tags
 	ImagePush(ctx context.Context, tagName string, opts *ImagePushOptions) (<-chan ImageProgress, error)
 	ImagePull(ctx context.Context, name string, opts *ImagePullOptions) (<-chan ImageProgress, error)
 	ImageTag(ctx context.Context, image, tag string) error

--- a/pkg/client/deferred.go
+++ b/pkg/client/deferred.go
@@ -248,9 +248,9 @@ func (d *DeferredClient) ImageGet(ctx context.Context, name string) (*apiv1.Imag
 	return d.Client.ImageGet(ctx, name)
 }
 
-func (d *DeferredClient) ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, error) {
+func (d *DeferredClient) ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, []string, error) {
 	if err := d.create(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return d.Client.ImageDelete(ctx, name, opts)
 }

--- a/pkg/client/ignore.go
+++ b/pkg/client/ignore.go
@@ -167,8 +167,10 @@ func (c IgnoreUninstalled) ImageGet(ctx context.Context, name string) (*apiv1.Im
 	return c.Client.ImageGet(ctx, name)
 }
 
-func (c IgnoreUninstalled) ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, error) {
-	return ignoreUninstalled(c.Client.ImageDelete(ctx, name, opts))
+func (c IgnoreUninstalled) ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, []string, error) {
+	i, t, err := c.Client.ImageDelete(ctx, name, opts)
+	_, err = ignoreUninstalled("", err)
+	return i, t, err
 }
 
 func (c IgnoreUninstalled) ImagePush(ctx context.Context, tagName string, opts *ImagePushOptions) (<-chan ImageProgress, error) {

--- a/pkg/client/multi.go
+++ b/pkg/client/multi.go
@@ -347,10 +347,10 @@ func (m *MultiClient) ImageGet(ctx context.Context, name string) (*apiv1.Image, 
 	return c.ImageGet(ctx, name)
 }
 
-func (m *MultiClient) ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, error) {
+func (m *MultiClient) ImageDelete(ctx context.Context, name string, opts *ImageDeleteOptions) (*apiv1.Image, []string, error) {
 	c, err := m.Factory.ForProject(ctx, m.Factory.DefaultProject())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return c.ImageDelete(ctx, name, opts)
 }

--- a/pkg/images/find.go
+++ b/pkg/images/find.go
@@ -1,0 +1,152 @@
+package images
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+
+	tags2 "github.com/acorn-io/acorn/pkg/tags"
+)
+
+type ErrImageNotFound struct {
+	ImageSearch string
+}
+
+func (e ErrImageNotFound) Error() string {
+	return fmt.Sprintf("image not found: %s", e.ImageSearch)
+}
+
+type ErrImageIdentifierNotUnique struct {
+	ImageSearch string
+}
+
+func (e ErrImageIdentifierNotUnique) Error() string {
+	return fmt.Sprintf("image identifier not unique: %s", e.ImageSearch)
+}
+
+// findImageMatch matches images by digest, digest prefix, or tag name:
+//
+// - digest (raw): sha256:<digest> or <digest> (exactly 64 chars)
+// - digest (image): <registry>/<repo>@sha256:<digest> or <repo>@sha256:<digest>
+// - digest prefix: sha256:<digest prefix> (min. 3 chars)
+// - tag name: <registry>/<repo>:<tag> or <repo>:<tag>
+// - tag name (with default): <registry>/<repo> or <repo> -> Will be matched against the default tag (:latest)
+//   - Note: if we get some string here, that matches the SHAPermissivePrefixPattern, it could be both a digest or a name without a tag
+//     so we will try to match it against the default tag (:latest) first and if that fails, we treat it as a digest(-prefix)
+func FindImageMatch(images apiv1.ImageList, search string) (*apiv1.Image, string, error) {
+	var (
+		repoDigest     name.Digest
+		digest         string
+		digestPrefix   string
+		tagName        string
+		tagNameDefault string
+		canBeMultiple  bool // if true, we will not return on first match
+	)
+	if strings.HasPrefix(search, "sha256:") {
+		digest = search
+	} else if tags2.SHAPattern.MatchString(search) {
+		digest = "sha256:" + search
+		tagNameDefault = search // this could as well be some name without registry/repo path and tag
+	} else if tags2.SHAPermissivePrefixPattern.MatchString(search) {
+		digestPrefix = "sha256:" + search
+		tagNameDefault = search // this could as well be some name without registry/repo path and tag
+	} else {
+		ref, err := name.ParseReference(search, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
+		if err != nil {
+			return nil, "", err
+		}
+		if ref.Identifier() == "" {
+			tagNameDefault = ref.Name() // some name without a tag, so we will try to match it against the default tag (:latest)
+			canBeMultiple = true
+		} else if dig, ok := ref.(name.Digest); ok {
+			repoDigest = dig
+		} else {
+			tagName = ref.Name()
+		}
+	}
+
+	if tagNameDefault != "" {
+		// add default tag (:latest)
+		t, err := name.ParseReference(tagNameDefault, name.WithDefaultRegistry(""))
+		if err != nil {
+			return nil, "", err
+		}
+		tagNameDefault = t.Name()
+	}
+
+	var matchedImage apiv1.Image
+	var matchedTag string
+	for _, image := range images.Items {
+		// >>> match by tag name with default tag (:latest)
+		if tagNameDefault != "" {
+			for _, tag := range image.Tags {
+				if tag == tagNameDefault {
+					return &image, tag, nil
+				}
+			}
+		}
+
+		// >>> match by digest or digest prefix
+		if image.Digest == digest {
+			return &image, "", nil
+		} else if digestPrefix != "" && strings.HasPrefix(image.Digest, digestPrefix) {
+			if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
+				return nil, "", ErrImageIdentifierNotUnique{ImageSearch: search}
+			}
+			matchedImage = image
+		}
+
+		// >>> match by repo digest
+		// this returns an image which matches the digest and has at least one tag
+		// which matches the repo part of the repo digest.
+		if repoDigest.Name() != "" && image.Digest == repoDigest.DigestStr() {
+			for _, tag := range image.Tags {
+				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""))
+				if err != nil {
+					continue
+				}
+				if imageParsedTag.Context().Name() == repoDigest.Context().Name() {
+					return &image, tag, nil
+				}
+			}
+		}
+
+		// >>> match by tag name
+		for _, tag := range image.Tags {
+			if tag == search {
+				if !canBeMultiple {
+					return &image, tag, nil
+				}
+				if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
+					return nil, "", ErrImageIdentifierNotUnique{ImageSearch: search}
+				}
+				matchedImage = image
+				matchedTag = tag
+			} else if tag != "" {
+				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""), name.WithDefaultTag("")) // no default here, as we also have repo-only tag items
+				if err != nil {
+					continue
+				}
+				if imageParsedTag.Name() == tagName {
+					if !canBeMultiple {
+						return &image, tag, nil
+					}
+					if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
+						return nil, "", ErrImageIdentifierNotUnique{ImageSearch: search}
+					}
+					matchedImage = image
+					matchedTag = tag
+				}
+			}
+		}
+	}
+
+	if matchedImage.Digest != "" {
+		return &matchedImage, matchedTag, nil
+	}
+
+	return nil, "", ErrImageNotFound{ImageSearch: search}
+}

--- a/pkg/mocks/mock_client.go
+++ b/pkg/mocks/mock_client.go
@@ -469,12 +469,13 @@ func (mr *MockClientMockRecorder) GetProject() *gomock.Call {
 }
 
 // ImageDelete mocks base method.
-func (m *MockClient) ImageDelete(arg0 context.Context, arg1 string, arg2 *client.ImageDeleteOptions) (*v1.Image, error) {
+func (m *MockClient) ImageDelete(arg0 context.Context, arg1 string, arg2 *client.ImageDeleteOptions) (*v1.Image, []string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImageDelete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1.Image)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ImageDelete indicates an expected call of ImageDelete.

--- a/pkg/server/registry/apigroups/acorn/images/storage_test.go
+++ b/pkg/server/registry/apigroups/acorn/images/storage_test.go
@@ -48,7 +48,7 @@ func TestFindMatchingImage(t *testing.T) {
 	// err: ambiguous digest prefix
 	_, _, err = findImageMatch(il, "123")
 	assert.Error(t, err)
-	assert.Equal(t, "Image identifier 123 is not unique", err.Error())
+	assert.Equal(t, "image identifier not unique: 123", err.Error())
 
 	// pass: full digest reference
 	image, ref, err = findImageMatch(il, "foo/bar@sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb")
@@ -66,7 +66,7 @@ func TestFindMatchingImage(t *testing.T) {
 	// err: ambiguous reg/repo reference
 	_, _, err = findImageMatch(il, "foo/bar")
 	assert.Error(t, err)
-	assert.Equal(t, "Image identifier foo/bar is not unique", err.Error())
+	assert.Equal(t, "image identifier not unique: foo/bar", err.Error())
 
 	// pass: full tag reference
 	image, ref, err = findImageMatch(il, "spam/eggs:v1")

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -2,15 +2,16 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	api "github.com/acorn-io/acorn/pkg/apis/api.acorn.io"
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/images"
 	"github.com/acorn-io/acorn/pkg/publicname"
 	"github.com/acorn-io/acorn/pkg/tables"
-	tags2 "github.com/acorn-io/acorn/pkg/tags"
 	"github.com/acorn-io/mink/pkg/strategy"
 	"github.com/acorn-io/mink/pkg/types"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -182,129 +183,16 @@ func (s *Strategy) findImage(ctx context.Context, namespace, imageName string) (
 	return findImageMatch(*result, imageName)
 }
 
-// findImageMatch matches images by digest, digest prefix, or tag name:
-//
-// - digest (raw): sha256:<digest> or <digest> (exactly 64 chars)
-// - digest (image): <registry>/<repo>@sha256:<digest> or <repo>@sha256:<digest>
-// - digest prefix: sha256:<digest prefix> (min. 3 chars)
-// - tag name: <registry>/<repo>:<tag> or <repo>:<tag>
-// - tag name (with default): <registry>/<repo> or <repo> -> Will be matched against the default tag (:latest)
-//   - Note: if we get some string here, that matches the SHAPermissivePrefixPattern, it could be both a digest or a name without a tag
-//     so we will try to match it against the default tag (:latest) first and if that fails, we treat it as a digest(-prefix)
-func findImageMatch(images apiv1.ImageList, search string) (*apiv1.Image, string, error) {
-	var (
-		repoDigest     name.Digest
-		digest         string
-		digestPrefix   string
-		tagName        string
-		tagNameDefault string
-		canBeMultiple  bool // if true, we will not return on first match
-	)
-	if strings.HasPrefix(search, "sha256:") {
-		digest = search
-	} else if tags2.SHAPattern.MatchString(search) {
-		digest = "sha256:" + search
-		tagNameDefault = search // this could as well be some name without registry/repo path and tag
-	} else if tags2.SHAPermissivePrefixPattern.MatchString(search) {
-		digestPrefix = "sha256:" + search
-		tagNameDefault = search // this could as well be some name without registry/repo path and tag
-	} else {
-		ref, err := name.ParseReference(search, name.WithDefaultRegistry(""), name.WithDefaultTag(""))
-		if err != nil {
-			return nil, "", err
+func findImageMatch(imagelist apiv1.ImageList, imageName string) (*apiv1.Image, string, error) {
+	img, match, err := images.FindImageMatch(imagelist, imageName)
+	if err != nil {
+		if errors.As(err, &images.ErrImageNotFound{}) {
+			return nil, match, apierrors.NewNotFound(schema.GroupResource{Group: api.Group, Resource: "images"}, imageName)
 		}
-		if ref.Identifier() == "" {
-			tagNameDefault = ref.Name() // some name without a tag, so we will try to match it against the default tag (:latest)
-			canBeMultiple = true
-		} else if dig, ok := ref.(name.Digest); ok {
-			repoDigest = dig
-		} else {
-			tagName = ref.Name()
+		if errors.As(err, &images.ErrImageIdentifierNotUnique{}) {
+			return nil, match, apierrors.NewBadRequest(err.Error())
 		}
+		return nil, match, apierrors.NewInternalError(fmt.Errorf("error while finding image %s", imageName))
 	}
-
-	if tagNameDefault != "" {
-		// add default tag (:latest)
-		t, err := name.ParseReference(tagNameDefault, name.WithDefaultRegistry(""))
-		if err != nil {
-			return nil, "", err
-		}
-		tagNameDefault = t.Name()
-	}
-
-	var matchedImage apiv1.Image
-	var matchedTag string
-	for _, image := range images.Items {
-		// >>> match by tag name with default tag (:latest)
-		if tagNameDefault != "" {
-			for _, tag := range image.Tags {
-				if tag == tagNameDefault {
-					return &image, tag, nil
-				}
-			}
-		}
-
-		// >>> match by digest or digest prefix
-		if image.Digest == digest {
-			return &image, "", nil
-		} else if digestPrefix != "" && strings.HasPrefix(image.Digest, digestPrefix) {
-			if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-				return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
-			}
-			matchedImage = image
-		}
-
-		// >>> match by repo digest
-		// this returns an image which matches the digest and has at least one tag
-		// which matches the repo part of the repo digest.
-		if repoDigest.Name() != "" && image.Digest == repoDigest.DigestStr() {
-			for _, tag := range image.Tags {
-				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""))
-				if err != nil {
-					continue
-				}
-				if imageParsedTag.Context().Name() == repoDigest.Context().Name() {
-					return &image, tag, nil
-				}
-			}
-		}
-
-		// >>> match by tag name
-		for _, tag := range image.Tags {
-			if tag == search {
-				if !canBeMultiple {
-					return &image, tag, nil
-				}
-				if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-					return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
-				}
-				matchedImage = image
-				matchedTag = tag
-			} else if tag != "" {
-				imageParsedTag, err := name.NewTag(tag, name.WithDefaultRegistry(""), name.WithDefaultTag("")) // no default here, as we also have repo-only tag items
-				if err != nil {
-					continue
-				}
-				if imageParsedTag.Name() == tagName {
-					if !canBeMultiple {
-						return &image, tag, nil
-					}
-					if matchedImage.Digest != "" && matchedImage.Digest != image.Digest {
-						return nil, "", apierrors.NewBadRequest(fmt.Sprintf("Image identifier %v is not unique", search))
-					}
-					matchedImage = image
-					matchedTag = tag
-				}
-			}
-		}
-	}
-
-	if matchedImage.Digest != "" {
-		return &matchedImage, matchedTag, nil
-	}
-
-	return nil, "", apierrors.NewNotFound(schema.GroupResource{
-		Group:    api.Group,
-		Resource: "images",
-	}, search)
+	return img, match, err
 }


### PR DESCRIPTION
Ref #1556 & #1551

### User-Facing changes

`acorn image rm` will now output the actions it took similar to `docker image rm` to make it clear if it just dropped some tag or actually deleted a whole image. See Test case further down.

### Note to reviewers

I'm not sure about the changes to client.ImageDelete as it's a little unconventional. Let me know what you think or if you have a better idea to solve this.

This is what we talked about @ibuildthecloud 

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

### Tests

```
$ acorn images         
REPOSITORY   TAG       IMAGE-ID
foo          latest    c5327c2d0729
foo          v1        c5327c2d0729
foo          v2        c5327c2d0729

$ acorn image rm foo:v1
Untagged foo:v1

$ acorn image rm c53   
  ✗  ERROR:  deleting c53: unable to delete c53 (must be forced) - image is referenced in multiple repositories

$ acorn image rm c53 -f
Untagged foo:latest
Untagged foo:v2
Deleted c5327c2d0729870b9f8b0a9269746f9ae7383843e7029da524ae76ef72a7080d
```