### PR TITLE
change: appname must be DNS-1035 compliant (no leading numeric char) (#1590)

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apps/validator_test.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator_test.go
@@ -6,7 +6,66 @@ import (
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	internalv1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestValidateAppName(t *testing.T) {
+	validator := &Validator{}
+
+	tests := []struct {
+		name        string
+		appName     string
+		expectValid bool
+	}{
+		{
+			name:        "Invalid Name: Underscore",
+			appName:     "my_app",
+			expectValid: false,
+		},
+		{
+			name:        "Invalid Name: Uppercase",
+			appName:     "MyApp",
+			expectValid: false,
+		},
+		{
+			name:        "Invalid Name: Starts with number",
+			appName:     "1app",
+			expectValid: false,
+		},
+		{
+			name:        "Invalid Name: Starts with dash",
+			appName:     "-app",
+			expectValid: false,
+		},
+		{
+			name:        "Invalid Name: Ends with dash",
+			appName:     "app-",
+			expectValid: false,
+		},
+		{
+			name:        "Valid Name: Lowercase",
+			appName:     "myapp",
+			expectValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &apiv1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tt.appName,
+				},
+			}
+			err := validator.validateName(app)
+			if tt.expectValid && err != nil {
+				t.Fatalf("Expected valid, got error: %v", err)
+			}
+			if !tt.expectValid && err == nil {
+				t.Fatalf("Expected error, got nil")
+			}
+		})
+	}
+}
 
 func TestCannotChangeAppRegion(t *testing.T) {
 	validator := &Validator{}


### PR DESCRIPTION
Ref #1590 

The appname is a critical reference throughout Acorn's logic, so it has to work everywhere in names.
It broke on service objects, so we tighten the restrictions to make them DNS-1035 compliant.
Basically that takes away the option to have an appname starting with a number.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

