### PR TITLE
Ensure create jobs are only run once (#1642)

### DIFF
--- a/pkg/controller/appdefinition/jobs.go
+++ b/pkg/controller/appdefinition/jobs.go
@@ -123,6 +123,7 @@ func toJob(req router.Request, appInstance *v1.AppInstance, pullSecrets *PullSec
 		appInstance.Status.AppSpec.Annotations, container.Annotations, appInstance.Spec.Annotations))
 
 	jobSpec := batchv1.JobSpec{
+		Suspend: appInstance.Spec.Stop,
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: jobLabels(appInstance, container, name,

--- a/pkg/controller/appdefinition/jobs_test.go
+++ b/pkg/controller/appdefinition/jobs_test.go
@@ -27,3 +27,7 @@ func TestCronJobs(t *testing.T) {
 func TestDeleteJob(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/job/delete-job", DeploySpec)
 }
+
+func TestJobAppStopped(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/job/stopped-app", DeploySpec)
+}

--- a/pkg/controller/appdefinition/testdata/job/stopped-app/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/job/stopped-app/expected.yaml
@@ -1,0 +1,110 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: oneimage
+  namespace: app-created-namespace
+  annotations:
+    apply.acorn.io/prune: "false"
+    apply.acorn.io/update: "true"
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    acorn.io/app-public-name: "app-name"
+    "acorn.io/job-name": "oneimage"
+    "acorn.io/managed": "true"
+spec:
+  suspend: true
+  backoffLimit: 1000
+  template:
+    metadata:
+      labels:
+        "acorn.io/app-namespace": "app-namespace"
+        "acorn.io/app-name": "app-name"
+        acorn.io/app-public-name: "app-name"
+        "acorn.io/job-name": "oneimage"
+        "acorn.io/managed": "true"
+      annotations:
+        acorn.io/container-spec: '{"build":{"context":".","dockerfile":"Dockerfile"},"image":"image-name","ports":[{"port":80,"protocol":"http","targetPort":81}],"probes":null,"sidecars":{"left":{"image":"foo","ports":[{"port":90,"protocol":"tcp","targetPort":91}],"probes":null}}}'
+    spec:
+      imagePullSecrets:
+        - name: oneimage-pull-1234567890ab
+      restartPolicy: Never
+      serviceAccountName: oneimage
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: oneimage
+          image: "image-name"
+          readinessProbe:
+            tcpSocket:
+              port: 81
+          ports:
+            - containerPort: 81
+              protocol: "TCP"
+          terminationMessagePath: "/run/secrets/output"
+          env:
+            - name: ACORN_EVENT
+              value: "create"
+        - name: left
+          env:
+            - name: ACORN_EVENT
+              value: "create"
+          image: "foo"
+          readinessProbe:
+            tcpSocket:
+              port: 91
+          ports:
+            - containerPort: 91
+              protocol: "TCP"
+          terminationMessagePath: "/run/secrets/output"
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: oneimage-pull-1234567890ab
+  namespace: app-created-namespace
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+type: "kubernetes.io/dockerconfigjson"
+data:
+  ".dockerconfigjson": eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+---
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  stop: true
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    jobs:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+          - port: 80
+            targetPort: 81
+            protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."
+  conditions:
+    - type: defined
+      reason: Success
+      status: "True"
+      success: true
+  jobsStatus:
+    oneimage: {}

--- a/pkg/controller/appdefinition/testdata/job/stopped-app/expected.yaml.d/serviceaccount.yaml
+++ b/pkg/controller/appdefinition/testdata/job/stopped-app/expected.yaml.d/serviceaccount.yaml
@@ -1,0 +1,11 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: oneimage
+  namespace: app-created-namespace
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-public-name: "app-name"
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/job-name: "oneimage"

--- a/pkg/controller/appdefinition/testdata/job/stopped-app/input.yaml
+++ b/pkg/controller/appdefinition/testdata/job/stopped-app/input.yaml
@@ -1,0 +1,31 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  stop: true
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    jobs:
+      oneimage:
+        sidecars:
+          left:
+            image: "foo"
+            ports:
+              - port: 90
+                targetPort: 91
+                protocol: tcp
+        ports:
+        - port: 80
+          targetPort: 81
+          protocol: http
+        image: "image-name"
+        build:
+          dockerfile: "Dockerfile"
+          context: "."

--- a/pkg/controller/appstatus/status.go
+++ b/pkg/controller/appstatus/status.go
@@ -293,7 +293,9 @@ func JobStatus(req router.Request, resp router.Response) error {
 			messageSet.Insert(message...)
 		}
 		jobStatus := v1.JobStatus{
-			Message: strings.Join(messageSet.List(), "; "),
+			Message:              strings.Join(messageSet.List(), "; "),
+			CreateEventSucceeded: app.Status.JobsStatus[job.Name].CreateEventSucceeded,
+			Skipped:              app.Status.JobsStatus[job.Name].Skipped,
 		}
 		if job.Status.Active > 0 {
 			jobStatus.Running = true


### PR DESCRIPTION
If a create job is also an update job, then we would lose track of the create "doneness" of the job. After this change, it should be maintained for the life of the app.

Additionally, if an app is stopped, then jobs will be suspended.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

