### PR TITLE
Determine container port uniqueness based on targetPort rather than port (#1402)

### DIFF
--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -199,10 +199,10 @@ func collectPorts(seen map[int32]struct{}, ports []v1.PortDef, devMode bool) (re
 		if !devMode && port.Dev {
 			continue
 		}
-		if _, ok := seen[port.Port]; ok {
+		if _, ok := seen[port.TargetPort]; ok {
 			continue
 		}
-		seen[port.Port] = struct{}{}
+		seen[port.TargetPort] = struct{}{}
 		result = append(result, port)
 	}
 	return


### PR DESCRIPTION
for #1402

When creating Services for a new Acorn Container, this `collectPorts` function was distinguishing ports and performing deduplication based on the `Port` field, which is `0` if not set and is an optional field. The `TargetPort` field is filled always, so it makes more sense to use that as the unique identifier.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

