### PR TITLE
Don't run validate-docs workflow all the time

### DIFF
--- a/.github/workflows/validate-docs.yaml
+++ b/.github/workflows/validate-docs.yaml
@@ -1,6 +1,10 @@
 name: Validate docs build
 on:
-  push: {}
+  push:
+    paths:
+    - docs/**
+    branches:
+    - main
   pull_request:
     paths:
       - docs/**


### PR DESCRIPTION
Noticed this while monitoring another workflow.

For pull-requests, we limit this worklflow to only when a docs change is
actually made. We should do the same for when a PR is merged.

Signed-off-by: Craig Jellick <craig@acorn.io>