### PR TITLE
Stop checking status for jobs that won't run (#1646)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20230522195721-1194d1256120
-	github.com/acorn-io/baaah v0.0.0-20230428031609-d553bca0d3d8
+	github.com/acorn-io/baaah v0.0.0-20230523230836-5b13bbf77130
 	github.com/acorn-io/mink v0.0.0-20230424190003-9a32355ec823
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/acorn-io/aml v0.0.0-20230522195721-1194d1256120 h1:6bvZoycPKEsXtpUKQb
 github.com/acorn-io/aml v0.0.0-20230522195721-1194d1256120/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
 github.com/acorn-io/apiserver v0.25.2-ot-2 h1:drxKtiHh2dGnKlhVYxgPCKkFXRvMFxdflCZ5fHpVp8E=
 github.com/acorn-io/apiserver v0.25.2-ot-2/go.mod h1:qRxmYneSxb8B1FYvgQf6mPeWuwugIzYKN3TeMmL4FVo=
-github.com/acorn-io/baaah v0.0.0-20230428031609-d553bca0d3d8 h1:8DA+z4B0aC+u4x1H+3vlgQHytVlyxlkNdS1aMYE/Y+A=
-github.com/acorn-io/baaah v0.0.0-20230428031609-d553bca0d3d8/go.mod h1:yE5MQ1xi7osIDHNnBdmdTHmtnBbYxHQgQfXm/q2bbkU=
+github.com/acorn-io/baaah v0.0.0-20230523230836-5b13bbf77130 h1:0mKG7xI4gJQ9yZx5uqHtpGGepCyMsV3lMRPQdsjvl8c=
+github.com/acorn-io/baaah v0.0.0-20230523230836-5b13bbf77130/go.mod h1:yE5MQ1xi7osIDHNnBdmdTHmtnBbYxHQgQfXm/q2bbkU=
 github.com/acorn-io/component-base v0.25.2-ot-1 h1:xinqJUNbpW2/zsvm8mDv6Q7riLhvXup9x7Kz9eIPM1M=
 github.com/acorn-io/component-base v0.25.2-ot-1/go.mod h1:/5qYr5BXGNPs+cRd6+WL1NfOYtzOstJlm1CMK06cm7s=
 github.com/acorn-io/etcd/client/pkg/v3 v3.6.0-ot-1 h1:u2g5S6DbDNyueFeRSAVIBGMrkyLlcBLhTmH8l0a/4DM=

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -174,11 +174,12 @@ type ContainerStatus struct {
 }
 
 type JobStatus struct {
-	Succeed    bool   `json:"succeed,omitempty"`
-	Failed     bool   `json:"failed,omitempty"`
-	Running    bool   `json:"running,omitempty"`
-	Message    string `json:"message,omitempty"`
-	CreateDone bool   `json:"createDone,omitempty"`
+	Succeed              bool   `json:"succeed,omitempty"`
+	Failed               bool   `json:"failed,omitempty"`
+	Running              bool   `json:"running,omitempty"`
+	Message              string `json:"message,omitempty"`
+	CreateEventSucceeded bool   `json:"createEventSucceeded,omitempty"`
+	Skipped              bool   `json:"skipped,omitempty"`
 }
 
 type AppColumns struct {

--- a/pkg/controller/appdefinition/jobs_test.go
+++ b/pkg/controller/appdefinition/jobs_test.go
@@ -23,3 +23,7 @@ func TestJobsLabelsNamespace(t *testing.T) {
 func TestCronJobs(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/cronjob", DeploySpec)
 }
+
+func TestDeleteJob(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/job/delete-job", DeploySpec)
+}

--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/appinstance.yaml
@@ -73,3 +73,5 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.yaml.d/job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     "apply.acorn.io/prune": "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/cronjob/expected.yaml
@@ -79,3 +79,5 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/appinstance.yaml
@@ -78,4 +78,6 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    job-name: {}
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.yaml.d/job.yaml
@@ -15,6 +15,7 @@ metadata:
     allowed-global.io: test-global
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
     admit-job.io: test-admit-job-ann
     allowed-global.io: test-global
     allowed.io: test-allowed-app-spec-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/appinstance.yaml
@@ -94,4 +94,6 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    job-name: {}
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.yaml.d/job.yaml
@@ -14,6 +14,7 @@ metadata:
     jobLabel: test-job-label
   annotations:
     "apply.acorn.io/prune": "false"
+    apply.acorn.io/update: "true"
     appSpecAnn: test-app-spec-ann
     "global-scoped-ann": test-global
     jobAnn: test-job-ann

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/appinstance.yaml
@@ -34,4 +34,6 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    job-name: {}
 ---

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.yaml.d/job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
@@ -103,3 +104,5 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/job/delete-job/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/job/delete-job/expected.yaml
@@ -6,22 +6,6 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
-  permissions:
-    - serviceName: oneimage
-      rules:
-        - verbs:
-            - create
-          apiGroups:
-            - "foo.io"
-          resources:
-            - "bar"
-          scope: "account"
-        - verbs:
-            - patch
-          apiGroups:
-            - "bar.io"
-          resources:
-            - "foo"
 status:
   namespace: app-created-namespace
   appImage:
@@ -29,6 +13,7 @@ status:
   appSpec:
     jobs:
       oneimage:
+        events: ["delete"]
         sidecars:
           left:
             image: "foo"
@@ -37,17 +22,18 @@ status:
                 targetPort: 91
                 protocol: tcp
         ports:
-        - port: 80
-          targetPort: 81
-          protocol: http
+          - port: 80
+            targetPort: 81
+            protocol: http
         image: "image-name"
         build:
           dockerfile: "Dockerfile"
           context: "."
   conditions:
-  - type: defined
-    reason: Success
-    status: "True"
-    success: true
+    - type: defined
+      reason: Success
+      status: "True"
+      success: true
   jobsStatus:
-    oneimage: {}
+    oneimage:
+      skipped: true

--- a/pkg/controller/appdefinition/testdata/job/delete-job/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/delete-job/input.yaml
@@ -6,22 +6,6 @@ metadata:
   uid: 1234567890abcdef
 spec:
   image: test
-  permissions:
-    - serviceName: oneimage
-      rules:
-        - verbs:
-            - create
-          apiGroups:
-            - "foo.io"
-          resources:
-            - "bar"
-          scope: "account"
-        - verbs:
-            - patch
-          apiGroups:
-            - "bar.io"
-          resources:
-            - "foo"
 status:
   namespace: app-created-namespace
   appImage:
@@ -29,6 +13,7 @@ status:
   appSpec:
     jobs:
       oneimage:
+        events: ["delete"]
         sidecars:
           left:
             image: "foo"
@@ -44,10 +29,3 @@ status:
         build:
           dockerfile: "Dockerfile"
           context: "."
-  conditions:
-  - type: defined
-    reason: Success
-    status: "True"
-    success: true
-  jobsStatus:
-    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/appinstance.yaml
@@ -88,4 +88,6 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    job1: {}
 ---

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.yaml.d/job.yaml
@@ -16,6 +16,7 @@ metadata:
     "global2": "value"
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
     "alljobsa": "value"
     "job1a": "value"
     "job3a": "value"

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/appinstance.yaml
@@ -58,3 +58,5 @@ status:
       reason: Success
       status: "True"
       success: true
+  jobsStatus:
+    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.yaml.d/job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/appinstance.yaml
@@ -81,3 +81,5 @@ status:
     reason: Success
     status: "True"
     success: true
+  jobsStatus:
+    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/jobs.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/jobs.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/appinstance.yaml
@@ -50,3 +50,5 @@ status:
     reason: Success
     status: "True"
     success: true
+  jobsStatus:
+    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/appdefinition/testdata/permissions/job/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/job/expected.yaml.d/job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/appinstance.yaml
@@ -80,3 +80,6 @@ status:
     reason: Success
     status: "True"
     success: true
+  jobsStatus:
+    oneimage: {}
+    twoimage: {}

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/job.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.yaml.d/job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"
@@ -63,6 +64,7 @@ metadata:
   namespace: app-created-namespace
   annotations:
     apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/jobs/finalize.go
+++ b/pkg/controller/jobs/finalize.go
@@ -109,12 +109,8 @@ func NeedsDestroyJobFinalization(next router.Handler) router.Handler {
 func FinalizeDestroyJob(req router.Request, resp router.Response) error {
 	app := req.Object.(*v1.AppInstance)
 	ns := &corev1.Namespace{}
-	if err := req.Get(ns, "", app.Namespace); err != nil {
+	if err := req.Get(ns, "", app.Namespace); err != nil || !ns.DeletionTimestamp.IsZero() {
 		return err
-	}
-
-	if !ns.DeletionTimestamp.IsZero() {
-		return nil
 	}
 
 	for jobName, jobDef := range app.Status.AppSpec.Jobs {

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -7149,7 +7149,13 @@ func schema_pkg_apis_internalacornio_v1_JobStatus(ref common.ReferenceCallback) 
 							Format: "",
 						},
 					},
-					"createDone": {
+					"createEventSucceeded": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"skipped": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",

--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -208,9 +208,7 @@ func (i *Interpolator) serviceProperty(svc *v1.ServiceInstance, prop string, ext
 	}()
 
 	switch prop {
-	case "secrets":
-		fallthrough
-	case "secret":
+	case "secret", "secrets":
 		if len(extra) != 2 {
 			return "", fmt.Errorf("invalid secret lookup on service [%s] key must be at least two parts, go %v", svc.Name, extra)
 		}
@@ -229,11 +227,7 @@ func (i *Interpolator) serviceProperty(svc *v1.ServiceInstance, prop string, ext
 		}
 		i.missing[i.serviceName] = append(i.missing[i.serviceName], "service endpoint "+svc.Name)
 		return "<pending>", nil
-	case "address":
-		fallthrough
-	case "host":
-		fallthrough
-	case "hostname":
+	case "address", "host", "hostname":
 		if svc.Spec.Address != "" {
 			return svc.Spec.Address, nil
 		}
@@ -242,9 +236,7 @@ func (i *Interpolator) serviceProperty(svc *v1.ServiceInstance, prop string, ext
 			return "", err
 		}
 		return fmt.Sprintf("%s.%s.%s", svc.Name, svc.Namespace, cfg.InternalClusterDomain), nil
-	case "port":
-		fallthrough
-	case "ports":
+	case "port", "ports":
 		if len(extra) != 1 {
 			return "", fmt.Errorf("can not lookup ports expecting single number, got [%s]", strings.Join(extra, "."))
 		}
@@ -302,9 +294,7 @@ func (i *Interpolator) resolve(token string) (string, bool, error) {
 	scheme, tail, ok := strings.Cut(token, "://")
 	if ok {
 		switch scheme {
-		case "secret":
-			fallthrough
-		case "secrets":
+		case "secret", "secrets":
 			parts := strings.Split(tail, "/")
 			if len(parts) == 2 {
 				return i.resolveSecrets([]string{parts[0]}, parts[1])
@@ -314,30 +304,22 @@ func (i *Interpolator) resolve(token string) (string, bool, error) {
 
 	parts := strings.Split(strings.TrimSpace(token), ".")
 	switch parts[0] {
-	case "service":
-		fallthrough
-	case "services":
+	case "service", "services":
 		if len(parts) < 3 {
 			return "", false, fmt.Errorf("invalid expression [%s], must have at least three parts separated by \".\"", token)
 		}
 		return i.resolveServices(parts[1:])
-	case "secret":
-		fallthrough
-	case "secrets":
+	case "secret", "secrets":
 		if len(parts) < 3 {
 			return "", false, fmt.Errorf("invalid expression [%s], must have at least three parts separated by \".\"", token)
 		}
 		return i.resolveSecrets(parts[1:len(parts)-1], parts[len(parts)-1])
-	case "acorn":
-		fallthrough
-	case "app":
+	case "acorn", "app":
 		if len(parts) != 2 {
 			return "", false, fmt.Errorf("invalid expression [%s], must have two parts separated by \".\"", token)
 		}
 		return i.resolveApp(parts[1])
-	case "image":
-		fallthrough
-	case "images":
+	case "image", "images":
 		if len(parts) != 2 {
 			return "", false, fmt.Errorf("invalid expression [%s], must have two parts separated by \".\"", token)
 		}


### PR DESCRIPTION
If a job is not expected to run for an event (like a delete job running on a create event), then the status checker would wait for the job to succeed before setting the app to a ready status. This will hang forever because the job will never run. After these changes, the status checker will ignore apps that are not expected to be created.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

