### PR TITLE
Get Project before modifying it in Quota test

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -60,6 +60,7 @@ jobs:
           KUBECONFIG: "/home/runner/.kube/config"
 
       - name: Build test summary
+        id: test_summary
         uses: test-summary/action@v1
         if: success() || failure()
         with:
@@ -71,7 +72,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: '${{ secrets.SLACK_BOT_FAILURE_CHANNEL }}'
-          slack-message: "❌ Nightly EKS test had ${{ steps.test_summary.outputs.failed }} test cases fail: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "❌ Nightly EKS test had ${{ steps.test_summary.outputs.failed }} test case(s) fail: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ validate-code: tidy generate lint gen-docs
 
 GOTESTSUM_VERSION ?= v1.10.0
 test:
-	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) $(TEST_FLAGS) ./...
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --format testname $(TEST_FLAGS) ./...
 
 goreleaser:
 	goreleaser build --snapshot --single-target --rm-dist

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1573,14 +1573,14 @@ func TestEnforcedQuota(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Update the project to enforce quota.
-	if project.Annotations == nil {
-		project.Annotations = make(map[string]string)
-	}
-	project.Annotations[labels.ProjectEnforcedQuotaAnnotation] = "true"
-	if err := kclient.Update(ctx, project); err != nil {
-		t.Fatal(err)
-	}
+	// Annotate the project to enforce quota.
+	project = helper.WaitForObject(t, helper.Watcher(t, c), &corev1.NamespaceList{}, project, func(obj *corev1.Namespace) bool {
+		if project.Annotations == nil {
+			project.Annotations = make(map[string]string)
+		}
+		project.Annotations[labels.ProjectEnforcedQuotaAnnotation] = "true"
+		return kclient.Update(ctx, obj) == nil
+	})
 
 	// Run a simple app.
 	image, err := c.AcornImageBuild(ctx, "./testdata/simple/Acornfile", &client.AcornImageBuildOptions{


### PR DESCRIPTION
The nightly integration test failed with the following error:

```
run_test.go:1582: Operation cannot be fulfilled on namespaces "acorn-project-6xvr9": the object has been modified; please apply your changes to the latest version and try again
```

As such I am updating the code to get the Project before modifying it. Additionally, I am fixing an issue where the message that was output for the failing tests did not have the correct count for failing test cases. Lastly, I am changing the format for `gotestsum` to display each test case to make it easier to see especially long test cases.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

