### PR TITLE
chore: update defaults to use oss-dns.acrn.io and .oss-acorn.io domains

### DIFF
--- a/.github/workflows/main-mac-smoke-test.yaml
+++ b/.github/workflows/main-mac-smoke-test.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-    - main
+      - main
 
 jobs:
   release:
@@ -62,13 +62,12 @@ jobs:
           AC_P12: ${{ secrets.AC_P12 }}
           AC_P12_PASSWORD: ${{ secrets.AC_P12_PASSWORD }}
           KEYCHAIN: ${{ steps.keychain.outputs['keychain-name'] }}
-          ACORN_DNS_ENDPOINT: https://alpha-dns.acrn.io/v1
       - name: report failure to slack
         if: failure()
         id: slack-failure
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: '${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}'
+          channel-id: "${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}"
           slack-message: "❌ Main-Mac-Release failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-    - main
+      - main
 
 permissions:
   contents: write
@@ -56,7 +56,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          ACORN_DNS_ENDPOINT: https://staging-dns.acrn.io/v1
       - name: Push Docker Images
         run: |
           VERSION=v$(cat releases/metadata.json | jq -r .version)
@@ -83,8 +82,7 @@ jobs:
         id: slack-failure
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: '${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}'
+          channel-id: "${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}"
           slack-message: "❌ Main-Release failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,14 +61,13 @@ jobs:
           AC_P12: ${{ secrets.AC_P12 }}
           AC_P12_PASSWORD: ${{ secrets.AC_P12_PASSWORD }}
           KEYCHAIN: ${{ steps.keychain.outputs['keychain-name'] }}
-          ACORN_DNS_ENDPOINT: https://alpha-dns.acrn.io/v1
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
       - name: report failure to slack
         if: failure()
         id: slack-failure
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: '${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}'
+          channel-id: "${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}"
           slack-message: "❌ Release failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -76,7 +75,7 @@ jobs:
         id: slack-success
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: '${{ secrets.USERS_SLACK_BOT_RELEASE_CHANNEL }}'
+          channel-id: "${{ secrets.USERS_SLACK_BOT_RELEASE_CHANNEL }}"
           slack-message: " ✅ Release ${{ github.ref_name }} is now available: ${{ github.server_url }}/${{ github.repository }}/releases/${{ github.ref_name }}"
         env:
-          SLACK_BOT_TOKEN: '${{ secrets.USERS_SLACK_BOT_TOKEN }}'
+          SLACK_BOT_TOKEN: "${{ secrets.USERS_SLACK_BOT_TOKEN }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,6 @@ builds:
       - -s
       - -w
       - -X "github.com/acorn-io/acorn/pkg/version.Tag=v{{ .Version }}"
-      - -X "github.com/acorn-io/acorn/pkg/config.AcornDNSEndpointDefault={{ .Env.ACORN_DNS_ENDPOINT }}"
 
 universal_binaries:
   - id: mac
@@ -48,7 +47,7 @@ archives:
     builds:
       - default
       - mac
-    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ if eq .Os \"darwin\" }}macOS-universal{{ else }}{{ .Os }}-{{ .Arch }}{{ .Arm }}{{ end }}"
+    name_template: '{{ .ProjectName }}-v{{ .Version }}-{{ if eq .Os "darwin" }}macOS-universal{{ else }}{{ .Os }}-{{ .Arch }}{{ .Arm }}{{ end }}'
     format_overrides:
       - goos: windows
         format: zip
@@ -62,7 +61,8 @@ signs:
   - id: cosign
     cmd: cosign
     stdin: "{{ .Env.COSIGN_PASSWORD }}"
-    args: ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
+    args:
+      ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
     artifacts: checksum
 
 changelog:

--- a/docs/docs/10-home.md
+++ b/docs/docs/10-home.md
@@ -122,7 +122,7 @@ To check the status of our app we can run the following.
 ```shell
 acorn apps green-bush
 #NAME         IMAGE                                                              HEALTHY   UPTODATE   CREATED              ENDPOINTS                                                              MESSAGE
-#green-bush   60d803258f7aa2680e4910c526485488949835728a2bc3519c09f1b6b3be1bb3   1         1          About a minute ago   http://web-nginx-green-bush-6cc6aeba547e.local.on-acorn.io => web:80   OK
+#green-bush   60d803258f7aa2680e4910c526485488949835728a2bc3519c09f1b6b3be1bb3   1         1          About a minute ago   http://web-nginx-green-bush-6cc6aeba547e.local.oss-acorn.io => web:80   OK
 ```
 
 In Chrome or Firefox browsers you can now open the URL listed under the endpoints column to see our app.

--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -28,7 +28,7 @@ acorn install
       --auto-upgrade-interval string                    For apps configured with automatic upgrades enabled, the interval at which to check for new versions. Upgrade intervals configured at the application level cannot be smaller than this. (default '5m' - 5 minutes)
       --aws-identity-provider-arn string                ARN of cluster's OpenID Connect provider registered in AWS
       --builder-per-project                             Create a dedicated builder per project
-      --cluster-domain strings                          The externally addressable cluster domain (default .on-acorn.io)
+      --cluster-domain strings                          The externally addressable cluster domain (default .oss-acorn.io)
       --controller-replicas int                         acorn-controller deployment replica count
       --controller-service-account-annotation strings   annotation to apply to the acorn-system service account
   -h, --help                                            help for install

--- a/docs/docs/30-installation/01-installing.md
+++ b/docs/docs/30-installation/01-installing.md
@@ -183,7 +183,7 @@ k3d cluster create --api-port 6550 -p "8081:80@loadbalancer"
 then you must reflect that in the `acorn install` command by specifying the port with the `--cluster-domain` flag:
 
 ```shell
-acorn install --cluster-domain '.local.on-acorn.io:8081'
+acorn install --cluster-domain '.local.oss-acorn.io:8081'
 ```
 
 **Kind** comes with a working storage class by default, but you need to take some extra steps to get ingress and service loadbalancer capabilities:

--- a/docs/docs/30-installation/02-options.md
+++ b/docs/docs/30-installation/02-options.md
@@ -13,7 +13,7 @@ $ acorn run -P ghcr.io/acorn-io/library/hello-world
 
 $ acorn ps
 NAME       IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS                                                                     MESSAGE
-black-sea   ghcr.io/acorn-io/library/hello-world   1         1            6s ago    http://webapp-black-sea-4232beae.qnrzq5.alpha.on-acorn.io => webapp:80      OK
+black-sea   ghcr.io/acorn-io/library/hello-world   1         1            6s ago    http://webapp-black-sea-4232beae.qnrzq5.alpha.oss-acorn.io => webapp:80      OK
 ```
 By default, endpoints are `http`. To have acorn automatically generate a [Let's Encrypt](https://letsencrypt.org/) certificate and secure your endpoints, you can enable acorn's Let's Encrypt integration like this:
 ```bash
@@ -25,7 +25,7 @@ acorn install --lets-encrypt enabled --lets-encrypt-tos-agree=true --lets-encryp
 ```
 
 :::info
-Let's Encrypt integration is only useful if you are running a non-local Kubernetes cluster. If you are running acorn on a local cluster such as Docker Desktop, Rancher Desktop, or minikube, enabling Let's Encrypt will have no effect. We don't issue certificates for the `.local.on-acorn.io` domains that are used in this scenario.
+Let's Encrypt integration is only useful if you are running a non-local Kubernetes cluster. If you are running acorn on a local cluster such as Docker Desktop, Rancher Desktop, or minikube, enabling Let's Encrypt will have no effect. We don't issue certificates for the `.local.oss-acorn.io` domains that are used in this scenario.
 :::
 
 ## Endpoint domain names

--- a/docs/docs/30-installation/02-options.md
+++ b/docs/docs/30-installation/02-options.md
@@ -13,7 +13,7 @@ $ acorn run -P ghcr.io/acorn-io/library/hello-world
 
 $ acorn ps
 NAME       IMAGE          HEALTHY   UP-TO-DATE   CREATED   ENDPOINTS                                                                     MESSAGE
-black-sea   ghcr.io/acorn-io/library/hello-world   1         1            6s ago    http://webapp-black-sea-4232beae.qnrzq5.alpha.oss-acorn.io => webapp:80      OK
+black-sea   ghcr.io/acorn-io/library/hello-world   1         1            6s ago    http://webapp-black-sea-4232beae.qnrzq5.oss-acorn.io => webapp:80      OK
 ```
 By default, endpoints are `http`. To have acorn automatically generate a [Let's Encrypt](https://letsencrypt.org/) certificate and secure your endpoints, you can enable acorn's Let's Encrypt integration like this:
 ```bash

--- a/docs/docs/37-getting-started.md
+++ b/docs/docs/37-getting-started.md
@@ -266,7 +266,7 @@ acorn apps
 ```bash
 $ acorn apps
 NAME            IMAGE          HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS                                                             MESSAGE
-awesome-acorn   2d73c8a0493f   3         3            121m ago   http://app-awesome-acorn-56d50c8c0915.local.on-acorn.io => app:5000   OK
+awesome-acorn   2d73c8a0493f   3         3            121m ago   http://app-awesome-acorn-56d50c8c0915.local.oss-acorn.io => app:5000   OK
 ```
 
 You probably already noticed the link right there in the `ENDPOINTS` column. It will take you to your Python Flask App.

--- a/docs/docs/50-running/02-networking.md
+++ b/docs/docs/50-running/02-networking.md
@@ -24,33 +24,33 @@ To launch the Acorn app with all ports internal, you can launch with the `-P=fal
 
 Publishing ports makes the services available outside of the cluster. HTTP ports will be exposed via the layer 7 ingress and TCP/UDP ports will be exposed via service load balancers. When specifying a port to publish without its protocol, the protocol defined for it in the Acornfile will be used. If no protocol is defined in the Acornfile, the default will be tcp.
 
-| Flag value | Description |
-| ---------- | ----------- |
-| `-p 80` | Publish port 80 in the Acorn to port 80 with its protocol. |
-| `-p 80/http` | Publish port 80/http in the Acorn to a random hostname. |
-| `-p 81:80` | Publish port 80 in the Acorn to 81 on cluster with the port's protocol.|
-| `-p 81:80/tcp` | Publish 80/tcp in the Acorn to 81 as a cluster service. |
-| `-p 81:80/http` | Publish 80/http in the Acorn to 81 with a random hostname. |
-| `-p app:80` | Publish container `app` port 80 in the Acorn to 80 on cluster with its protocol. |
-| `-p app:80/tcp` | Publish container `app` port 80/tcp in the Acorn to 80 as a cluster service. |
-| `-p app:80/http` | Publish container `app` port 80/http in the Acorn to 80 with a random hostname. |
-| `-p app.example.com:app` | Publish container `app` protocol HTTP from the Acorn to external name `app.example.com`. |
-| `-p app.example.com:app:80` | Publish container `app` port 80 from the Acorn to external name `app.example.com`. |
+| Flag value                  | Description                                                                              |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `-p 80`                     | Publish port 80 in the Acorn to port 80 with its protocol.                               |
+| `-p 80/http`                | Publish port 80/http in the Acorn to a random hostname.                                  |
+| `-p 81:80`                  | Publish port 80 in the Acorn to 81 on cluster with the port's protocol.                  |
+| `-p 81:80/tcp`              | Publish 80/tcp in the Acorn to 81 as a cluster service.                                  |
+| `-p 81:80/http`             | Publish 80/http in the Acorn to 81 with a random hostname.                               |
+| `-p app:80`                 | Publish container `app` port 80 in the Acorn to 80 on cluster with its protocol.         |
+| `-p app:80/tcp`             | Publish container `app` port 80/tcp in the Acorn to 80 as a cluster service.             |
+| `-p app:80/http`            | Publish container `app` port 80/http in the Acorn to 80 with a random hostname.          |
+| `-p app.example.com:app`    | Publish container `app` protocol HTTP from the Acorn to external name `app.example.com`. |
+| `-p app.example.com:app:80` | Publish container `app` port 80 from the Acorn to external name `app.example.com`.       |
 
 ## Expose individual ports
 
 Exposing ports makes the services available to applications and other Acorns running on the cluster. When specifying a port to expose without its protocol the protocol defined for it in the Acornfile will be used. If no protocol is defined in the Acornfile, the default will be tcp.
 
-| Flag value | Description |
-| ---------- | ----------- |
-| `--expose 80` | Expose port 80 in the Acorn to port 80 with its protocol. |
-| `--expose 81:80` | Expose 80 in the Acorn to 81 on cluster with its protocol. |
-| `--expose 81:80/tcp` | Expose 80/tcp in the Acorn to 81 as a cluster service. |
-| `--expose 81:80/http` | Expose 80/http in the Acorn to 81 as a cluster service. |
-| `--expose app:80` | Expose container `app` port 80 with its protocol in the Acorn to 80 as a cluster service. |
-| `--expose app:80/tcp` |  Expose container `app` port 80/tcp in the Acorn to 80 as a cluster service. |
-| `--expose app:80/http` |  Expose container `app` port 80/http in the Acorn to 80  as a cluster service. |
-| `--expose web:80:app:80` | Expose container `app` port 80/tcp as cluster service called `web` on port 80/tcp. |
+| Flag value               | Description                                                                               |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| `--expose 80`            | Expose port 80 in the Acorn to port 80 with its protocol.                                 |
+| `--expose 81:80`         | Expose 80 in the Acorn to 81 on cluster with its protocol.                                |
+| `--expose 81:80/tcp`     | Expose 80/tcp in the Acorn to 81 as a cluster service.                                    |
+| `--expose 81:80/http`    | Expose 80/http in the Acorn to 81 as a cluster service.                                   |
+| `--expose app:80`        | Expose container `app` port 80 with its protocol in the Acorn to 80 as a cluster service. |
+| `--expose app:80/tcp`    | Expose container `app` port 80/tcp in the Acorn to 80 as a cluster service.               |
+| `--expose app:80/http`   | Expose container `app` port 80/http in the Acorn to 80  as a cluster service.             |
+| `--expose web:80:app:80` | Expose container `app` port 80/tcp as cluster service called `web` on port 80/tcp.        |
 
 ## DNS
 
@@ -58,7 +58,7 @@ When an Acorn app has published a port, it will be accessible on a unique endpoi
 
 ```shell
 NAME             IMAGE                 HEALTHY   UP-TO-DATE   CREATED     ENDPOINTS                                                                           MESSAGE
-purple-water     my-org/my-acorn:v1    1         1            50s ago     http://app-purple-water-caa5ade4.local.on-acorn.io => default:8080   OK
+purple-water     my-org/my-acorn:v1    1         1            50s ago     http://app-purple-water-caa5ade4.local.oss-acorn.io => default:8080   OK
 ```
 
 You have significant control over the domain name and format of your endpoints, as described below.
@@ -67,13 +67,13 @@ You have significant control over the domain name and format of your endpoints, 
 
 Your cluster domain is the domain used as the suffix for all your Acorn apps' endpoints.
 
-If you're running a local cluster, such as Docker Desktop, Rancher Desktop, or Minikube, the cluster domain will be `local.on-acorn.io` and will always resolve to `localhost`.
+If you're running a local cluster, such as Docker Desktop, Rancher Desktop, or Minikube, the cluster domain will be `local.oss-acorn.io` and will always resolve to `localhost`.
 
-If you are running any other type of cluster, Acorn provides a DNS service that will reserve a unique cluster domain and create publicly accessible DNS entries for you. The domain will look like `<random cluster ID>.on-acorn.io` and will resolve to the hostnames or IP addresses supplied by your ingress controller.  This domain is unique to your cluster and will be used for all Acorn apps.
+If you are running any other type of cluster, Acorn provides a DNS service that will reserve a unique cluster domain and create publicly accessible DNS entries for you. The domain will look like `<random cluster ID>.oss-acorn.io` and will resolve to the hostnames or IP addresses supplied by your ingress controller.  This domain is unique to your cluster and will be used for all Acorn apps.
 
 :::caution
 
-The on-acorn.io DNS service is a public service ran on the Internet. Your Acorn installation must have outbound access to <https://alpha-dns.acrn.io> to access it.
+The oss-acorn.io DNS service is a public service ran on the Internet. Your Acorn installation must have outbound access to <https://oss-dns.acrn.io> to access it.
 
 To create and maintain public DNS entries, the DNS service expects your Acorn installation to make on-demand and periodic renewal requests to it.
 
@@ -94,7 +94,7 @@ You can turn off the Acorn DNS feature as part of installation (or after by reru
 acorn install --acorn-dns disabled
 ```
 
-This will prevent Acorn from reserving a domain for your cluster. If you disable the DNS service and haven't defined a custom cluster domain, the `local.on-acorn.io` domain will be used as a fallback.
+This will prevent Acorn from reserving a domain for your cluster. If you disable the DNS service and haven't defined a custom cluster domain, the `local.oss-acorn.io` domain will be used as a fallback.
 
 ### Naming Conventions
 
@@ -107,7 +107,7 @@ The endpoints generated for your Acorn apps follow this convention by default:
 Here's an example:
 
 ```
-web-purple-water-7961a9e1.73fh5y.on-acorn.io
+web-purple-water-7961a9e1.73fh5y.oss-acorn.io
 ```
 
 Let's break that FQDN down:
@@ -115,7 +115,7 @@ Let's break that FQDN down:
 - **web** is the name of the container from your Acorn app. If the container name is "*default*", it will be omitted from the FQDN.
 - **purple-water** is the generated name of your Acorn app. You can control this by supplying a name through the `--name` flag.
 - **7961a9e1** is a hash created from the container name and app name together. This ensures that the url is unique and will be persistent across runs.
-- **73fh5y.on-acorn.io** is the cluster domain generated for your cluster. You can control this as described in the previous section.
+- **73fh5y.oss-acorn.io** is the cluster domain generated for your cluster. You can control this as described in the previous section.
 
 To highlight the level of control this gives you, consider the following:
 
@@ -125,7 +125,7 @@ In addition to this method of controlling your endpoint, you can publish to an e
 
 Endpoints generated by Acorn are built using a Go Template. By default, endpoints are built using the `{{.Container}}-{{.App}}-{{.Hash}}.{{.ClusterDomain}}` pattern to allow integration with [Let's Encrypt](30-installation/02-options.md#tls-via-lets-encrypt).
 
-However, should you want your application endpoints to be something completely different, you can pass a Go Template to the `--http-endpoint-pattern` flag. For example, say that we want our `blog` container to be reachable at `blog.local.on-acorn.io` instead of the the standard Let's Encrypt variant. To accomplish this, we just need to install Acorn with a pattern for it set.
+However, should you want your application endpoints to be something completely different, you can pass a Go Template to the `--http-endpoint-pattern` flag. For example, say that we want our `blog` container to be reachable at `blog.local.oss-acorn.io` instead of the the standard Let's Encrypt variant. To accomplish this, we just need to install Acorn with a pattern for it set.
 
 ```shell
 acorn install --http-endpoint-pattern "{{.Container}}.{{.ClusterDomain}}"
@@ -140,7 +140,7 @@ acorn install --http-endpoint-pattern ""
 When building the template, there are a few variables that can be referenced in any order.
 
 | Variable           | Description                                             |
-|--------------------|---------------------------------------------------------|
+| ------------------ | ------------------------------------------------------- |
 | {{.Container}}     | Name of the container being hit with the endpoint.      |
 | {{.App}}           | Name of the application.                                |
 | {{.Hash}}          | A hash generated from the Container and App together.   |
@@ -177,7 +177,7 @@ containers: {
 If you start this Acornfile with `acorn run` the generated output should look like
 
 ```shell
- STATUS: ENDPOINTS[http://api-wild-cloud-a6e8ab1c.local.on-acorn.io => api:80, http://auth-wild-cloud-aa56b1c9.local.on-acorn.io => auth:80] HEALTHY[2] UPTODATE[2] OK
+ STATUS: ENDPOINTS[http://api-wild-cloud-a6e8ab1c.local.oss-acorn.io => api:80, http://auth-wild-cloud-aa56b1c9.local.oss-acorn.io => auth:80] HEALTHY[2] UPTODATE[2] OK
 ```
 
 Adding in the router to the Acornfile
@@ -208,4 +208,4 @@ containers: api: {
 Results in an endpoint that now routes to both services through `/api` and `/auth`
 
 ```shell
-| STATUS: ENDPOINTS[http://api-delicate-leaf-4ceee54b.local.on-acorn.io => api:80, http://auth-delicate-leaf-a6e05d96.local.on-acorn.io => auth:80, http://myroute-delicate-leaf-6633a4ae.local.on-acorn.io => myroute:8080] HEALTHY[2] UPTODATE[2] OK |
+| STATUS: ENDPOINTS[http://api-delicate-leaf-4ceee54b.local.oss-acorn.io => api:80, http://auth-delicate-leaf-a6e05d96.local.oss-acorn.io => auth:80, http://myroute-delicate-leaf-6633a4ae.local.oss-acorn.io => myroute:8080] HEALTHY[2] UPTODATE[2] OK |

--- a/docs/docs/50-running/03-certificates.md
+++ b/docs/docs/50-running/03-certificates.md
@@ -2,7 +2,7 @@
 title: TLS Certificates
 ---
 
-Applications that publish HTTP endpoints can be protected by TLS certificates.  If you've enabled Acorn's [Let's Encrypt integration](30-installation/02-options.md#tls-via-lets-encrypt), a valid certificate will be provisioned for your app's endpoints. This applies to on-acorn.io generated endpoints and custom endpoints configured using the [publish flag](50-running/02-networking.md#publish-individual-ports).
+Applications that publish HTTP endpoints can be protected by TLS certificates.  If you've enabled Acorn's [Let's Encrypt integration](30-installation/02-options.md#tls-via-lets-encrypt), a valid certificate will be provisioned for your app's endpoints. This applies to oss-acorn.io generated endpoints and custom endpoints configured using the [publish flag](50-running/02-networking.md#publish-individual-ports).
 
 ## Manually adding certificates
 If you don't wish to use Acorn's Let's Encrypt integration, you can configure certificates manually or by integrating with cert-manager. Acorn will automatically look for SANs in secrets of type `kubernetes.io/tls` for the exposed FQDN of the application in the Acorn namespace.

--- a/docs/docs/50-running/65-update-acorns.md
+++ b/docs/docs/50-running/65-update-acorns.md
@@ -39,7 +39,7 @@ awesome-acorn
 
 $ acorn app                   
 NAME             IMAGE          HEALTHY   UP-TO-DATE   CREATED    ENDPOINTS                                                            MESSAGE
-awesome-acorn    3e23d225e777   1         1            10s ago    http://nginx-awesome-acorn-9ca4278a.local.on-acorn.io => nginx:80    OK
+awesome-acorn    3e23d225e777   1         1            10s ago    http://nginx-awesome-acorn-9ca4278a.local.oss-acorn.io => nginx:80    OK
 
 #update the msg arg and add a label
 acorn run --update --label label=new -n awesome-acorn -- --msg 2

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -396,7 +396,7 @@ type Config struct {
 	// See ClusterDomains as an example.
 
 	IngressClassName               *string  `json:"ingressClassName" usage:"The ingress class name to assign to all created ingress resources (default '')"`
-	ClusterDomains                 []string `json:"clusterDomains" name:"cluster-domain" usage:"The externally addressable cluster domain (default .on-acorn.io)"`
+	ClusterDomains                 []string `json:"clusterDomains" name:"cluster-domain" usage:"The externally addressable cluster domain (default .oss-acorn.io)"`
 	LetsEncrypt                    *string  `json:"letsEncrypt" name:"lets-encrypt" usage:"enabled|disabled|staging. If enabled, acorn generated endpoints will be secured using TLS certificate from Let's Encrypt. Staging uses Let's Encrypt's staging environment. (default disabled)"`
 	LetsEncryptEmail               string   `json:"letsEncryptEmail" name:"lets-encrypt-email" usage:"Required if --lets-encrypt=enabled. The email address to use for Let's Encrypt registration(default '')"`
 	LetsEncryptTOSAgree            *bool    `json:"letsEncryptTOSAgree" name:"lets-encrypt-tos-agree" usage:"Required if --lets-encrypt=enabled. If true, you agree to the Let's Encrypt terms of service (default false)"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,11 +16,11 @@ import (
 )
 
 var (
-	ClusterDomainDefault         = ".local.on-acorn.io"
+	ClusterDomainDefault         = ".oss-acorn.io"
 	InternalClusterDomainDefault = "svc.cluster.local"
 
 	// AcornDNSEndpointDefault will be overridden at build time for releases
-	AcornDNSEndpointDefault = "https://staging-dns.acrn.io/v1"
+	AcornDNSEndpointDefault = "https://oss-dns.acrn.io/v1"
 	AcornDNSStateDefault    = "auto"
 
 	// LetsEncryptOptionDefault is the default state for the Let's Encrypt integration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ClusterDomainDefault         = ".oss-acorn.io"
+	ClusterDomainDefault         = "local.oss-acorn.io"
 	InternalClusterDomainDefault = "svc.cluster.local"
 
 	// AcornDNSEndpointDefault will be overridden at build time for releases

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ var (
 	ClusterDomainDefault         = ".local.oss-acorn.io"
 	InternalClusterDomainDefault = "svc.cluster.local"
 
-	// AcornDNSEndpointDefault will be overridden at build time for releases
 	AcornDNSEndpointDefault = "https://oss-dns.acrn.io/v1"
 	AcornDNSStateDefault    = "auto"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ClusterDomainDefault         = "local.oss-acorn.io"
+	ClusterDomainDefault         = ".local.oss-acorn.io"
 	InternalClusterDomainDefault = "svc.cluster.local"
 
 	// AcornDNSEndpointDefault will be overridden at build time for releases

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -60,7 +60,7 @@ func TestAcornDNSStates(t *testing.T) {
 			conf: &apiv1.Config{
 				AcornDNS: &[]string{"auto"}[0],
 			},
-			expectedClusterDomains: []string{".local.on-acorn.io"},
+			expectedClusterDomains: []string{".local.oss-acorn.io"},
 			prepare: func(f *mocks.MockReader) {
 				f.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				f.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil)

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/existing.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/existing.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  config: '{"clusterDomains":[".local.on-acorn.io:8081"],"httpEndpointPattern":"{{.Container}}.{{.App}}.{{.Namespace}}.{{.ClusterDomain}}"}'
+  config: '{"clusterDomains":[".local.oss-acorn.io:8081"],"httpEndpointPattern":"{{.Container}}.{{.App}}.{{.Namespace}}.{{.ClusterDomain}}"}'
 kind: ConfigMap
 metadata:
   name: acorn-config

--- a/pkg/controller/config/dns_test.go
+++ b/pkg/controller/config/dns_test.go
@@ -43,7 +43,7 @@ func TestBasicInit(t *testing.T) {
 	assert.Equal(t, "acorn-dns", secret.Name)
 	assert.Equal(t, "acorn-system", secret.Namespace)
 	assert.Equal(t, "enabled", secret.Annotations[labels.AcornDNSState])
-	assert.Equal(t, []byte("test.on-acorn.io"), secret.Data["domain"])
+	assert.Equal(t, []byte("test.oss-acorn.io"), secret.Data["domain"])
 	assert.Equal(t, []byte("token"), secret.Data["token"])
 
 	// Test when AcornDNS set to "auto" and no cluster domains
@@ -56,7 +56,7 @@ func TestBasicInit(t *testing.T) {
 	assert.Len(t, resp.Client.Updated, 0)
 	secret = resp.Client.Created[0].(*corev1.Secret)
 	assert.Equal(t, "auto", secret.Annotations[labels.AcornDNSState])
-	assert.Equal(t, []byte("test.on-acorn.io"), secret.Data["domain"])
+	assert.Equal(t, []byte("test.oss-acorn.io"), secret.Data["domain"])
 	assert.Equal(t, []byte("token"), secret.Data["token"])
 
 	// Test when AcornDNS set to "auto" and there is cluster domains
@@ -69,7 +69,7 @@ func TestBasicInit(t *testing.T) {
 	assert.Len(t, resp.Client.Updated, 0)
 	secret = resp.Client.Created[0].(*corev1.Secret)
 	assert.Equal(t, "auto", secret.Annotations[labels.AcornDNSState])
-	assert.Equal(t, []byte("test.on-acorn.io"), secret.Data["domain"])
+	assert.Equal(t, []byte("test.oss-acorn.io"), secret.Data["domain"])
 	assert.Equal(t, []byte("token"), secret.Data["token"])
 
 	// Test when AcornDNS set to "disabled"
@@ -115,7 +115,7 @@ func TestDisabling(t *testing.T) {
 			},
 		},
 		Data: map[string][]byte{
-			"domain": []byte("test.on-acorn.io"),
+			"domain": []byte("test.oss-acorn.io"),
 			"token":  []byte("token"),
 		},
 	})
@@ -131,7 +131,7 @@ func TestDisabling(t *testing.T) {
 	assert.Equal(t, "acorn-dns", secret.Name)
 	assert.Equal(t, "acorn-system", secret.Namespace)
 	assert.Equal(t, "disabled", secret.Annotations[labels.AcornDNSState])
-	assert.Equal(t, []byte("test.on-acorn.io"), secret.Data["domain"])
+	assert.Equal(t, []byte("test.oss-acorn.io"), secret.Data["domain"])
 	assert.Equal(t, []byte("token"), secret.Data["token"])
 }
 
@@ -144,7 +144,7 @@ func (t *mockClient) CreateRecords(endpoint, domain, token string, records []dns
 }
 
 func (t *mockClient) ReserveDomain(endpoint string) (string, string, error) {
-	return "test.on-acorn.io", "token", nil
+	return "test.oss-acorn.io", "token", nil
 }
 
 func (t *mockClient) Renew(endpoint, domain, token string, renew dns.RenewRequest) (dns.RenewResponse, error) {

--- a/pkg/controller/ingress/dns_test.go
+++ b/pkg/controller/ingress/dns_test.go
@@ -50,7 +50,7 @@ func (t *mockClient) CreateRecords(endpoint, domain, token string, records []dns
 }
 
 func (t *mockClient) ReserveDomain(endpoint string) (string, string, error) {
-	return "test.on-acorn.io", "token", nil
+	return "test.oss-acorn.io", "token", nil
 }
 
 func (t *mockClient) Renew(endpoint, domain, token string, renew dns.RenewRequest) (dns.RenewResponse, error) {

--- a/pkg/controller/ingress/testdata/ingress/existing.yaml
+++ b/pkg/controller/ingress/testdata/ingress/existing.yaml
@@ -7,9 +7,10 @@ metadata:
   namespace: acorn-system
 ---
 apiVersion: v1
-stringData:
-  domain: test.oss-acorn.io
-  token: token
+data:
+  # base64 encoded. Values are "test.oss-acorn.io" and "token"
+  domain: dGVzdC5vc3MtYWNvcm4uaW8=
+  token: dG9rZW4=
 kind: Secret
 metadata:
   name: acorn-dns

--- a/pkg/controller/ingress/testdata/ingress/existing.yaml
+++ b/pkg/controller/ingress/testdata/ingress/existing.yaml
@@ -8,7 +8,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  # base64 encoded. Values are "test.on-acorn.io" and "token"
+  # base64 encoded. Values are "test.oss-acorn.io" and "token"
   domain: dGVzdC5vbi1hY29ybi5pbw==
   token: dG9rZW4=
 kind: Secret

--- a/pkg/controller/ingress/testdata/ingress/existing.yaml
+++ b/pkg/controller/ingress/testdata/ingress/existing.yaml
@@ -7,10 +7,9 @@ metadata:
   namespace: acorn-system
 ---
 apiVersion: v1
-data:
-  # base64 encoded. Values are "test.oss-acorn.io" and "token"
-  domain: dGVzdC5vbi1hY29ybi5pbw==
-  token: dG9rZW4=
+stringData:
+  domain: test.oss-acorn.io
+  token: token
 kind: Secret
 metadata:
   name: acorn-dns

--- a/pkg/controller/ingress/testdata/ingress/expected.yaml
+++ b/pkg/controller/ingress/testdata/ingress/expected.yaml
@@ -13,7 +13,7 @@ metadata:
     acorn.io/container-name: con1
 spec:
   rules:
-    - host: con1.app-name.app-namespace.test.on-acorn.io
+    - host: con1.app-name.app-namespace.test.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/ingress/testdata/ingress/expected.yaml
+++ b/pkg/controller/ingress/testdata/ingress/expected.yaml
@@ -9,7 +9,7 @@ metadata:
     "acorn.io/container-name": "con1"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/dns-hash: "5dedee4fb5aca80f3520412b7db02c0d6ada7bbb"
+    acorn.io/dns-hash: "73bf5777c6437485fd801fefe6b5ef37d8b76a9e"
     acorn.io/container-name: con1
 spec:
   rules:

--- a/pkg/controller/ingress/testdata/ingress/input.yaml
+++ b/pkg/controller/ingress/testdata/ingress/input.yaml
@@ -13,7 +13,7 @@ metadata:
     acorn.io/container-name: con1
 spec:
   rules:
-    - host: con1.app-name.app-namespace.test.on-acorn.io
+    - host: con1.app-name.app-namespace.test.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/externalname/input.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/externalname/input.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: other-namespace
 spec:
   rules:
-    - host: myhostname.on-acorn.io
+    - host: myhostname.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/ingress/input.yaml
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/ingress/input.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: my-app-namespace
 spec:
   rules:
-    - host: myhostname.on-acorn.io
+    - host: myhostname.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -96,7 +96,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper) {
 	router.Type(&corev1.Pod{}).Selector(managedSelector).HandlerFunc(jobs.JobPodOrphanCleanup)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).Namespace(system.ImagesNamespace).HandlerFunc(gc.GCOrphans)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).Middleware(ingress.RequireLBs).Handler(ingress.NewDNSHandler())
-	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, including the on-acorn.io wildcard cert
+	router.Type(&corev1.Secret{}).Selector(managedSelector).Middleware(tls.RequireSecretTypeTLS).HandlerFunc(tls.RenewCert) // renew (expired) TLS certificates, including the oss-acorn.io wildcard cert
 	router.Type(&storagev1.StorageClass{}).HandlerFunc(volume.SyncVolumeClasses)
 	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(networkpolicy.ForService)
 	router.Type(&netv1.Ingress{}).Selector(managedSelector).HandlerFunc(networkpolicy.ForIngress)

--- a/pkg/controller/service/testdata/ingress/basic/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/ingress/basic/expected.yaml.d/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     "acorn.io/container-name": "oneimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"ci1.acorn.not":{"port":81,"service":"oneimage"},"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.on-acorn.io":{"port":81,"service":"oneimage"}}'
+    acorn.io/targets: '{"ci1.acorn.not":{"port":81,"service":"oneimage"},"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.oss-acorn.io":{"port":81,"service":"oneimage"}}'
 spec:
   rules:
-    - host: oneimage-app-name-a5b0aade.local.on-acorn.io
+    - host: oneimage-app-name-a5b0aade.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/ingress/clusterdomainport/existing.yaml
+++ b/pkg/controller/service/testdata/ingress/clusterdomainport/existing.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  config: '{"clusterDomains":[".local.on-acorn.io:8081"],"httpEndpointPattern":"{{.Container}}.{{.App}}.{{.Namespace}}.{{.ClusterDomain}}"}'
+  config: '{"clusterDomains":[".local.oss-acorn.io:8081"],"httpEndpointPattern":"{{.Container}}.{{.App}}.{{.Namespace}}.{{.ClusterDomain}}"}'
 kind: ConfigMap
 metadata:
   name: acorn-config
@@ -23,10 +23,10 @@ status:
     containers:
       oneimage:
         ports:
-        - port: 80
-          targetPort: 81
-          publish: true
-          protocol: http
+          - port: 80
+            targetPort: 81
+            publish: true
+            protocol: http
         image: "image-name"
         build:
           dockerfile: "Dockerfile"

--- a/pkg/controller/service/testdata/ingress/clusterdomainport/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/ingress/clusterdomainport/expected.yaml.d/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     "acorn.io/container-name": "oneimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"oneimage.app-name.app-namespace.local.on-acorn.io:8081":{"port":81,"service":"oneimage"}}'
+    acorn.io/targets: '{"oneimage.app-name.app-namespace.local.oss-acorn.io:8081":{"port":81,"service":"oneimage"}}'
 spec:
   rules:
-    - host: oneimage.app-name.app-namespace.local.on-acorn.io
+    - host: oneimage.app-name.app-namespace.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/ingress/labels/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/ingress/labels/expected.yaml.d/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     "globall1": "value"
     "globall2": "value"
   annotations:
-    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.on-acorn.io":{"port":81,"service":"con1"}}'
+    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.oss-acorn.io":{"port":81,"service":"con1"}}'
     "allconsa1": "value"
     "cona1": "value"
     "cona3": "value"
@@ -22,7 +22,7 @@ metadata:
     "globala2": "value"
 spec:
   rules:
-    - host: con1-app-name-2aaa2251.local.on-acorn.io
+    - host: con1-app-name-2aaa2251.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/ingress/letsencrypt/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/ingress/letsencrypt/expected.yaml.d/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     "acorn.io/container-name": "app1"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"app1-app-name-04396c88.local.on-acorn.io":{"port":81,"service":"app1"},"ci1.acorn.not":{"port":81,"service":"app1"}}'
+    acorn.io/targets: '{"app1-app-name-04396c88.local.oss-acorn.io":{"port":81,"service":"app1"},"ci1.acorn.not":{"port":81,"service":"app1"}}'
 spec:
   rules:
-    - host: app1-app-name-04396c88.local.on-acorn.io
+    - host: app1-app-name-04396c88.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-1/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-1/expected.yaml.d/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     "globall1": "value"
     "globall2": "value"
   annotations:
-    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.on-acorn.io":{"port":81,"service":"con1"}}'
+    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.oss-acorn.io":{"port":81,"service":"con1"}}'
     "allconsa1": "value"
     "cona1": "value"
     "cona3": "value"
@@ -22,7 +22,7 @@ metadata:
     "globala2": "value"
 spec:
   rules:
-    - host: con1-app-name-2aaa2251.local.on-acorn.io
+    - host: con1-app-name-2aaa2251.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-2/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-2/expected.yaml.d/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     "globall1": "value"
     "globall2": "value"
   annotations:
-    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.on-acorn.io":{"port":81,"service":"con1"}}'
+    "acorn.io/targets": '{"con1-app-name-2aaa2251.local.oss-acorn.io":{"port":81,"service":"con1"}}'
     "allconsa1": "value"
     "cona1": "value"
     "cona3": "value"
@@ -22,7 +22,7 @@ metadata:
     "globala2": "value"
 spec:
   rules:
-    - host: con1-app-name-2aaa2251.local.on-acorn.io
+    - host: con1-app-name-2aaa2251.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/router/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/router/expected.yaml.d/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     acorn.io/managed: "true"
     acorn.io/router-name: router-name
   annotations:
-    acorn.io/targets: '{"router-name-app-name-3de5df49.local.on-acorn.io":{"port":8080,"service":"router-name"}}'
+    acorn.io/targets: '{"router-name-app-name-3de5df49.local.oss-acorn.io":{"port":8080,"service":"router-name"}}'
 spec:
   rules:
-    - host: router-name-app-name-3de5df49.local.on-acorn.io
+    - host: router-name-app-name-3de5df49.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/service/basic/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/service/basic/expected.yaml.d/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     "acorn.io/container-name": "oneimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.on-acorn.io":{"port":81,"service":"oneimage"}}'
+    acorn.io/targets: '{"localhost":{"port":81,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.oss-acorn.io":{"port":81,"service":"oneimage"}}'
 spec:
   rules:
-    - host: oneimage-app-name-a5b0aade.local.on-acorn.io
+    - host: oneimage-app-name-a5b0aade.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/service/testdata/service/tcp-http-overlap/expected.yaml.d/ingress.yaml
+++ b/pkg/controller/service/testdata/service/tcp-http-overlap/expected.yaml.d/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     "acorn.io/container-name": "oneimage"
     "acorn.io/managed": "true"
   annotations:
-    acorn.io/targets: '{"localhost":{"port":80,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.on-acorn.io":{"port":80,"service":"oneimage"}}'
+    acorn.io/targets: '{"localhost":{"port":80,"service":"oneimage"},"oneimage-app-name-a5b0aade.local.oss-acorn.io":{"port":80,"service":"oneimage"}}'
 spec:
   rules:
-    - host: oneimage-app-name-a5b0aade.local.on-acorn.io
+    - host: oneimage-app-name-a5b0aade.local.oss-acorn.io
       http:
         paths:
           - backend:

--- a/pkg/controller/tls/certs.go
+++ b/pkg/controller/tls/certs.go
@@ -26,7 +26,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-// ProvisionWildcardCert provisions a Let's Encrypt wildcard certificate for *.<domain>.on-acorn.io
+// ProvisionWildcardCert provisions a Let's Encrypt wildcard certificate for *.<domain>.oss-acorn.io
 func ProvisionWildcardCert(req router.Request, resp router.Response, domain, token string) error {
 	logrus.Debugf("Provisioning wildcard cert for %v", domain)
 	// Ensure that we have a Let's Encrypt account ready
@@ -166,7 +166,7 @@ func ProvisionCerts(req router.Request, resp router.Response) error {
 }
 
 func prov(req router.Request, leUser *LEUser, domain, appname, segment, namespace string) error {
-	if domain == "" || len(validation.IsFullyQualifiedDomainName(&field.Path{}, domain)) > 0 || strings.HasSuffix(domain, "on-acorn.io") {
+	if domain == "" || len(validation.IsFullyQualifiedDomainName(&field.Path{}, domain)) > 0 || strings.HasSuffix(domain, "oss-acorn.io") {
 		logrus.Debugf("Skipping cert provisioning for %s", domain)
 		return nil
 	}

--- a/pkg/controller/tls/letsencrypt.go
+++ b/pkg/controller/tls/letsencrypt.go
@@ -377,8 +377,8 @@ func (u *LEUser) mustRenew(sec *corev1.Secret) bool {
 }
 
 func (u *LEUser) dnsChallenge(ctx context.Context, domain string) (*certificate.Resource, error) {
-	if !strings.HasSuffix(domain, "on-acorn.io") {
-		return nil, fmt.Errorf("ACME DNS challenge is only supported for on-acorn.io subdomains, not for %s", domain)
+	if !strings.HasSuffix(domain, "oss-acorn.io") {
+		return nil, fmt.Errorf("ACME DNS challenge is only supported for oss-acorn.io subdomains, not for %s", domain)
 	}
 
 	client, err := u.leClient()

--- a/pkg/publish/ingress_test.go
+++ b/pkg/publish/ingress_test.go
@@ -26,9 +26,9 @@ func TestToEndpoint(t *testing.T) {
 		wantErr      error
 	}{
 		{
-			name: "\"on-acorn.io no -\" pattern set",
+			name: "\"oss-acorn.io no -\" pattern set",
 			args: args{
-				domain:      "domain.on-acorn.io",
+				domain:      "domain.oss-acorn.io",
 				serviceName: "app-test",
 				pattern:     "{{hashConcat 8 .Container .App .Namespace | truncate}}.{{.ClusterDomain}}",
 				appInstance: &v1.AppInstance{
@@ -38,12 +38,12 @@ func TestToEndpoint(t *testing.T) {
 					Status:     v1.AppInstanceStatus{},
 				},
 			},
-			wantEndpoint: "app-test-green-star-b19d0b34.domain.on-acorn.io",
+			wantEndpoint: "app-test-green-star-b19d0b34.domain.oss-acorn.io",
 		},
 		{
-			name: "\"on-acorn.io no -\" pattern set with 12 characters",
+			name: "\"oss-acorn.io no -\" pattern set with 12 characters",
 			args: args{
-				domain:      "domain.on-acorn.io",
+				domain:      "domain.oss-acorn.io",
 				serviceName: "app-test",
 				pattern:     "{{hashConcat 12 .Container .App .Namespace | truncate}}.{{.ClusterDomain}}",
 				appInstance: &v1.AppInstance{
@@ -53,12 +53,12 @@ func TestToEndpoint(t *testing.T) {
 					Status:     v1.AppInstanceStatus{},
 				},
 			},
-			wantEndpoint: "app-test-green-star-b19d0b346674.domain.on-acorn.io",
+			wantEndpoint: "app-test-green-star-b19d0b346674.domain.oss-acorn.io",
 		},
 		{
-			name: "\"on-acorn.io no -\" pattern set with less than two parameters should return empty string",
+			name: "\"oss-acorn.io no -\" pattern set with less than two parameters should return empty string",
 			args: args{
-				domain:      "domain.on-acorn.io",
+				domain:      "domain.oss-acorn.io",
 				serviceName: "app-test",
 				pattern:     "{{hashConcat 8 .Container | truncate}}.{{.ClusterDomain}}",
 				appInstance: &v1.AppInstance{
@@ -68,7 +68,7 @@ func TestToEndpoint(t *testing.T) {
 					Status:     v1.AppInstanceStatus{},
 				},
 			},
-			wantEndpoint: ".domain.on-acorn.io",
+			wantEndpoint: ".domain.oss-acorn.io",
 		},
 		{
 			name: "\"custom domain\" pattern set",


### PR DESCRIPTION
Point acorn at new acorn-dns deployment by default. Simplify the build process by no longer overriding the acorn-dns endpoint.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

