### PR TITLE
Make public name labels safe for k8s

### DIFF
--- a/pkg/publicname/publicname.go
+++ b/pkg/publicname/publicname.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/acorn-io/acorn/pkg/labels"
+	"github.com/acorn-io/baaah/pkg/name"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,7 +17,7 @@ func Get(obj kclient.Object) string {
 }
 
 func ForChild(parent kclient.Object, childName string) string {
-	return Get(parent) + "." + childName
+	return name.SafeConcatName(Get(parent) + "." + childName)
 }
 
 func Split(name string) (string, string) {


### PR DESCRIPTION
This issue can prevent ServiceInstances, Volumes, and other Acorn API objects from getting created if the public name ends up being too long or in some other way invalid for Kubernetes. Using baaah's SafeConcatName function will fix this for us.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

