### PR TITLE
Fix collectPorts by detecting duplicate ports and targetPorts (#1402)

### DIFF
--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -194,15 +194,23 @@ func matches(binding v1.PortPublish, port v1.PortDef) bool {
 		portMatches(binding, port)
 }
 
-func collectPorts(seen map[int32]struct{}, ports []v1.PortDef, devMode bool) (result []v1.PortDef) {
+func collectPorts(seen, seenTargets map[int32]struct{}, ports []v1.PortDef, devMode bool) (result []v1.PortDef) {
 	for _, port := range ports {
 		if !devMode && port.Dev {
 			continue
 		}
-		if _, ok := seen[port.TargetPort]; ok {
+
+		if _, ok := seen[port.Port]; ok {
+			continue
+		} else if _, ok := seenTargets[port.TargetPort]; ok {
 			continue
 		}
-		seen[port.TargetPort] = struct{}{}
+
+		if port.Port != 0 {
+			seen[port.Port] = struct{}{}
+		}
+		seenTargets[port.TargetPort] = struct{}{}
+
 		result = append(result, port)
 	}
 	return
@@ -220,10 +228,11 @@ func FilterDevPorts(ports []v1.PortDef, devMode bool) (result []v1.PortDef) {
 
 func CollectContainerPorts(container *v1.Container, devMode bool) (result []v1.PortDef) {
 	seen := map[int32]struct{}{}
+	seenTargets := map[int32]struct{}{}
 
-	result = append(result, collectPorts(seen, container.Ports, devMode)...)
+	result = append(result, collectPorts(seen, seenTargets, container.Ports, devMode)...)
 	for _, entry := range typed.Sorted(container.Sidecars) {
-		result = append(result, collectPorts(seen, entry.Value.Ports, devMode)...)
+		result = append(result, collectPorts(seen, seenTargets, entry.Value.Ports, devMode)...)
 	}
 
 	return

--- a/pkg/ports/publish.go
+++ b/pkg/ports/publish.go
@@ -208,7 +208,13 @@ func collectPorts(seen, seenTargets map[int32]struct{}, ports []v1.PortDef, devM
 
 		if port.Port != 0 {
 			seen[port.Port] = struct{}{}
+		} else {
+			// If port.Port is 0, that means only the TargetPort has been defined, and not the public-facing Port.
+			// The public-facing Port will ultimately use the same number as the TargetPort, so we add TargetPort to
+			// the Port "seen" map in that case.
+			seen[port.TargetPort] = struct{}{}
 		}
+
 		seenTargets[port.TargetPort] = struct{}{}
 
 		result = append(result, port)


### PR DESCRIPTION
for #1402

I realized there was a mistake with my previous fix (#1681) because it no longer detects duplicate ports (only duplicate targetPorts), which is something we still need to do in case the user specifies something like `8080:80, 8080:8000`. This new PR makes it check for uniqueness on both fields.

In cases where the Port is 0 but the TargetPort is defined, this means that no public-facing port number was explicitly defined by the user, and the public-facing port will end up just matching the TargetPort. I also added logic to prevent duplication from happening if the user were to specify something like `8080, 8080:8000`.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

