### PR TITLE
Update login command to not suggest a broken command

### DIFF
--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -158,7 +158,7 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 			if def == "" {
 				def = fmt.Sprintf("%s/%s/acorn", serverAddress, a.Username)
 			}
-			pterm.Info.Printf("Run \"acorn projects %s\" to list available projects\n", serverAddress)
+			pterm.Info.Printf("Run \"acorn projects\" to list available projects\n")
 			pterm.Info.Printf("Run \"acorn project use %s\" to set default project\n", def)
 		}
 	}


### PR DESCRIPTION
Prior this commit, we were suggesting a command that does not work upon successful login:

```console
acorn login acorn.io
# ...
  •  Run "acorn projects acorn.io" to list available projects
  •  Run "acorn project use acorn.io/sangee2004/mytest1" to set default project
  ✔  Login to acorn.io as sangee2004 succeeded
```

This now looks like:

```console
acorn login acorn.io
# ...
  •  Run "acorn projects" to list available projects
  •  Run "acorn project use acorn.io/sangee2004/mytest1" to set default project
  ✔  Login to acorn.io as sangee2004 succeeded
```

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

