### PR TITLE
fix: use remote images by short ID (#1563)

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -86,9 +86,6 @@ func ResolveLocal(ctx context.Context, c kclient.Client, namespace, image string
 		}
 	} else if err != nil {
 		return "", false, err
-	} else if !localImage.Remote {
-		// The name will match the name we used to lookup, so trim the digest
-		return strings.TrimPrefix(localImage.Digest, "sha256:"), true, nil
 	}
-	return image, false, nil
+	return strings.TrimPrefix(localImage.Digest, "sha256:"), !localImage.Remote, nil
 }


### PR DESCRIPTION
... resolvelocal should always return full ID if image is found

Ref #1563

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

