### PR TITLE
Fix nightly EKS tests and up test-summary action's version

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build test summary
         id: test_summary
-        uses: test-summary/action@v1
+        uses: test-summary/action@v2
         if: success() || failure()
         with:
           paths: test-summary.xml

--- a/integration/run/run_test.go
+++ b/integration/run/run_test.go
@@ -1574,11 +1574,11 @@ func TestEnforcedQuota(t *testing.T) {
 	}
 
 	// Annotate the project to enforce quota.
-	project = helper.WaitForObject(t, helper.Watcher(t, c), &corev1.NamespaceList{}, project, func(obj *corev1.Namespace) bool {
-		if project.Annotations == nil {
-			project.Annotations = make(map[string]string)
+	helper.WaitForObject(t, helper.Watcher(t, c), &corev1.NamespaceList{}, project, func(obj *corev1.Namespace) bool {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
 		}
-		project.Annotations[labels.ProjectEnforcedQuotaAnnotation] = "true"
+		obj.Annotations[labels.ProjectEnforcedQuotaAnnotation] = "true"
 		return kclient.Update(ctx, obj) == nil
 	})
 


### PR DESCRIPTION
Through some trial and error, I figured out that there was a typo causing the quota annotation for the project to not be properly updated. Also, I am updating the test summary action so that we can get numeric counts of test cases that failed.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

