### PR TITLE
Initial docs for services

### DIFF
--- a/docs/docs/100-reference/03-acornfile.md
+++ b/docs/docs/100-reference/03-acornfile.md
@@ -5,13 +5,15 @@ title: Acornfile
 ## Root
 
 The root level elements are,
-[args](#args)
+[args](#args),
+[services](#services),
+[acorns](#acorns),
 [containers](#containers),
 [jobs](#jobs),
 [routers](#routers),
 [volumes](#volumes),
 [secrets](#secrets),
-and [localData](#localData).
+and [localData](#localdata).
 
 [containers](#containers),
 [jobs](#jobs),
@@ -23,6 +25,14 @@ the keys could be using in a DNS name so the keys must only contain the characte
 ```acorn
 // User configurable values that can be changed at build or run time.
 args: {
+}
+
+// Definition of services the Acorn app will consume
+services: {
+}
+
+// Definition of Acorns that will consumed by this Acorn app
+acorns: {
 }
 
 // Definition of containers to run
@@ -49,15 +59,16 @@ secrets: {
 localData: {
 }
 ```
+
 ## containers
 
-`containers` defines the templates of containers to be ran. Depending on the 
+`containers` defines the templates of containers to be ran. Depending on the
 scale parameter 1 or more containers can be created from each template (including their [sidecars](#sidecars)).
 
 ```acorn
 containers: web: {
-	image: "nginx"
-	ports: publish: "80/http"
+ image: "nginx"
+ ports: publish: "80/http"
 }
 ```
 
@@ -69,41 +80,40 @@ to the [volumes](#volumes) section for more information on volume types.
 
 ```acorn
 containers: default: {
-	image: "nginx"
-	dirs: {
-		// A volume named "volume-name" will be mounted at /var/tmp
-		"/var/tmp": "volume-name"
-		
-		// A volume named "volume-name" will be mounted at /var/tmp-full with the size of 20G and an
-		// access mode of readWriteMany
-		"/var/tmp-full": "volume://volume-name?size=20G,accessMode=readWriteMany"
-		
-		// An ephemeral volume will be created and mounted to "/var/tmp-ephemeral"
-		"/var/tmp-ephemeral": "ephemeral://"
-		
-		// An ephemeral volume named "shared" will be created and mounted to "/var/tmp-ephemeral"
-		"/var/tmp-ephemeral-named": "ephemeral://shared"
-		
-		// A folder will be created at /var/tmp-secret/ where the filenames are the
-		// key names of the secret "sec-name" and the contents of each file is the corresponding
-		// secret data value
-		"/var/tmp-secret": "secret://sec-nam"
-		
-		// The local folder ./www will be copied during build into the container image
-		// as /var/www.  If running in dev mode the directory will be syncronized live with
-		// changes.  Local folders must start with "./".
-		"/var/www": "./www"
-	}
-	sidecars: sidecar: {
-		image: "ubuntu"
-		dirs: {
-			// An ephemeral volume named "shared" will be mounted to /var/tmp with the contents of
-			// the volume shared with the main containers /var/tmp-ephemeral-named folder
+ image: "nginx"
+ dirs: {
+  // A volume named "volume-name" will be mounted at /var/tmp
+  "/var/tmp": "volume-name"
+  
+  // A volume named "volume-name" will be mounted at /var/tmp-full with the size of 20G and an
+  // access mode of readWriteMany
+  "/var/tmp-full": "volume://volume-name?size=20G,accessMode=readWriteMany"
+  
+  // An ephemeral volume will be created and mounted to "/var/tmp-ephemeral"
+  "/var/tmp-ephemeral": "ephemeral://"
+  
+  // An ephemeral volume named "shared" will be created and mounted to "/var/tmp-ephemeral"
+  "/var/tmp-ephemeral-named": "ephemeral://shared"
+  
+  // A folder will be created at /var/tmp-secret/ where the filenames are the
+  // key names of the secret "sec-name" and the contents of each file is the corresponding
+  // secret data value
+  "/var/tmp-secret": "secret://sec-nam"
+  
+  // The local folder ./www will be copied during build into the container image
+  // as /var/www.  If running in dev mode the directory will be syncronized live with
+  // changes.  Local folders must start with "./".
+  "/var/www": "./www"
+ }
+ sidecars: sidecar: {
+  image: "ubuntu"
+  dirs: {
+   // An ephemeral volume named "shared" will be mounted to /var/tmp with the contents of
+   // the volume shared with the main containers /var/tmp-ephemeral-named folder
             "/var/tmp": "ephemeral://shared"
-		}
-	}
+  }
+ }
 ```
-
 
 ### files
 
@@ -111,203 +121,228 @@ containers: default: {
 `files` parameter is a map structure with the key being the file name and the value being the text of the file
 or a reference to a secret value. The default mode for files is `0644` unless the file ends with `.sh` or contains
 `/bin/` or `/sbin/`.  In those situations the mode will be `0755`.
+
 ```acorn
 containers: default: {
-	image: "nginx"
-	files: {
-		// A file named /var/tmp/file.txt will be created with mode 0644
-		"/var/tmp/file.txt": "some file contents"
-		
-		// A file named /run/secret/password will be created with mode 0400 with the
-		// contents of from the secret named "sec-name" and the value of the data
-		// key named "key".
-		"/run/secret/password": "secret://sec-name/key?mode=0400"
-		
-		// By default if a secret value changes the application will be restarted.
-		// the following example will cause the container to not be restarted when
-		// the secret value changes, but instead the container is dynamically updated
-		"/run/secret/password-reload": "secret://sec-name/key?onchange=no-action"
-		
-		// A file /var/tmp/other.txt will be created with a custom mode value "0600"
-		"/var/tmp/other.txt": {
-			content: "file content"
-			mode: "0600"
-		}
-		
-	}
+ image: "nginx"
+ files: {
+  // A file named /var/tmp/file.txt will be created with mode 0644
+  "/var/tmp/file.txt": "some file contents"
+  
+  // A file named /run/secret/password will be created with mode 0400 with the
+  // contents of from the secret named "sec-name" and the value of the data
+  // key named "key".
+  "/run/secret/password": "secret://sec-name/key?mode=0400"
+  
+  // By default if a secret value changes the application will be restarted.
+  // the following example will cause the container to not be restarted when
+  // the secret value changes, but instead the container is dynamically updated
+  "/run/secret/password-reload": "secret://sec-name/key?onchange=no-action"
+  
+  // A file /var/tmp/other.txt will be created with a custom mode value "0600"
+  "/var/tmp/other.txt": {
+   content: "file content"
+   mode: "0600"
+  }
+  
+ }
 }
 ```
+
 ### image
+
 `image` refers to the OCI (Docker) image to run for this container.
+
 ```acorn
 containers: web: {
-	image: "nginx"
+ image: "nginx"
 }
 ```
+
 ### build
+
 `build` contains the information need to build an OCI image to run for this container
+
 ```acorn
 containers: build1: {
-	// Build the Docker image using the context dir "." and the "./Dockerfile".
-	build: "."
+ // Build the Docker image using the context dir "." and the "./Dockerfile".
+ build: "."
 }
 
 containers: build2: {
-	build: {
-		// Build using the context dir "./subdir"
-		context: "./subdir"
-		// Build using the "./subdir/Dockerfile"
-		dockerfile: "./subdir/Dockerfile"
-		// Build with the multi-stage target named "multistage-target"
-		target: "multistage-target"
-		// Pass the following build arguements to the dockerfile
-		buildArgs: {
-			"arg1": "value1"
-			"arg2": "value2"
-		}
-	}
+ build: {
+  // Build using the context dir "./subdir"
+  context: "./subdir"
+  // Build using the "./subdir/Dockerfile"
+  dockerfile: "./subdir/Dockerfile"
+  // Build with the multi-stage target named "multistage-target"
+  target: "multistage-target"
+  // Pass the following build arguements to the dockerfile
+  buildArgs: {
+   "arg1": "value1"
+   "arg2": "value2"
+  }
+ }
 }
 ```
+
 ### command, cmd
+
 `command` will overwrite the `CMD` value set in the Dockerfile for the running container
+
 ```acorn
 containers: arg1: {
-	image: "nginx"
-	// This command will be parsed as a shell expression and turned into an array and ran
-	cmd: #"/bin/sh -c "echo hi""#
+ image: "nginx"
+ // This command will be parsed as a shell expression and turned into an array and ran
+ cmd: #"/bin/sh -c "echo hi""#
 }
 
 containers: arg2: {
-	image: "nginx"
-	// The following will not be parsed and will be ran as defined.
-	cmd: ["/bin/sh", "-c", "echo hi"]
+ image: "nginx"
+ // The following will not be parsed and will be ran as defined.
+ cmd: ["/bin/sh", "-c", "echo hi"]
 }
 
 ```
+
 ### entrypoint
+
 `entrypoint` will overwrite the `ENTRYPOINT` value set in the Dockerfile for this running container
+
 ```acorn
 containers: arg1: {
-	image: "nginx"
-	// This command will be parsed as a shell expression and turned into an array and ran
-	entrypoint: #"/bin/sh -c "echo hi""#
+ image: "nginx"
+ // This command will be parsed as a shell expression and turned into an array and ran
+ entrypoint: #"/bin/sh -c "echo hi""#
 }
 
 containers: arg2: {
-	image: "nginx"
-	// The following will not be parsed and will be ran as defined.
-	entrypoint: ["/bin/sh", "-c", "echo hi"]
+ image: "nginx"
+ // The following will not be parsed and will be ran as defined.
+ entrypoint: ["/bin/sh", "-c", "echo hi"]
 }
 ```
+
 ### env, environment
+
 `env` will set environment variables on the defined container.  The value of the environment variable
 may be static text or a value from a secret.
+
 ```acorn
 containers: env1: {
-	image: "nginx"
-	env: [
-	    // An environment variable of name "NAME" and value "VALUE" will be set
-		"NAME=VALUE",
+ image: "nginx"
+ env: [
+     // An environment variable of name "NAME" and value "VALUE" will be set
+  "NAME=VALUE",
 
-	    // An environment variable of name "SECRET" and value of the key "key" in the
-	    // secret named "sec-name" will be set. When this secret changes the container
-	    // will not be restarted.
-		"SECRET=secret://sec-name/key?onchange=no-action"
-	]
+     // An environment variable of name "SECRET" and value of the key "key" in the
+     // secret named "sec-name" will be set. When this secret changes the container
+     // will not be restarted.
+  "SECRET=secret://sec-name/key?onchange=no-action"
+ ]
 }
 
 containers: env1: {
-	image: "nginx"
-	// The same configuration as above but in map form
-	env: [
-		NAME: "VALUE"
-		SECRET: "secret://sec-name/key?onchange=no-action"
-	]
+ image: "nginx"
+ // The same configuration as above but in map form
+ env: [
+  NAME: "VALUE"
+  SECRET: "secret://sec-name/key?onchange=no-action"
+ ]
 }
 ```
+
 ### workDir, workingDir
+
 `workDir` sets the current working directory of the running process defined in `cmd` and `entrypoint`
+
 ```acorn
 containers: env1: {
-	image: "nginx"
-	command: "ls"
-	// Run the command "ls", as defined above, in the directory "/tmp"
-	workDir: "/tmp"
+ image: "nginx"
+ command: "ls"
+ // Run the command "ls", as defined above, in the directory "/tmp"
+ workDir: "/tmp"
 }
 ```
 
 ### dependsOn
+
 `dependsOn` will prevent a container from being created and/or updated until all of
 it's dependencies are considered ready. Ready service are considered ready as soon as
 their [ready probe](#probes-probe) passes.  If there is no ready probe it is as soon
 as the containers have started.
+
 ```acorn
 containers: web: {
-	image: "nginx"
-	dependsOn: ["db"]
+ image: "nginx"
+ dependsOn: ["db"]
 }
 containers: db: {
-	// ...
-	image: "mariadb"
+ // ...
+ image: "mariadb"
 }
 ```
+
 ### ports
+
 `ports` defines which ports are available on the container and the default level of access. Ports
 are defined with three different access modes: internal, expose, publish. Internal ports are only available
 to the containers within an Acorn. Expose(d) ports are available to services within the cluster. And
 publish ports are available publicly outside the cluster. The access mode defined in the Acornfile is
 just the default behavior and can be changed at deploy time.
+
 ```acorn
 containers: web: {
-	image: "nginx"
-	
-	// Define internal TCP port 80 available internally as DNS web:80
-	ports: 80
-	
-	// Define internal HTTP port 80 available internally as DNS web:80
-	// Valid protocols are tcp, udp, and http
-	ports: "80/http"
-	
-	// Define internal HTTP port 80 that maps to the container port 8080
-	// available internally as DNS web:80
-	ports: "80:8080/http"
-	
-	// Define internal TCP port 80 that maps to the container port 8080
-	// available internally as DNS web:80
-	ports: "80:8080"
-	
-	// Define internal TCP port 80 that maps to the container port 8080
-	// available internally as DNS web-alias:80
-	ports: "web-alias:80:8080"
-	
-	// The similar ports as above but just in a list
-	ports: [
-		80,
-	    "80/http",
-	    "80:8080/http",
-	]
-	
-	ports: {
-		// Define publically accessible HTTP port 80 that maps to the container port 8080
-	    // available publically as a DNS assigned at runtime
-		publish: ["80:8080/http"]
-		
-		// Define cluster accessible HTTP port 80 that maps to the container port 8080
-	    // available publically as a DNS assigned at runtime
-		expose: ["80:8080/http"]
-		
-	    // Define internal HTTP port 80 that maps to the container port 8080
-	    // available internally as DNS web:80
-		internal: ["80:8080/http"]
-	}
-	
+ image: "nginx"
+ 
+ // Define internal TCP port 80 available internally as DNS web:80
+ ports: 80
+ 
+ // Define internal HTTP port 80 available internally as DNS web:80
+ // Valid protocols are tcp, udp, and http
+ ports: "80/http"
+ 
+ // Define internal HTTP port 80 that maps to the container port 8080
+ // available internally as DNS web:80
+ ports: "80:8080/http"
+ 
+ // Define internal TCP port 80 that maps to the container port 8080
+ // available internally as DNS web:80
+ ports: "80:8080"
+ 
+ // Define internal TCP port 80 that maps to the container port 8080
+ // available internally as DNS web-alias:80
+ ports: "web-alias:80:8080"
+ 
+ // The similar ports as above but just in a list
+ ports: [
+  80,
+     "80/http",
+     "80:8080/http",
+ ]
+ 
+ ports: {
+  // Define publically accessible HTTP port 80 that maps to the container port 8080
+     // available publically as a DNS assigned at runtime
+  publish: ["80:8080/http"]
+  
+  // Define cluster accessible HTTP port 80 that maps to the container port 8080
+     // available publically as a DNS assigned at runtime
+  expose: ["80:8080/http"]
+  
+     // Define internal HTTP port 80 that maps to the container port 8080
+     // available internally as DNS web:80
+  internal: ["80:8080/http"]
+ }
+ 
     // Define publically accessible HTTP port 80 that maps to the container port 8080
     // available publically as a DNS assigned at runtime
-	ports: publish: "80:8080/http"
+ ports: publish: "80:8080/http"
 }
 ```
 
 ### probes, probe
+
 `probes` configure probes that can signal when the container is ready, alive, and started. There are
 three probe types: `readiness`, `liveness`, and `startup`. `readiness` probes indicate when an application
 is available to handle requests. Ports will not be accessible until the `readiness` probe passes. `liveness`
@@ -316,19 +351,19 @@ and restarted. `startup` probe indicates that the container has started for the 
 
 ```acorn
 containers: web: {
-	image: "nginx"
-	
-	// Configure readiness probe to run probe.sh
-	probe: "probe.sh"
-	
-	// Configure readiness probe to look for a HTTP 200 response from localhost port 80
-	probe: "http://localhost:80"
-	
-	// Configure readiness probe to connect to TCP port 1234
-	probe: "tcp://localhost:1234"
-	
-	probes: {
-		"readiness": {
+ image: "nginx"
+ 
+ // Configure readiness probe to run probe.sh
+ probe: "probe.sh"
+ 
+ // Configure readiness probe to look for a HTTP 200 response from localhost port 80
+ probe: "http://localhost:80"
+ 
+ // Configure readiness probe to connect to TCP port 1234
+ probe: "tcp://localhost:1234"
+ 
+ probes: {
+  "readiness": {
             // Configure a HTTP readiness probe
             http: {
                 url: "http://localhost:80"
@@ -342,45 +377,50 @@ containers: web: {
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
-		}
-		"liveness": {
+  }
+  "liveness": {
             // Configure an Exec liveness probe
             exec: {
                 command: ["probe.sh"]
             }
-		}
-		"startup": {
+  }
+  "startup": {
             // Configure a TCP startup liveness probe
             tcp: {
-            	url: "tcp://localhost:1234"
+             url: "tcp://localhost:1234"
             }
-		}
-	}
+  }
+ }
 }
 
 ```
+
 ### scale
+
 `scale` configures the number of container replicas based on this configuration that should
 be ran.
 
 ```acorn
 containers: web: {
-	image: "nginx"
-	scale: 2
+ image: "nginx"
+ scale: 2
 }
 ```
 
 ### sidecars
+
 `sidecars` are containers that run colocated with the parent container and share the same network
 address. Sidecars accept all the same parameters as a container and one additional parameter `init`
+
 ```acorn
 containers: web: {
-	image: "nginx"
-	sidecars: sidecar: {
-		image: "someother-image"
-	}
+ image: "nginx"
+ sidecars: sidecar: {
+  image: "someother-image"
+ }
 }
 ```
+
 #### init
 
 `init` tells the container runtime that this `sidecar` must be ran first on startup and the main
@@ -391,10 +431,10 @@ containers: web: {
     image: "nginx"
     dirs: "/run/startup/": "ephemeral://startup-info"
     sidecars: "stage-data": {
-    	// This sidecar will run first and only when it exits with exit code 0 will the 
-    	// parent "web" container start
-    	init: true
-    	image: "ubuntu"
+     // This sidecar will run first and only when it exits with exit code 0 will the 
+     // parent "web" container start
+     init: true
+     image: "ubuntu"
         dirs: "/run/startup/": "ephemeral://startup-info"
         command: "./stage-data-to /run/startup"
     }
@@ -409,47 +449,48 @@ containers: web: {
 containers: web: {
     image: "nginx"
     permissions: {
-		// These are permissions that will only be granted for this container in its namespace.
-		rules: [{
-			// Configure what actions you can do on the defined resources
-			verbs: [
-				"get", 
-				"list", 
-				"watch",
-				"create", 
-			]
-			// Define what API group the resources belong to
-			apiGroups: [
-				"api.sample.io"
-			]
-			// Configure which resources in the above apiGroups to apply the above verbs to
-			resources: [
-				"fooresource"
-			]
-		}]
-		// These are permissions that will be granted for this container in all namespaces.
-		clusterRules: [{
-			verbs: [
-				"get", 
-				"list", 
-				"watch",
-			]
-			apiGroups: [
-				"api.sample.io"
-			]
-			resources: [
-				"fooresource"
-			]
-			// Optionally restrict permissions to a specific namespace and not globally
-			namespaces: [
-				"other-namespace"
-			]
-		}]
+  // These are permissions that will only be granted for this container in its namespace.
+  rules: [{
+   // Configure what actions you can do on the defined resources
+   verbs: [
+    "get", 
+    "list", 
+    "watch",
+    "create", 
+   ]
+   // Define what API group the resources belong to
+   apiGroups: [
+    "api.sample.io"
+   ]
+   // Configure which resources in the above apiGroups to apply the above verbs to
+   resources: [
+    "fooresource"
+   ]
+  }]
+  // These are permissions that will be granted for this container in all namespaces.
+  clusterRules: [{
+   verbs: [
+    "get", 
+    "list", 
+    "watch",
+   ]
+   apiGroups: [
+    "api.sample.io"
+   ]
+   resources: [
+    "fooresource"
+   ]
+   // Optionally restrict permissions to a specific namespace and not globally
+   namespaces: [
+    "other-namespace"
+   ]
+  }]
     }
 }
 ```
 
 ### memory
+
 `memory` allows you to specify how much memory the container should run with. It can be abbreviated to `mem`. If left unspecified, it will be defaulted to the installation default (see the [reference documentation for memory](06-compute-resources.md#memory) for more information).
 
 ```acorn
@@ -466,12 +507,13 @@ containers: {
 ```
 
 ### class
+
 `class` allows you to specify what compute class the container should run on. If left unspecified, it will be defaulted to the project-level default. If there is no project-level default it will use the cluster-level default. If there is no cluster-level default then no compute class will be used. See the [reference documentation](06-compute-resources.md#compute-classes) for more information.
 
 ```acorn
 containers: {
     nginx: {
-		class: "sample-compute-class"
+  class: "sample-compute-class"
         image: "nginx"
         ports: publish: "80/http"
         files: {
@@ -482,19 +524,208 @@ containers: {
 }
 ```
 
+## services (consuming)
+
+`services` are Acorns that will deploy cloud services outside the scope of Acorn and provide endpoints, credentials, and other information needed for other Acorns to consume the service. These services are typically managed by the cloud provider.  For example, a service could be a RDS database or a S3 bucket.
+
+```acorn
+services: rds: {
+ image: "ghcr.io/acorn-io/aws/rds-aurora-cluster"
+}
+
+containers: web: {
+ image: "nginx"
+ env: {
+ DB_SERVER: "@{service.rds.address}"
+ DB_USER: "@{service.rds.secrets.admin.username}"
+ DB_PASS: "@{service.rds.secrets.admin.password}"
+ } 
+}
+```
+
+### image
+
+`image` refers to the Acorn image to run to provision and provide the service.
+
+### secrets
+
+`secrets` here should be used to define links from the Acorn apps secrets into the service secrets. For example, if the credentials for a service provider need to be bound into the service Acorn for it to provision a new database.
+
+### autoUpgrade
+
+`autoUpgrade` will automatically upgrade the service Acorn when a new version of the service is available in the registry.
+
+### autoUpgradeInterval
+
+`autoUpgradeInterval` will configure how often to check for a new version of the service Acorn in the registry.
+
+### notifyUpgrade
+
+`notifyUpgrade` is a boolean value that will prompt the user to upgrade the service Acorn when a new version is available in the registry.
+
+### memory, mem
+
+`memory` allows you to define a memory resource limit for the pods running/provisioning the service.
+
+### environment, env
+
+`environment` allows you to define environment variables that will be available to the service Acorn.
+
+### serviceArgs
+
+`serviceArgs` allows you to define arguments that will be passed to the service Acorn.
+
+## services (generating)
+
+`services` when defined in an Acornfile will generate a service that can be consumed by other Acorns follow this schema.
+
+```acorn
+services: "my-service": {
+    generated: job: "create-service"
+}
+```
+
+### default
+
+`default` is a boolean value that can be used to specify if this service should be the default service when creating multiple services in the same Acornfile.
+
+### generated
+
+`generated` has a single key `job` that defines which job in the Acornfile will be ran to generate the service. The contents of `/run/secrets/output` will be parsed as an Acornfile and the service will be created from that.
+
+## services (generated)
+
+The generated service is the definition consumed by other Acorn applications.
+
+```acorn
+services: "my-service": {
+    address: "https://my-service-url"
+    secrets: ["service-credentials"]
+    data: {
+        "key1": "value1"
+        "key2": "value2"
+    }
+}
+// ...
+```
+
+### address
+
+`address` is a string that provides the address of the service. This is typically a URL or hostname. **address** and **container** are mutually exclusive.
+
+### Container
+
+`container` is a string that provides the name of the container that is providing the service. This will automatically set the address of the service. **container** and **address** are mutually exclusive.
+
+### ports
+
+`ports` can specifiy a single port or be defined as a list of ports the service endpoint is listening on.
+
+### secrets
+
+`secrets` is a list of secrets that are exposed as part of the service that can be consumed by other Acorns. These secrets can provide API keys or other credentials needed to access the service.
+
+### data
+
+`data` is an object where the service author can provide key/value data needed to consume the service like a database name or other configuration data.
+
+## acorns
+
+`acorns` reference Acorns that have been published to a registry or will be built from a self contained Acornfile outside of the current Acornfile.
+
+```acorn
+acorns: {
+    "my-acorn": {
+        image: "my-acorn"
+        publishMode: "defined"
+        secrets: ["redis-password:redis-password"]
+        autoUpgrade: true
+        profiles: "prod"
+    }
+}
+```
+
+### image
+
+`image` is the name of the Acorn image to run. **image** and **build** are mutually exclusive.
+
+### build
+
+`build` provides the information to build the Acorn image from source. **build** and **image** are mutually exclusive.
+
+```acorn
+acorns: {
+    "my-acorn": {
+        build: {
+            context: "./acorn-other"
+            acornfile: "./acorn-other/Acornfile"
+            args: {
+                "ARG1": "value1"
+            }
+        }
+        ...
+    }
+}
+```
+
+Where `context` is the directory to build the Acorn image from, `acornfile` is the path to the Acornfile to build from, and `args` is a map of arguments to pass during the build.
+
+### publish
+
+`publish` is a list of one or more ports to publish from the acorn image.
+
+### publishMode
+
+`publishMode` defines the behavior of the defined ports in the Acorn image. The values are `all`, `defined`, and `none`. `all` will publish all ports defined in the Acornfile. `defined` will only publish ports defined as `publish` in the Acornfile. `none` will not publish any ports. The default value is `none`.
+
+### volumes
+
+`volumes` are a list of volume bindings to mount into the Acorn image.
+
+### secrets
+
+`secrets` are a list of secrets to mount into the Acorn image.
+
+### links
+
+`links` are a list of links to other Acorns that will be available to the Acorn image.
+
+### autoUpgrade
+
+`autoUpgrade` is a boolean value that will automatically upgrade the Acorn image when a new version is available in the registry.
+
+### autoUpgradeInterval
+
+`autoUpgradeInterval` is a string that defines how often to check for a new version of the Acorn image in the registry.
+
+### notifyUpgrade
+
+`notifyUpgrade` is a boolean value that will prompt the user to upgrade the Acorn image when a new version is available in the registry.
+
+### deployArgs
+
+`deployArgs` is a map of arguments to pass to the Acorn image when it is deployed.
+
+### profiles
+
+`profiles` is a string that specifies which profile to use when deploying the Acorn image.
+
 ## jobs
+
 `jobs` are containers that are run once to completion. If the configuration of the job changes, the will
 be ran once again.  All fields that apply to [containers](#containers) also apply to
 jobs.
 
 ```acorn
 jobs: "setup-volume": {
-	image: "my-app"
-	command: "init-data.sh"
-	dirs: "/mnt/data": "data"
+ image: "my-app"
+ command: "init-data.sh"
+ dirs: "/mnt/data": "data"
 }
 ```
+
 ### schedule
+
 `schedule` field will configure your job to run on a cron schedule. The format is the standard cron format.
 
 ```
@@ -508,17 +739,19 @@ jobs: "setup-volume": {
  │ │ │ │ │
  * * * * *
 ```
+
 The following shorthand syntaxes are supported
 
-| Entry                   | 	Description	                                            | Equivalent to |
+| Entry                   |  Description                                             | Equivalent to |
 |-------------------------|------------------------------------------------------------|---------------|
-| @yearly (or @annually)  | Run once a year at midnight of 1 January	                | 0 0 1 1 *     |
-| @monthly	               | Run once a month at midnight of the first day of the month | 0 0 1 * *     |
-| @weekly	               | Run once a week at midnight on Sunday morning	            | 0 0 * * 0     |
-| @daily (or @midnight)   | Run once a day at midnight	                                | 0 0 * * *     |
-| @hourly	               | Run once an hour at the beginning of the hour	            | 0 * * * *     |
+| @yearly (or @annually)  | Run once a year at midnight of 1 January                 | 0 0 1 1 *     |
+| @monthly                | Run once a month at midnight of the first day of the month | 0 0 1 **     |
+| @weekly                | Run once a week at midnight on Sunday morning             | 0 0 ** 0     |
+| @daily (or @midnight)   | Run once a day at midnight                                 | 0 0 ** *     |
+| @hourly                | Run once an hour at the beginning of the hour             | 0 ****     |
 
 ## routers
+
 `routers` support path based HTTP routing so one can expose multiple containers through a
 single published service.  For example, if you have two containers named `auth` and `api`
 they would have to be exposed as two different HTTP services like `auth.example.com` and `api.example.com`.
@@ -583,56 +816,64 @@ is currently `containers`, `jobs`, `routers` and linked in services.
 port defined or else the traffic will be dropped.  If you are targeting another router, routers
 implicitly have the internal port `80`
 
-
 ## volumes
+
 `volumes` store persistent data that can be mounted by containers
+
 ```acorn
 containers: db: {
-	image: "mariadb"
-	dirs: "/var/lib/mysql": "data"
+ image: "mariadb"
+ dirs: "/var/lib/mysql": "data"
 }
 volumes: data: {
-	size: "100G"
-	accessModes: "readWriteOnce"
-	class: "default"
+ size: "100G"
+ accessModes: "readWriteOnce"
+ class: "default"
 }
 ```
+
 ### size
+
 `size` configures the default size of the volume to be created.  At deploy-time this value can be
 overwritten.
 
 ```acorn
 volumes: data: {
-	// All numbers are assumed to be gigabytes
-	size: 100
+ // All numbers are assumed to be gigabytes
+ size: 100
 
-	// The following suffixes are understood
+ // The following suffixes are understood
     // 2^x  - Ki | Mi | Gi | Ti | Pi | Ei
     // 10^x - m | k | M | G | T | P | E
-	size: "10G"
+ size: "10G"
 }
 ```
+
 ### class
-`class` refers to the `storageclass` within kubernetes. 
+
+`class` refers to the `storageclass` within kubernetes.
+
 ```acorn
 volumes: data: {
         // either "default" or a storageclass from `kubectl get sc`
-	class: "longhorn"
+ class: "longhorn"
 }
 ```
+
 ### accessModes
+
 `accessModes` configures how a volume can be shared among containers.
 
 ```acorn
 volumes: data: {
-	accessModes: [
-		// Only usable by containers on the same node
-		"readWriteOnce",
-		// Usable by containers across many nodes
-		"readWriteMany",
-		// Usable by containers across many nodes but read only
-		"readOnlyMany",
-	]
+ accessModes: [
+  // Only usable by containers on the same node
+  "readWriteOnce",
+  // Usable by containers across many nodes
+  "readWriteMany",
+  // Usable by containers across many nodes but read only
+  "readOnlyMany",
+ ]
 }
 ```
 
@@ -651,21 +892,24 @@ secrets: "my-secret": {
 ```
 
 ### type
+
 The common pattern in Acorn is for secrets to be generated if not supplied. `type`
 specifies how the secret can be generated. Refer to [the secrets documentation](38-authoring/05-secrets.md) for
 descriptions of the different secret types and how they are used.
 
 ```acorn
 secrets: "a-token": {
-	// Valid types are "opaque", "token", "basic", "generated", and "template"
-	type: "opaque"
+ // Valid types are "opaque", "token", "basic", "generated", and "template"
+ type: "opaque"
 }
 ```
 
 ### params
+
 `params` are used to configure the behavior of the secrets generation for different types.
 Refer to [the secrets documentation](38-authoring/05-secrets.md) for
 descriptions of the different secret types and how their parameters.
+
 ```acorn
 secrets: "my-token": {
     type: "token"
@@ -675,7 +919,9 @@ secrets: "my-token": {
     }
 }
 ```
+
 ### data
+
 `data` defines the keys and non-sensitive values that will be used by the secret.
 Refer to [the secrets documentation](38-authoring/05-secrets.md) for
 descriptions of the different secret types and how to use data keys and values.

--- a/docs/docs/100-reference/10-services.md
+++ b/docs/docs/100-reference/10-services.md
@@ -1,0 +1,110 @@
+---
+title: Services
+---
+
+Service Acorns offer a convenient way for developers to provision databases, caches, storage buckets, and other as-a-service offerings from cloud providers and Kubernetes operators from within the Acorn context. The provisioning process can be implemented using any tooling that can be called from a container.
+
+## Creating a service Acorn
+
+To create a Service Acorn, you will need to create an Acornfile that interacts with the required provider APIs for creating, updating, and deleting the desired service. It will then need to generate a new Acornfile providing the connection details of the created service.
+
+Follow these steps to create a Service Acorn:
+
+1. Declare that a service is going to be created in this Acornfile.
+
+    ```acorn
+    services: "my-service": {
+        generated: job: "create-service"
+    }
+    ```
+
+    The snippet above specifies that the complete service definition will be coming from a job called `create-service`. This is similar to how generated secrets are created.
+
+1. Declare any secrets as type generated that will be used by consumers of the service.
+
+    Typically credentials or API keys will be required to connect to the provisioned endpoints. If these are to be exposed to the consuming Acorn app, they need to be declared as generated secrets in the service Acornfile.
+
+    ```acorn
+    services: "my-service": {
+        generated: job: "create-service"
+    }
+    // ...
+    secrets: "my-service-secret": {
+        type: "generated"
+        params: job: "create-service"
+    }
+    ```
+
+    The above snippet adds a secret `my-service-secret` that must be produced by the `create-service` job.
+
+1. Last, create the job(s) that will be used to manage the lifecycle of the service. The job must produce a complete Acornfile that defines the complete service and any expected secrets. The output must be written to `/run/secrets/output` the same as a generated secret. The job can use any language or tooling to create the generated Acornfile. These examples use a shell script for simplicity and readability but could be generated in other languages.
+
+    ```acorn
+    services: "my-service": {
+      generated: job: "create-service"
+    }
+    jobs: "create-service": {
+        image: "ubuntu:latest"
+        entrypoint: "/app/create-service.sh"
+        files: "/app/create-service.sh": """
+          #!/bin/bash
+          cat <<EOF > /run/secrets/output
+          services: "my-service": {
+            secrets: ["my-service-secret"]
+          }
+          secrets: "my-service-secret": {
+              type: "basic"
+              data: {
+                username: "foo"
+                password: "bar"
+              }
+          }
+          EOF
+          """
+    }
+    secrets: "my-service-secret": {
+        type: "generated"
+        params: job: "create-service"
+    }
+    ```
+
+    The example above shows a job that creates a service that exposes a secret containing basic auth credentials. Here it is static, but it could be generated dynamically by the job reaching out to a service like AWS secret manager or Vault.
+
+   The Acornfile here is using an inline script for illustration, the best practice is to use a separate file and copy it into the container like the following example.
+
+    ```acorn
+    services: "my-service": {
+        generated: job: "create-service"
+    }
+    jobs: "create-service": {
+        image: "ubuntu:latest"
+        entrypoint: "/app/create-service.sh"
+        dirs: "/app/create-service.sh": "./create-service.sh"
+        events: ["create", "update", "delete"]
+    }
+    secrets: "my-service-secret": {
+        type: "generated"
+        params: job: "create-service"
+    }
+    ```
+
+    In this case the `create-service.sh` file will be copied into the container at `/app/create-service.sh`, it is easier to maintain scripts this way. Using this method, you will need to ensure the script is executable.
+
+## Lifecycle
+
+To automate the lifecycle of the service, there are lifecycle events that can be used to trigger the correct behavior. The events are:
+
+- `create` - Runs on the initial deployment of the Acorn.
+- `update` - This will be called when the Acorn app is updated or restarted.
+- `stop`   - This event will be called when the Acorn app is stopped by the command `acorn stop [APP_NAME]`.
+- `delete` - This will be called when the Service Acorn is being deleted.
+
+If no events are specified the default behavior is run on create and update.
+
+If no job is watching for the delete event, the resources created outside of Acorn will be orphaned when the Service Acorn is deleted.
+
+## Troubleshooting
+
+### Generated secret contains the generated Acornfile instead of secret values
+
+In this case, it means that there is an issue with the formatting of the generated output. Common issues are missing double quotes around names with hyphens. A quick way to determine what might be wrong is to copy the contents to a scratch `Acornfile` and run `acorn render .` to see if there are formatting issues.

--- a/docs/docs/38-authoring/05-secrets.md
+++ b/docs/docs/38-authoring/05-secrets.md
@@ -242,3 +242,50 @@ secrets: {
     }
 }
 ```
+
+## External secrets
+
+External secrets are defined in the Acornfile to specify a specific secret must be present in the cluster before the Acorn can be deployed. The definition must include the field `external` with the value of the expected name of the secret in the cluster.
+
+```acorn
+containers: app: {
+    image: ubuntu
+    entrypoint: ["sleep"]
+    command: ["3600"]
+    env: {
+        USER: "secret://foo/user"
+        PASS: "secret://foo/pass"
+    }
+}
+
+secrets: foo:{
+    external: "basic-creds"
+}
+```
+
+The above example requires a secret named `basic-creds` to be present in the cluster before the Acorn can be deployed.
+
+For readability and documentation purposes, the best practice to define the type and data fields that the external secret is expected to have. This is optional and the values will be ignored by Acorn.
+
+```acorn
+containers: app: {
+    image: ubuntu
+    entrypoint: ["sleep"]
+    command: ["3600"]
+    env: {
+        USER: "secret://foo/user"
+        PASS: "secret://foo/pass"
+    }
+}
+
+secrets: foo: {
+    external: "basic-creds"
+    type: "opaque"
+    data: {
+        user: "username"
+        pass: "password"
+    }
+}
+```
+
+Looking at the above example a user knows they must create a secret named `basic-creds` with keys/values for `user` and `pass` before the Acorn can be deployed.

--- a/docs/docs/38-authoring/06-jobs.md
+++ b/docs/docs/38-authoring/06-jobs.md
@@ -4,22 +4,7 @@ title: Jobs
 
 Jobs are containers that perform one-off or scheduled tasks to support the application. Jobs are defined in their own top-level `jobs` section of the Acornfile. A job container will continue to run until it has successfully completed all operations once.
 
-A Job has all the same fields as a container, with the exception of an optional `schedule` field.
-
-## On update jobs
-
-By default, jobs will run whenever the Acorn has been updated.
-
-```acorn
-jobs: {
-    "cluster-reconcile": {
-        image: "registry.io/myorg/cluster-reconcile"
-        env: {
-            "CLUSTER_PASS": "secret://cluster-auth-token/token"
-        }
-    }
-}
-```
+A Job has all the same fields as a container, with the exception of an optional `schedule` and `events` field.
 
 ## Scheduled jobs
 
@@ -40,3 +25,49 @@ jobs: {
 ```
 
 The `schedule` key makes this a cron based job. The `schedule` field must be a valid crontab format entry. Meaning it can use standard `* * * * *` format or @[interval] crontab shorthand.
+
+## Events
+
+Acorn supports four events that can trigger a job to run: `create`, `update`, `stop`, and `delete`. By default jobs will run on create and update. To change this behavior, use the `events` field.
+
+The `create` event will run the job when the app is created, or when the job is first added to the Acornfile.
+
+The `update` event will run the job when the app is updated or started from stop.
+
+The `stop` event will run the job when the app is stopped.
+
+The `delete` event will run the job when the app is deleted. The job will run, and must complete successfully, before the remaining containers are deleted in that Acorn app.
+
+```acorn
+jobs: {
+    "cluster-reconcile": {
+        image: "registry.io/myorg/cluster-manager"
+        env: {
+            "CLUSTER_PASS": "secret://cluster-auth-token/token"
+        }
+        events: ["create", "update", "stop", "delete"]
+        entrypoint: ["/lc.sh"]
+        files: {
+            "/lc.sh": """
+              #!/bin/sh
+              if if [ "${ACORN_EVENT}" = "create" ]; then
+                echo "Create event"
+                exit 0
+              elif [ "${ACORN_EVENT}" = "update" ]; then
+                echo "Update event"
+                exit 0
+              elif [ "${ACORN_EVENT}" = "stop" ]; then
+                echo "Stop event"
+                exit 0
+              elif [ "${ACORN_EVENT}" = "delete" ]; then
+                echo "Delete event"
+                exit 0
+              else
+                echo "Unknown event"
+                exit 1
+              fi
+            """
+        }
+    }
+}
+```

--- a/docs/docs/38-authoring/21-services.md
+++ b/docs/docs/38-authoring/21-services.md
@@ -1,0 +1,33 @@
+---
+title: Services
+---
+
+## Consuming services
+
+When you are authoring the Acornfile for your application you can define cloud services that will be provisioned for your application. The services will be deployed alongside your application at deploy/run time. To learn how to create your own service Acorns see [services](/100-reference/10-services.md) in the reference section.
+
+### Wiring services into your Acorn app
+
+Service attritibutes are accessed through the `@{}` syntax in the Acornfile. Here is a simple example of accessing the `address` attribute of a service named `db`. For complete service syntax see the [services](/100-reference/03-acornfile.md#services-consuming) section in the Acornfile reference.
+
+```acorn
+
+```acorn
+// This service exposes an address and a secret
+services: db: {
+    image: "ghcr.io/acorn-io/aws/rds-aurora-cluster:latest"
+}
+
+containers: app: {
+    image: "my-app:latest"
+    env: {
+        MY_SERVICE_ADDRESS: "@{service.db.address}"
+        MY_SERVICE_PORT: "@{service.db.ports.3306}"
+        DB_USER: "@{service.db.secrets.admin.username}"
+        DB_PASS: "@{service.db.secrets.admin.password}"
+        DB_NAME: "@{service.db.data.dbName}"
+    }
+}
+```
+
+In the above example the service db parameters are accessed using the `@{service.db}` syntax. Ports are referenced by the expected value, in this case `3306` for MySQL. However, the actual port number may not be `3306` as it can be dynamically assigned during the service creation.

--- a/docs/docs/38-authoring/31-nested-acorns.md
+++ b/docs/docs/38-authoring/31-nested-acorns.md
@@ -1,0 +1,62 @@
+---
+title: Nested Acorns
+---
+
+Nested acorns allow you to describe a collection of microservices that make up a complete deployment of an Application. This is useful when describing entire deployments along with profiles for their arguments. Combined with the auto-upgrade functionality, it allows you to create a delivery pipeline in a single file that can be checked into VCS. Additionally, Acorns can also be used within an Acorn app to provide functionality to the app. The use of Acorns can be thought of as using a module or library in a programming language.
+
+## Using nested Acorn
+
+Acorns are defined under the `acorns` toplevel key in the Acornfile.
+
+```acorn
+//...
+acorns: {
+    "my-acorn": {
+        image: "ghcr.io/acorn-io/library/hello-world:latest"
+    }
+}
+//...
+```
+
+## Desribe a deployment pipeline with Acorns and services
+
+To describe an entire deployment with Acorns you declare each Acorn and define a profile for the deployment type. You can also use `services` to provide infrastructure components to the app deployment.
+
+```acorn
+args: {
+    uri: ""
+    tag: ""
+}
+
+profiles: {
+    dev: {
+        uri: "index.io/my-app/dev/secret-name"
+        tag: "latest"
+    }
+    prod: {
+        uri: "index.io/my-app/prod/secret-name"
+        tag: "1.2.#"
+    }
+}
+
+acorns: {
+    "my-app": {
+        image: "example.com/repo/org/hello-world:\(args.tag)"
+        secrets: ["secrets-getter.this:redis-creds"]
+        autoUpgrade: true
+    }
+
+}
+
+services: {
+    // A service that returns a secret from an external source under the name `this`
+    "secret-getter": {
+        image: "example.com/repo/org/secret-getter:latest"
+        serviceArgs: {
+            secretURI: args.uri
+        }
+    }
+}
+```
+
+Now when this Acornfile is initially deployed with the `--profile` flag Acorn will deploy the app with the appropriate default values. In this case `dev` will always update whenever the latest tag moves. Production will always update on new patch releases.

--- a/docs/docs/50-running/66-remove-acorns.md
+++ b/docs/docs/50-running/66-remove-acorns.md
@@ -1,0 +1,19 @@
+---
+title: Removing Acorns
+---
+
+When you want to remove an Acorn and its components, you can use the `acorn rm` command.
+
+## Default behavior
+
+To remove an Acorn app run `acorn rm [APP]`. This will remove the app and all of the containers associated with it. If the app has any services, secrets, or volumes they will remain until they are removed manually.  This behavior is to protect against accidental deletion of data.
+
+## Removing services and nested Acorns
+
+To remove services and nested Acorns when removing the Acorn app use the `--all` and optionally `--force` flags. The `--all` flag will remove all services and nested Acorns. The `--force` flag will remove the services and nested Acorns without prompting for confirmation. This will also remove all of the secrets and volumes for the app and the child services and nested Acorns.
+
+Otherwise, you can remove the services and nested Acorns manually with the `acorn rm` command after the app has been removed.
+
+```bash
+acorn rm [APP].[SERVICE]
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -14,147 +14,151 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   "sidebar": [
-  "home",
-  {
-    "type": "category",
-    "label": "Installation",
-    "items": [
-      "installation/installing",
-      "installation/options",
-      "installation/upgrading",
-      "installation/uninstalling"
-    ],
-    "collapsed": true
-  },
-  "getting-started",
-  {
-    "type": "category",
-    "label": "Authoring Acornfiles",
-    "items": [
-      "authoring/overview",
-      "authoring/best-practices",
-      "authoring/structure",
-      "authoring/containers",
-      "authoring/volumes",
-      "authoring/secrets",
-      "authoring/jobs",
-      "authoring/args-and-profiles",
-      "authoring/localdata",
-      "authoring/permissions",
-      "authoring/labels",
-      "authoring/advanced"
-    ]
-  },
-  "publishing",
-  {
-    "type": "category",
-    "label": "Running Acorn Apps",
-    "items": [
-      "running/args-and-secrets",
-      "running/networking",
-      "running/certificates",
-      "running/volumes",
-      "running/linking-acorns",
-      "running/labels",
-      "running/troubleshooting",
-      "running/upgrades",
-      "running/auto-upgrades",
-      "running/namespaces-and-service-accounts",
-      "running/compute-resources",
-      "running/projects",
-      "running/update-acorns",
-      "running/dev",
-        
-    ],
-    "collapsed": true
-  },
-  {
-    "type": "category",
-    "label": "Integrations",
-    "items": [
-      "integrations/github-actions"
-    ],
-    "collapsed": true
-  },
-  {
-    "type": "category",
-    "label": "Architecture",
-    "items": [
-      "architecture/ten-thousand-foot-view",
-      "architecture/security-considerations"
-    ],
-    "collapsed": true
-  },
-  {
-    "type": "category",
-    "label": "Reference",
-    "items": [
-      {
-        "type": "category",
-        "label": "Command Line",
-        "items": [
-          "reference/command-line/acorn",
-          "reference/command-line/acorn_all",
-          "reference/command-line/acorn_app",
-          "reference/command-line/acorn_build",
-          "reference/command-line/acorn_check",
-          "reference/command-line/acorn_container",
-          "reference/command-line/acorn_container_kill",
-          "reference/command-line/acorn_credential",
-          "reference/command-line/acorn_credential_login",
-          "reference/command-line/acorn_credential_logout",
-          "reference/command-line/acorn_exec",
-          "reference/command-line/acorn_image",
-          "reference/command-line/acorn_image_rm",
-          "reference/command-line/acorn_info",
-          "reference/command-line/acorn_install",
-          "reference/command-line/acorn_login",
-          "reference/command-line/acorn_logout",
-          "reference/command-line/acorn_logs",
-          "reference/command-line/acorn_project",
-          "reference/command-line/acorn_project_create",
-          "reference/command-line/acorn_project_rm",
-          "reference/command-line/acorn_project_use",
-          "reference/command-line/acorn_pull",
-          "reference/command-line/acorn_push",
-          "reference/command-line/acorn_offerings",
-          "reference/command-line/acorn_offerings_computeclasses",
-          "reference/command-line/acorn_offerings_volumeclasses",
-          "reference/command-line/acorn_render",
-          "reference/command-line/acorn_rm",
-          "reference/command-line/acorn_run",
-          "reference/command-line/acorn_secret",
-          "reference/command-line/acorn_secret_create",
-          "reference/command-line/acorn_secret_encrypt",
-          "reference/command-line/acorn_secret_reveal",
-          "reference/command-line/acorn_secret_rm",
-          "reference/command-line/acorn_start",
-          "reference/command-line/acorn_stop",
-          "reference/command-line/acorn_tag",
-          "reference/command-line/acorn_uninstall",
-          "reference/command-line/acorn_update",
-          "reference/command-line/acorn_volume",
-          "reference/command-line/acorn_volume_rm",
-          "reference/command-line/acorn_wait"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "Administration",
-        "items": [
+    "home",
+    {
+      "type": "category",
+      "label": "Installation",
+      "items": [
+        "installation/installing",
+        "installation/options",
+        "installation/upgrading",
+        "installation/uninstalling"
+      ],
+      "collapsed": true
+    },
+    "getting-started",
+    {
+      "type": "category",
+      "label": "Authoring Acornfiles",
+      "items": [
+        "authoring/overview",
+        "authoring/best-practices",
+        "authoring/structure",
+        "authoring/containers",
+        "authoring/volumes",
+        "authoring/secrets",
+        "authoring/jobs",
+        "authoring/args-and-profiles",
+        "authoring/localdata",
+        "authoring/permissions",
+        "authoring/labels",
+        "authoring/services",
+        "authoring/advanced",
+        "authoring/nested-acorns"
+      ]
+    },
+    "publishing",
+    {
+      "type": "category",
+      "label": "Running Acorn Apps",
+      "items": [
+        "running/args-and-secrets",
+        "running/networking",
+        "running/certificates",
+        "running/volumes",
+        "running/linking-acorns",
+        "running/labels",
+        "running/troubleshooting",
+        "running/upgrades",
+        "running/auto-upgrades",
+        "running/namespaces-and-service-accounts",
+        "running/compute-resources",
+        "running/projects",
+        "running/update-acorns",
+        "running/remove-acorns",
+        "running/dev",
+
+      ],
+      "collapsed": true
+    },
+    {
+      "type": "category",
+      "label": "Integrations",
+      "items": [
+        "integrations/github-actions"
+      ],
+      "collapsed": true
+    },
+    {
+      "type": "category",
+      "label": "Architecture",
+      "items": [
+        "architecture/ten-thousand-foot-view",
+        "architecture/security-considerations"
+      ],
+      "collapsed": true
+    },
+    {
+      "type": "category",
+      "label": "Reference",
+      "items": [
+        {
+          "type": "category",
+          "label": "Command Line",
+          "items": [
+            "reference/command-line/acorn",
+            "reference/command-line/acorn_all",
+            "reference/command-line/acorn_app",
+            "reference/command-line/acorn_build",
+            "reference/command-line/acorn_check",
+            "reference/command-line/acorn_container",
+            "reference/command-line/acorn_container_kill",
+            "reference/command-line/acorn_credential",
+            "reference/command-line/acorn_credential_login",
+            "reference/command-line/acorn_credential_logout",
+            "reference/command-line/acorn_exec",
+            "reference/command-line/acorn_image",
+            "reference/command-line/acorn_image_rm",
+            "reference/command-line/acorn_info",
+            "reference/command-line/acorn_install",
+            "reference/command-line/acorn_login",
+            "reference/command-line/acorn_logout",
+            "reference/command-line/acorn_logs",
+            "reference/command-line/acorn_project",
+            "reference/command-line/acorn_project_create",
+            "reference/command-line/acorn_project_rm",
+            "reference/command-line/acorn_project_use",
+            "reference/command-line/acorn_pull",
+            "reference/command-line/acorn_push",
+            "reference/command-line/acorn_offerings",
+            "reference/command-line/acorn_offerings_computeclasses",
+            "reference/command-line/acorn_offerings_volumeclasses",
+            "reference/command-line/acorn_render",
+            "reference/command-line/acorn_rm",
+            "reference/command-line/acorn_run",
+            "reference/command-line/acorn_secret",
+            "reference/command-line/acorn_secret_create",
+            "reference/command-line/acorn_secret_encrypt",
+            "reference/command-line/acorn_secret_reveal",
+            "reference/command-line/acorn_secret_rm",
+            "reference/command-line/acorn_start",
+            "reference/command-line/acorn_stop",
+            "reference/command-line/acorn_tag",
+            "reference/command-line/acorn_uninstall",
+            "reference/command-line/acorn_update",
+            "reference/command-line/acorn_volume",
+            "reference/command-line/acorn_volume_rm",
+            "reference/command-line/acorn_wait"
+          ]
+        },
+        {
+          "type": "category",
+          "label": "Administration",
+          "items": [
             "reference/admin/volumeclasses",
             "reference/admin/computeclasses"
-        ]
-      },
-      "reference/acornfile",
-      "reference/functions",
-      "reference/compute-resources",
-      "reference/encryption"
-    ],
-    "collapsed": true
-  },
-  "faq"
-]
+          ]
+        },
+        "reference/acornfile",
+        "reference/functions",
+        "reference/compute-resources",
+        "reference/encryption",
+        "reference/services"
+      ],
+      "collapsed": true
+    },
+    "faq"
+  ]
 
 };
 


### PR DESCRIPTION
Adds sections to Acornfile reference.
- Is this how we want it displayed? There are three separate schemas for services depending on context, I don't have another example of this.

Adds new page for creating services to the reference section. 

Adds new page to authoring section on how to use services that are pre-existing. 

Adds section on nested Acorns.

Describes job events.

