### PR TITLE
Make service default a bit more explicit

### DIFF
--- a/pkg/controller/appdefinition/testdata/acorn/labels/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/labels/expected.yaml.d/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   appName: app-name
   appNamespace: app-namespace
-  default: true
+  default: false
   external: app-name.acorn-name
   annotations:
     allacornsa: value

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set-overwrite-computeclass/expected.yaml.d/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   appName: app-name
   appNamespace: app-namespace
-  default: true
+  default: false
   labels:
     "acorn.io/app-namespace": "app-namespace"
     "acorn.io/app-name": "app-name"

--- a/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/all-set/expected.yaml.d/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   appName: app-name
   appNamespace: app-namespace
-  default: true
+  default: false
   container: oneimage
   labels:
     "acorn.io/app-namespace": "app-namespace"

--- a/pkg/controller/appdefinition/testdata/computeclass/container/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/container/expected.yaml.d/service.yaml
@@ -10,7 +10,7 @@ metadata:
     "acorn.io/container-name": "oneimage"
     "acorn.io/public-name": "app-name.oneimage"
 spec:
-  default: true
+  default: false
   appName: app-name
   appNamespace: app-namespace
   labels:

--- a/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/overwrite-acornfile-computeclass/expected.yaml.d/service.yaml
@@ -10,7 +10,7 @@ metadata:
     "acorn.io/container-name": "oneimage"
     "acorn.io/public-name": "app-name.oneimage"
 spec:
-  default: true
+  default: false
   appName: app-name
   appNamespace: app-namespace
   labels:

--- a/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/computeclass/with-acornfile-computeclass/expected.yaml.d/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   appName: app-name
   appNamespace: app-namespace
-  default: true
+  default: false
   container: oneimage
   labels:
     "acorn.io/app-namespace": "app-namespace"

--- a/pkg/controller/appdefinition/testdata/deployspec/basic/expected.yaml
+++ b/pkg/controller/appdefinition/testdata/deployspec/basic/expected.yaml
@@ -145,7 +145,7 @@ spec:
     "acorn.io/app-name": "app-name"
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
-  default: true
+  default: false
   container: oneimage
   type: ClusterIP
   ports:

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.yaml.d/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   appName: app-name
   appNamespace: app-namespace
-  default: true
+  default: false
   external: app-name.acorn-name
   labels:
     "acorn.io/app-namespace": "app-namespace"

--- a/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/clusterdomainport/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/container-name": "oneimage"
     "acorn.io/managed": "true"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/labels/expected.yaml.d/service.yaml
@@ -28,7 +28,7 @@ spec:
     "cona3": "value"
     "globala1": "value"
     "globala2": "value"
-  default: true
+  default: false
   container: con1
   ports:
     - port: 80

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-1/expected.yaml.d/service.yaml
@@ -28,7 +28,7 @@ spec:
     "cona3": "value"
     "globala1": "value"
     "globala2": "value"
-  default: true
+  default: false
   container: con1
   ports:
     - port: 80

--- a/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/ingress/prefix/prefix-2/expected.yaml.d/service.yaml
@@ -10,7 +10,7 @@ metadata:
     "acorn.io/managed": "true"
     "acorn.io/public-name": "app-name.con1"
 spec:
-  default: true
+  default: false
   appName: app-name
   appNamespace: app-namespace
   labels:

--- a/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set-overwrite/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/memory/all-set/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/all-set/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/memory/container/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/container/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/overwrite-acornfile-memory/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/memory/sidecar/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/sidecar/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/memory/with-acornfile-memory/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "twoimage"
   container: twoimage
-  default: true
+  default: false
   type: ClusterIP
   ports:
     - port: 80

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "twoimage"
   container: twoimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/permissions/container/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/container/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/permissions/containerwithnamespace/expected.yaml.d/service.yaml
@@ -18,7 +18,7 @@ spec:
     "acorn.io/managed": "true"
     "acorn.io/container-name": "oneimage"
   container: oneimage
-  default: true
+  default: false
   ports:
     - port: 80
       targetPort: 81

--- a/pkg/controller/appdefinition/testdata/router/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/router/expected.yaml.d/service.yaml
@@ -56,7 +56,7 @@ spec:
   appName: app-name
   appNamespace: app-namespace
   publishMode: all
-  default: false
+  default: true
   labels:
     acorn.io/app-name: app-name
     acorn.io/app-namespace: app-namespace

--- a/pkg/controller/service/testdata/router/expected.yaml.d/service.yaml
+++ b/pkg/controller/service/testdata/router/expected.yaml.d/service.yaml
@@ -1,27 +1,6 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: app-name
-  namespace: app-namespace
-  labels:
-    acorn.io/app-name: app-name
-    acorn.io/app-namespace: app-namespace
-    acorn.io/managed: "true"
-    acorn.io/router-name: router-name
-spec:
-  ports:
-    - appProtocol: HTTP
-      name: "80"
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-  type: ExternalName
-  externalName: router-name.app-created-namespace.svc.cluster.local
----
-
-kind: Service
-apiVersion: v1
-metadata:
   name: router-name
   namespace: app-created-namespace
   labels:

--- a/pkg/controller/service/testdata/router/input.yaml
+++ b/pkg/controller/service/testdata/router/input.yaml
@@ -13,7 +13,7 @@ spec:
   publishMode: all
   appName: app-name
   appNamespace: app-namespace
-  default: true
+  default: false
   routes:
   - pathType: exact
     path: /foo

--- a/pkg/services/acorn.go
+++ b/pkg/services/acorn.go
@@ -284,6 +284,19 @@ func ToAcornServices(ctx context.Context, c kclient.Client, appInstance *v1.AppI
 	if err != nil {
 		return nil, err
 	}
+
+	defaultFound := false
+	for _, obj := range objs {
+		if defaultFound {
+			obj.(*v1.ServiceInstance).Spec.Default = false
+		} else if obj.(*v1.ServiceInstance).Spec.Default {
+			defaultFound = true
+		}
+	}
+	if !defaultFound && len(objs) > 0 {
+		objs[0].(*v1.ServiceInstance).Spec.Default = true
+	}
+
 	result = append(result, objs...)
 	result = append(result, forAcorns(appInstance)...)
 	result = append(result, forContainers(appInstance)...)
@@ -293,11 +306,6 @@ func ToAcornServices(ctx context.Context, c kclient.Client, appInstance *v1.AppI
 		return nil, err
 	}
 	result = append(result, routers...)
-
-	// determine default before adding linked services
-	if len(result) == 1 {
-		result[0].(*v1.ServiceInstance).Spec.Default = true
-	}
 
 	result = append(result, forLinkedServices(appInstance)...)
 	return


### PR DESCRIPTION
A default services is only assigned by default to the first alphabetically
listed service entry in the Acornfile.

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

