### PR TITLE
fix: make IARs without signature rules work again (#1678)

### DIFF
--- a/pkg/imageallowrules/imageallowrules.go
+++ b/pkg/imageallowrules/imageallowrules.go
@@ -104,10 +104,6 @@ func CheckImageAgainstRules(ctx context.Context, c client.Reader, namespace stri
 		image = digestRef.Name()
 	}
 
-	if err := cosign.EnsureReferences(ctx, c, image, &verifyOpts); err != nil {
-		return fmt.Errorf("error ensuring references for image %s: %w", image, err)
-	}
-
 iarLoop:
 	for _, imageAllowRule := range imageAllowRules {
 		// Check if the image is in scope of the ImageAllowRule
@@ -118,6 +114,9 @@ iarLoop:
 		// > Signatures
 		// Any verification error or failed verification issue will skip on to the next IAR
 		for _, rule := range imageAllowRule.Signatures.Rules {
+			if err := cosign.EnsureReferences(ctx, c, image, &verifyOpts); err != nil {
+				return fmt.Errorf("error ensuring references for image %s: %w", image, err)
+			}
 			verifyOpts.AnnotationRules = rule.Annotations
 
 			// allOf: all signatures must pass verification


### PR DESCRIPTION
- move EnsureReferences back into the signature rules loop so that we only check for the signature artifact if we intend to check it

Ref #1678

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

