### PR TITLE
Prioritize remote images for auto-upgrade (#1496)

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -172,22 +172,20 @@ func (a AppInstanceStatus) GetDevMode() bool {
 }
 
 type AppInstanceStatus struct {
-	DevSession                   *DevSessionInstanceSpec `json:"devSession,omitempty"`
-	ObservedGeneration           int64                   `json:"observedGeneration,omitempty"`
-	ObservedImageDigest          string                  `json:"observedImageDigest,omitempty"`
-	Columns                      AppColumns              `json:"columns,omitempty"`
-	Ready                        bool                    `json:"ready,omitempty"`
-	Namespace                    string                  `json:"namespace,omitempty"`
-	AppImage                     AppImage                `json:"appImage,omitempty"`
-	AvailableAppImage            string                  `json:"availableAppImage,omitempty"`
-	AvailableAppImageDigest      string                  `json:"availableAppImageDigest,omitempty"`
-	ConfirmUpgradeAppImage       string                  `json:"confirmUpgradeAppImage,omitempty"`
-	ConfirmUpgradeAppImageDigest string                  `json:"confirmUpgradeAppImageDigest,omitempty"`
-	AppSpec                      AppSpec                 `json:"appSpec,omitempty"`
-	AppStatus                    AppStatus               `json:"appStatus,omitempty"`
-	Scheduling                   map[string]Scheduling   `json:"scheduling,omitempty"`
-	Conditions                   []Condition             `json:"conditions,omitempty"`
-	Defaults                     Defaults                `json:"defaults,omitempty"`
+	DevSession             *DevSessionInstanceSpec `json:"devSession,omitempty"`
+	ObservedGeneration     int64                   `json:"observedGeneration,omitempty"`
+	ObservedImageDigest    string                  `json:"observedImageDigest,omitempty"`
+	Columns                AppColumns              `json:"columns,omitempty"`
+	Ready                  bool                    `json:"ready,omitempty"`
+	Namespace              string                  `json:"namespace,omitempty"`
+	AppImage               AppImage                `json:"appImage,omitempty"`
+	AvailableAppImage      string                  `json:"availableAppImage,omitempty"`
+	ConfirmUpgradeAppImage string                  `json:"confirmUpgradeAppImage,omitempty"`
+	AppSpec                AppSpec                 `json:"appSpec,omitempty"`
+	AppStatus              AppStatus               `json:"appStatus,omitempty"`
+	Scheduling             map[string]Scheduling   `json:"scheduling,omitempty"`
+	Conditions             []Condition             `json:"conditions,omitempty"`
+	Defaults               Defaults                `json:"defaults,omitempty"`
 }
 
 type Defaults struct {

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -172,20 +172,22 @@ func (a AppInstanceStatus) GetDevMode() bool {
 }
 
 type AppInstanceStatus struct {
-	DevSession             *DevSessionInstanceSpec `json:"devSession,omitempty"`
-	ObservedGeneration     int64                   `json:"observedGeneration,omitempty"`
-	ObservedImageDigest    string                  `json:"observedImageDigest,omitempty"`
-	Columns                AppColumns              `json:"columns,omitempty"`
-	Ready                  bool                    `json:"ready,omitempty"`
-	Namespace              string                  `json:"namespace,omitempty"`
-	AppImage               AppImage                `json:"appImage,omitempty"`
-	AvailableAppImage      string                  `json:"availableAppImage,omitempty"`
-	ConfirmUpgradeAppImage string                  `json:"confirmUpgradeAppImage,omitempty"`
-	AppSpec                AppSpec                 `json:"appSpec,omitempty"`
-	AppStatus              AppStatus               `json:"appStatus,omitempty"`
-	Scheduling             map[string]Scheduling   `json:"scheduling,omitempty"`
-	Conditions             []Condition             `json:"conditions,omitempty"`
-	Defaults               Defaults                `json:"defaults,omitempty"`
+	DevSession                   *DevSessionInstanceSpec `json:"devSession,omitempty"`
+	ObservedGeneration           int64                   `json:"observedGeneration,omitempty"`
+	ObservedImageDigest          string                  `json:"observedImageDigest,omitempty"`
+	Columns                      AppColumns              `json:"columns,omitempty"`
+	Ready                        bool                    `json:"ready,omitempty"`
+	Namespace                    string                  `json:"namespace,omitempty"`
+	AppImage                     AppImage                `json:"appImage,omitempty"`
+	AvailableAppImage            string                  `json:"availableAppImage,omitempty"`
+	AvailableAppImageRemote      bool                    `json:"availableAppImageRemote,omitempty"`
+	ConfirmUpgradeAppImage       string                  `json:"confirmUpgradeAppImage,omitempty"`
+	ConfirmUpgradeAppImageRemote bool                    `json:"confirmUpgradeAppImageRemote,omitempty"`
+	AppSpec                      AppSpec                 `json:"appSpec,omitempty"`
+	AppStatus                    AppStatus               `json:"appStatus,omitempty"`
+	Scheduling                   map[string]Scheduling   `json:"scheduling,omitempty"`
+	Conditions                   []Condition             `json:"conditions,omitempty"`
+	Defaults                     Defaults                `json:"defaults,omitempty"`
 }
 
 type Defaults struct {

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -172,20 +172,22 @@ func (a AppInstanceStatus) GetDevMode() bool {
 }
 
 type AppInstanceStatus struct {
-	DevSession             *DevSessionInstanceSpec `json:"devSession,omitempty"`
-	ObservedGeneration     int64                   `json:"observedGeneration,omitempty"`
-	ObservedImageDigest    string                  `json:"observedImageDigest,omitempty"`
-	Columns                AppColumns              `json:"columns,omitempty"`
-	Ready                  bool                    `json:"ready,omitempty"`
-	Namespace              string                  `json:"namespace,omitempty"`
-	AppImage               AppImage                `json:"appImage,omitempty"`
-	AvailableAppImage      string                  `json:"availableAppImage,omitempty"`
-	ConfirmUpgradeAppImage string                  `json:"confirmUpgradeAppImage,omitempty"`
-	AppSpec                AppSpec                 `json:"appSpec,omitempty"`
-	AppStatus              AppStatus               `json:"appStatus,omitempty"`
-	Scheduling             map[string]Scheduling   `json:"scheduling,omitempty"`
-	Conditions             []Condition             `json:"conditions,omitempty"`
-	Defaults               Defaults                `json:"defaults,omitempty"`
+	DevSession                   *DevSessionInstanceSpec `json:"devSession,omitempty"`
+	ObservedGeneration           int64                   `json:"observedGeneration,omitempty"`
+	ObservedImageDigest          string                  `json:"observedImageDigest,omitempty"`
+	Columns                      AppColumns              `json:"columns,omitempty"`
+	Ready                        bool                    `json:"ready,omitempty"`
+	Namespace                    string                  `json:"namespace,omitempty"`
+	AppImage                     AppImage                `json:"appImage,omitempty"`
+	AvailableAppImage            string                  `json:"availableAppImage,omitempty"`
+	AvailableAppImageDigest      string                  `json:"availableAppImageDigest,omitempty"`
+	ConfirmUpgradeAppImage       string                  `json:"confirmUpgradeAppImage,omitempty"`
+	ConfirmUpgradeAppImageDigest string                  `json:"confirmUpgradeAppImageDigest,omitempty"`
+	AppSpec                      AppSpec                 `json:"appSpec,omitempty"`
+	AppStatus                    AppStatus               `json:"appStatus,omitempty"`
+	Scheduling                   map[string]Scheduling   `json:"scheduling,omitempty"`
+	Conditions                   []Condition             `json:"conditions,omitempty"`
+	Defaults                     Defaults                `json:"defaults,omitempty"`
 }
 
 type Defaults struct {

--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -243,23 +243,19 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 				mode, _ := Mode(app.Spec)
 				switch mode {
 				case "enabled":
-					if app.Status.AvailableAppImage == nextAppImage && app.Status.AvailableAppImageDigest == digest {
+					if app.Status.AvailableAppImage == nextAppImage {
 						d.appKeysPrevCheck[appKey] = updateTime
 						continue
 					}
 					app.Status.AvailableAppImage = nextAppImage
-					app.Status.AvailableAppImageDigest = digest
 					app.Status.ConfirmUpgradeAppImage = ""
-					app.Status.ConfirmUpgradeAppImageDigest = ""
 				case "notify":
-					if app.Status.ConfirmUpgradeAppImage == nextAppImage && app.Status.ConfirmUpgradeAppImageDigest == digest {
+					if app.Status.ConfirmUpgradeAppImage == nextAppImage {
 						d.appKeysPrevCheck[appKey] = updateTime
 						continue
 					}
 					app.Status.ConfirmUpgradeAppImage = nextAppImage
-					app.Status.ConfirmUpgradeAppImageDigest = digest
 					app.Status.AvailableAppImage = ""
-					app.Status.AvailableAppImageDigest = ""
 				default:
 					logrus.Warnf("Unrecognized auto-upgrade mode %v for %v", mode, app.Name)
 					continue

--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -243,19 +243,23 @@ func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v
 				mode, _ := Mode(app.Spec)
 				switch mode {
 				case "enabled":
-					if app.Status.AvailableAppImage == nextAppImage {
+					if app.Status.AvailableAppImage == nextAppImage && app.Status.AvailableAppImageDigest == digest {
 						d.appKeysPrevCheck[appKey] = updateTime
 						continue
 					}
 					app.Status.AvailableAppImage = nextAppImage
+					app.Status.AvailableAppImageDigest = digest
 					app.Status.ConfirmUpgradeAppImage = ""
+					app.Status.ConfirmUpgradeAppImageDigest = ""
 				case "notify":
-					if app.Status.ConfirmUpgradeAppImage == nextAppImage {
+					if app.Status.ConfirmUpgradeAppImage == nextAppImage && app.Status.ConfirmUpgradeAppImageDigest == digest {
 						d.appKeysPrevCheck[appKey] = updateTime
 						continue
 					}
 					app.Status.ConfirmUpgradeAppImage = nextAppImage
+					app.Status.ConfirmUpgradeAppImageDigest = digest
 					app.Status.AvailableAppImage = ""
+					app.Status.AvailableAppImageDigest = ""
 				default:
 					logrus.Warnf("Unrecognized auto-upgrade mode %v for %v", mode, app.Name)
 					continue

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -44,7 +44,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 		appInstance := req.Object.(*v1.AppInstance)
 		cond := condition.Setter(appInstance, resp, v1.AppInstanceConditionPulled)
 
-		target, digest, unknownReason := determineTargetImage(appInstance)
+		target, unknownReason := determineTargetImage(appInstance)
 		if target == "" {
 			if unknownReason != "" {
 				cond.Unknown(unknownReason)
@@ -54,19 +54,10 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 			return nil
 		}
 
-		var (
-			resolved string
-			err      error
-		)
-		// If we already have the digest, we don't need to resolve the image
-		if digest != "" {
-			resolved = fmt.Sprintf("%s@%s", target, digest)
-		} else {
-			resolved, _, err = client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
-			if err != nil {
-				cond.Error(err)
-				return nil
-			}
+		resolved, _, err := client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
+		if err != nil {
+			cond.Error(err)
+			return nil
 		}
 
 		var (
@@ -91,9 +82,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 		}
 		targetImage.Name = target
 		appInstance.Status.AvailableAppImage = ""
-		appInstance.Status.AvailableAppImageDigest = ""
 		appInstance.Status.ConfirmUpgradeAppImage = ""
-		appInstance.Status.ConfirmUpgradeAppImageDigest = ""
 		appInstance.Status.AppImage = *targetImage
 
 		cond.Success()
@@ -101,7 +90,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 	}
 }
 
-func determineTargetImage(appInstance *v1.AppInstance) (string, string, string) {
+func determineTargetImage(appInstance *v1.AppInstance) (string, string) {
 	_, on := autoupgrade.Mode(appInstance.Spec)
 	pattern, isPattern := autoupgrade.AutoUpgradePattern(appInstance.Spec.Image)
 
@@ -109,19 +98,15 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string, string) 
 		if appInstance.Status.AvailableAppImage != "" || appInstance.Status.ConfirmUpgradeAppImage != "" {
 			if appInstance.Status.AvailableAppImage != "" {
 				// AvailableAppImage is not blank, use it and reset the other fields
-				return appInstance.Status.AvailableAppImage, appInstance.Status.AvailableAppImageDigest, ""
+				return appInstance.Status.AvailableAppImage, ""
 			} else {
 				// ConfirmUpgradeAppImage is not blank. Normally, we shouldn't get the desiredImage from it. That should
 				// be done explicitly by the user via the apps/confirmupgrade subresource (which would set it to the
 				// AvailableAppImage field). But if AppImage.ID is blank, this app has never had an image pulled. So, do the initial pull.
 				if appInstance.Status.AppImage.Name == "" {
-					return appInstance.Status.ConfirmUpgradeAppImage, appInstance.Status.ConfirmUpgradeAppImageDigest, ""
+					return appInstance.Status.ConfirmUpgradeAppImage, ""
 				} else {
-					if appInstance.Status.ConfirmUpgradeAppImageDigest != "" {
-						return "", "", fmt.Sprintf("confirm upgrade to %v@%v", appInstance.Status.ConfirmUpgradeAppImage, appInstance.Status.ConfirmUpgradeAppImageDigest)
-					} else {
-						return "", "", fmt.Sprintf("confirm upgrade to %v", appInstance.Status.ConfirmUpgradeAppImage)
-					}
+					return "", fmt.Sprintf("confirm upgrade to %v", appInstance.Status.ConfirmUpgradeAppImage)
 				}
 			}
 		} else {
@@ -130,15 +115,15 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string, string) 
 				if appInstance.Status.AppImage.Name == "" {
 					// Need to trigger a sync since this app has never had a concrete image set
 					autoupgrade.Sync()
-					return "", "", fmt.Sprintf("waiting for image to satisfy auto-upgrade tag %v", pattern)
+					return "", fmt.Sprintf("waiting for image to satisfy auto-upgrade tag %v", pattern)
 				} else {
-					return "", "", ""
+					return "", ""
 				}
 			} else {
 				if appInstance.Spec.Image == appInstance.Status.AppImage.Name {
-					return "", "", ""
+					return "", ""
 				} else {
-					return appInstance.Spec.Image, "", ""
+					return appInstance.Spec.Image, ""
 				}
 			}
 		}
@@ -146,9 +131,9 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string, string) 
 		// Auto-upgrade is off. Only need to pull if spec and status are not equal or we're trying to trigger a repull
 		if appInstance.Spec.Image != appInstance.Status.AppImage.Name ||
 			appInstance.Status.AvailableAppImage == appInstance.Spec.Image {
-			return appInstance.Spec.Image, "", ""
+			return appInstance.Spec.Image, ""
 		} else {
-			return "", "", ""
+			return "", ""
 		}
 	}
 }

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -54,10 +54,19 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 			return nil
 		}
 
-		resolved, _, err := client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
-		if err != nil {
-			cond.Error(err)
-			return nil
+		// skip the attempt to locally resolve if we already know that the image will be remote
+		var (
+			resolved string
+			err      error
+		)
+		if !appInstance.Status.AvailableAppImageRemote {
+			resolved, _, err = client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
+			if err != nil {
+				cond.Error(err)
+				return nil
+			}
+		} else {
+			resolved = target
 		}
 
 		var (

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -44,7 +44,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 		appInstance := req.Object.(*v1.AppInstance)
 		cond := condition.Setter(appInstance, resp, v1.AppInstanceConditionPulled)
 
-		target, unknownReason := determineTargetImage(appInstance)
+		target, digest, unknownReason := determineTargetImage(appInstance)
 		if target == "" {
 			if unknownReason != "" {
 				cond.Unknown(unknownReason)
@@ -54,10 +54,19 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 			return nil
 		}
 
-		resolved, _, err := client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
-		if err != nil {
-			cond.Error(err)
-			return nil
+		var (
+			resolved string
+			err      error
+		)
+		// If we already have the digest, we don't need to resolve the image
+		if digest != "" {
+			resolved = fmt.Sprintf("%s@%s", target, digest)
+		} else {
+			resolved, _, err = client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
+			if err != nil {
+				cond.Error(err)
+				return nil
+			}
 		}
 
 		var (
@@ -82,7 +91,9 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 		}
 		targetImage.Name = target
 		appInstance.Status.AvailableAppImage = ""
+		appInstance.Status.AvailableAppImageDigest = ""
 		appInstance.Status.ConfirmUpgradeAppImage = ""
+		appInstance.Status.ConfirmUpgradeAppImageDigest = ""
 		appInstance.Status.AppImage = *targetImage
 
 		cond.Success()
@@ -90,7 +101,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 	}
 }
 
-func determineTargetImage(appInstance *v1.AppInstance) (string, string) {
+func determineTargetImage(appInstance *v1.AppInstance) (string, string, string) {
 	_, on := autoupgrade.Mode(appInstance.Spec)
 	pattern, isPattern := autoupgrade.AutoUpgradePattern(appInstance.Spec.Image)
 
@@ -98,15 +109,19 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string) {
 		if appInstance.Status.AvailableAppImage != "" || appInstance.Status.ConfirmUpgradeAppImage != "" {
 			if appInstance.Status.AvailableAppImage != "" {
 				// AvailableAppImage is not blank, use it and reset the other fields
-				return appInstance.Status.AvailableAppImage, ""
+				return appInstance.Status.AvailableAppImage, appInstance.Status.AvailableAppImageDigest, ""
 			} else {
 				// ConfirmUpgradeAppImage is not blank. Normally, we shouldn't get the desiredImage from it. That should
 				// be done explicitly by the user via the apps/confirmupgrade subresource (which would set it to the
 				// AvailableAppImage field). But if AppImage.ID is blank, this app has never had an image pulled. So, do the initial pull.
 				if appInstance.Status.AppImage.Name == "" {
-					return appInstance.Status.ConfirmUpgradeAppImage, ""
+					return appInstance.Status.ConfirmUpgradeAppImage, appInstance.Status.ConfirmUpgradeAppImageDigest, ""
 				} else {
-					return "", fmt.Sprintf("confirm upgrade to %v", appInstance.Status.ConfirmUpgradeAppImage)
+					if appInstance.Status.ConfirmUpgradeAppImageDigest != "" {
+						return "", "", fmt.Sprintf("confirm upgrade to %v@%v", appInstance.Status.ConfirmUpgradeAppImage, appInstance.Status.ConfirmUpgradeAppImageDigest)
+					} else {
+						return "", "", fmt.Sprintf("confirm upgrade to %v", appInstance.Status.ConfirmUpgradeAppImage)
+					}
 				}
 			}
 		} else {
@@ -115,15 +130,15 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string) {
 				if appInstance.Status.AppImage.Name == "" {
 					// Need to trigger a sync since this app has never had a concrete image set
 					autoupgrade.Sync()
-					return "", fmt.Sprintf("waiting for image to satisfy auto-upgrade tag %v", pattern)
+					return "", "", fmt.Sprintf("waiting for image to satisfy auto-upgrade tag %v", pattern)
 				} else {
-					return "", ""
+					return "", "", ""
 				}
 			} else {
 				if appInstance.Spec.Image == appInstance.Status.AppImage.Name {
-					return "", ""
+					return "", "", ""
 				} else {
-					return appInstance.Spec.Image, ""
+					return appInstance.Spec.Image, "", ""
 				}
 			}
 		}
@@ -131,9 +146,9 @@ func determineTargetImage(appInstance *v1.AppInstance) (string, string) {
 		// Auto-upgrade is off. Only need to pull if spec and status are not equal or we're trying to trigger a repull
 		if appInstance.Spec.Image != appInstance.Status.AppImage.Name ||
 			appInstance.Status.AvailableAppImage == appInstance.Spec.Image {
-			return appInstance.Spec.Image, ""
+			return appInstance.Spec.Image, "", ""
 		} else {
-			return "", ""
+			return "", "", ""
 		}
 	}
 }

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -59,7 +59,7 @@ func TestDetermineDesiredImage(t *testing.T) {
 
 func testTargetImage(t *testing.T, appInstance *v1.AppInstance, expectedTargetImage string, expectedUnknownReason string) {
 	t.Helper()
-	actualTargetImage, _, actualUnknownReason := determineTargetImage(appInstance)
+	actualTargetImage, actualUnknownReason := determineTargetImage(appInstance)
 	assert.Equal(t, expectedTargetImage, actualTargetImage)
 	assert.Equal(t, expectedUnknownReason, actualUnknownReason)
 }

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -59,7 +59,7 @@ func TestDetermineDesiredImage(t *testing.T) {
 
 func testTargetImage(t *testing.T, appInstance *v1.AppInstance, expectedTargetImage string, expectedUnknownReason string) {
 	t.Helper()
-	actualTargetImage, actualUnknownReason := determineTargetImage(appInstance)
+	actualTargetImage, _, actualUnknownReason := determineTargetImage(appInstance)
 	assert.Equal(t, expectedTargetImage, actualTargetImage)
 	assert.Equal(t, expectedUnknownReason, actualUnknownReason)
 }

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -5530,9 +5530,21 @@ func schema_pkg_apis_internalacornio_v1_AppInstanceStatus(ref common.ReferenceCa
 							Format: "",
 						},
 					},
+					"availableAppImageRemote": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"confirmUpgradeAppImage": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"confirmUpgradeAppImageRemote": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},

--- a/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
+++ b/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
@@ -38,6 +38,7 @@ func (s *ConfirmUpgradeStrategy) Create(ctx context.Context, obj types.Object) (
 		return nil, err
 	}
 	app.Status.AvailableAppImage = app.Status.ConfirmUpgradeAppImage
+	app.Status.AvailableAppImageRemote = app.Status.ConfirmUpgradeAppImageRemote
 
 	err = s.client.Status().Update(ctx, app)
 	if err != nil {

--- a/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
+++ b/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
@@ -38,7 +38,6 @@ func (s *ConfirmUpgradeStrategy) Create(ctx context.Context, obj types.Object) (
 		return nil, err
 	}
 	app.Status.AvailableAppImage = app.Status.ConfirmUpgradeAppImage
-	app.Status.AvailableAppImageDigest = app.Status.ConfirmUpgradeAppImageDigest
 
 	err = s.client.Status().Update(ctx, app)
 	if err != nil {

--- a/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
+++ b/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
@@ -38,6 +38,7 @@ func (s *ConfirmUpgradeStrategy) Create(ctx context.Context, obj types.Object) (
 		return nil, err
 	}
 	app.Status.AvailableAppImage = app.Status.ConfirmUpgradeAppImage
+	app.Status.AvailableAppImageDigest = app.Status.ConfirmUpgradeAppImageDigest
 
 	err = s.client.Status().Update(ctx, app)
 	if err != nil {


### PR DESCRIPTION
for #1496

These changes add new fields to the AppInstanceStatus so that the autoupgrade daemon can effectively communicate when an available image is from a remote repository and not available locally within Acorn.

Previously, it would communicate with just the tag (i.e. `docker.io/grantlinville/myimage:latest`) and the pullAppImage function would always attempt to resolve that tag locally. If any local image matches that tag, it will be used, even if a newer image is available remotely. So this makes it skip that local resolution when needed.

I discovered some other bugs while implementing this (that were also present prior to these changes), which I documented in #1662.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

