### PR TITLE
Disallow removing a supported region if a volume exists in that region

### DIFF
--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -290,6 +290,10 @@ func (in *Volume) HasRegion(region string) bool {
 	return in.Spec.Region == region
 }
 
+func (in *Volume) GetRegion() string {
+	return in.Spec.Region
+}
+
 // +k8s:conversion-gen:explicit-from=net/url.Values
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/server/registry/apigroups/acorn/projects/validator_test.go
+++ b/pkg/server/registry/apigroups/acorn/projects/validator_test.go
@@ -98,6 +98,9 @@ func TestProjectUpdateValidation(t *testing.T) {
 			name:      "Update project to have default region, no supported regions",
 			wantError: true,
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion: "my-region",
 				},
@@ -106,11 +109,17 @@ func TestProjectUpdateValidation(t *testing.T) {
 		{
 			name: "Update project to have default region and supported region",
 			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Status: apiv1.ProjectStatus{
 					DefaultRegion: "my-region",
 				},
 			},
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region"},
@@ -120,11 +129,17 @@ func TestProjectUpdateValidation(t *testing.T) {
 		{
 			name: "Update project to have default region and non-existent supported regions",
 			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Status: apiv1.ProjectStatus{
 					DefaultRegion: "my-region",
 				},
 			},
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region", "dne-region"},
@@ -135,6 +150,9 @@ func TestProjectUpdateValidation(t *testing.T) {
 			name:      "Remove default region as supported region",
 			wantError: true,
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-other-region"},
@@ -144,12 +162,18 @@ func TestProjectUpdateValidation(t *testing.T) {
 		{
 			name: "Update project remove a supported region, no apps",
 			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region", "my-other-region"},
 				},
 			},
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region"},
@@ -160,12 +184,18 @@ func TestProjectUpdateValidation(t *testing.T) {
 		{
 			name: "Update project remove a supported region, no apps in project",
 			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region", "my-other-region"},
 				},
 			},
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region"},
@@ -190,12 +220,18 @@ func TestProjectUpdateValidation(t *testing.T) {
 		{
 			name: "Update project remove a supported region, no apps in removed region",
 			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region", "my-other-region"},
 				},
 			},
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region"},
@@ -206,7 +242,8 @@ func TestProjectUpdateValidation(t *testing.T) {
 					Items: []apiv1.App{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "my-app",
+								Name:      "my-app",
+								Namespace: "my-project",
 							},
 							Spec: v1.AppInstanceSpec{
 								Region: "my-region",
@@ -220,12 +257,18 @@ func TestProjectUpdateValidation(t *testing.T) {
 			name:      "Update project remove a supported region with apps in removed region",
 			wantError: true,
 			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region", "my-other-region"},
 				},
 			},
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region"},
@@ -236,9 +279,47 @@ func TestProjectUpdateValidation(t *testing.T) {
 					Items: []apiv1.App{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "my-app",
+								Name:      "my-app",
+								Namespace: "my-project",
 							},
 							Spec: v1.AppInstanceSpec{
+								Region: "my-other-region",
+							},
+						},
+					},
+				},
+			).Build(),
+		},
+		{
+			name:      "Update project remove a supported region with volumes in removed region",
+			wantError: true,
+			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region", "my-other-region"},
+				},
+			},
+			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
+				Spec: apiv1.ProjectSpec{
+					DefaultRegion:    "my-region",
+					SupportedRegions: []string{"my-region"},
+				},
+			},
+			client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithLists(
+				&apiv1.VolumeList{
+					Items: []apiv1.Volume{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "my-volume",
+								Namespace: "my-project",
+							},
+							Spec: apiv1.VolumeSpec{
 								Region: "my-other-region",
 							},
 						},
@@ -250,12 +331,18 @@ func TestProjectUpdateValidation(t *testing.T) {
 			name:      "Update project remove a supported region with apps defaulted to removed region",
 			wantError: true,
 			oldProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region", "my-other-region"},
 				},
 			},
 			newProject: apiv1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-project",
+				},
 				Spec: apiv1.ProjectSpec{
 					DefaultRegion:    "my-region",
 					SupportedRegions: []string{"my-region"},
@@ -266,7 +353,8 @@ func TestProjectUpdateValidation(t *testing.T) {
 					Items: []apiv1.App{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "my-app",
+								Name:      "my-app",
+								Namespace: "my-project",
 							},
 							Status: v1.AppInstanceStatus{
 								Defaults: v1.Defaults{


### PR DESCRIPTION
A previous changed disallowed a user from removing a supported region from a project when there were apps in that region. This change does the same for volumes.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

