### PR TITLE
Only build test summary when tests run

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build test summary
         uses: test-summary/action@v1
-        if: always()
+        if: success() || failure()
         with:
           paths: test-summary.xml
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,6 @@ jobs:
       - run: TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile test-summary.xml" make test
       - name: Build test summary
         uses: test-summary/action@v1
-        if: always()
+        if: success() || failure()
         with:
           paths: test-summary.xml


### PR DESCRIPTION
This makes it so that the test summary doesn't run everytime, only when the no previous steps (including the running of the tests) failed.