### PR TITLE
Clean up output of help messages for acorn run and update commands (#1358)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -64,8 +64,6 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
   -o, --output string     Output API request without creating app (json, yaml)
       --profile strings   Profile to assign default values
   -q, --quiet             Do not print status
-      --replace           Replace the app with only defined values, resetting undefined fields to default values
-  -u, --update            Update the app if it already exists
       --wait              Wait for app to become ready before command exiting (default: true)
 ```
 

--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -16,13 +16,14 @@ acorn update [flags] APP_NAME [deploy flags]
       --confirm-upgrade   When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade.
   -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
   -h, --help              help for update
+      --help-advanced     Show verbose help text
+      --image string      Acorn image name
   -n, --name string       Name of app to create
       --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
   -o, --output string     Output API request without creating app (json, yaml)
       --profile strings   Profile to assign default values
       --pull              Re-pull the app's image, which will cause the app to re-deploy if the image has changed
   -q, --quiet             Do not print status
-      --replace           Replace the app with only defined values, resetting undefined fields to default values
       --wait              Wait for app to become ready before command exiting (default: true)
 ```
 

--- a/docs/docs/50-running/65-update-acorns.md
+++ b/docs/docs/50-running/65-update-acorns.md
@@ -52,7 +52,7 @@ The purpose of using -- is to distinguish between command-line options (flags) a
 :::
 
 
-### acorn --replace
+### run --replace
 Similarly to `acorn run --update`, `acorn run --replace` will create or update an existing acorn with ONLY the provided flags and args. Any previous modifications will be replaced.
 
 If we attempt a replace on the previous acorn, we should see the label be dropped

--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -4,6 +4,8 @@ import (
 	"io"
 
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
+	"github.com/acorn-io/acorn/pkg/dev"
+	"github.com/acorn-io/acorn/pkg/imagesource"
 	"github.com/spf13/cobra"
 )
 
@@ -44,13 +46,23 @@ type Dev struct {
 }
 
 func (s *Dev) Run(cmd *cobra.Command, args []string) error {
-	run := Run{
-		RunArgs:           s.RunArgs,
-		Dev:               true,
-		BidirectionalSync: s.BidirectionalSync,
-		Replace:           s.Replace,
-		out:               s.out,
-		client:            s.client,
+	c, err := s.client.CreateDefault()
+	if err != nil {
+		return err
 	}
-	return run.Run(cmd, args)
+
+	imageSource := imagesource.NewImageSource(s.File, args, s.Profile, nil)
+
+	opts, err := s.ToOpts()
+	if err != nil {
+		return err
+	}
+
+	return dev.Dev(cmd.Context(), c, &dev.Options{
+		ImageSource:       imageSource,
+		Run:               opts,
+		Replace:           s.Replace,
+		Dangerous:         s.Dangerous,
+		BidirectionalSync: s.BidirectionalSync,
+	})
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -12,7 +12,6 @@ import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
-	"github.com/acorn-io/acorn/pkg/dev"
 	"github.com/acorn-io/acorn/pkg/imagesource"
 	"github.com/acorn-io/acorn/pkg/rulerequest"
 	"github.com/acorn-io/acorn/pkg/wait"
@@ -126,17 +125,15 @@ More Usages:
         acorn run --volume mydata:data .`
 
 var hideRunFlags = []string{"dangerous", "memory", "target-namespace", "secret", "volume", "region", "publish-all",
-	"publish", "link", "label", "interval", "env", "compute-class", "annotation", "dev", "bidirectional-sync"}
+	"publish", "link", "label", "interval", "env", "compute-class", "annotation"}
 
 type Run struct {
 	RunArgs
-	Dev               bool  `usage:"Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit" short:"i"`
-	BidirectionalSync bool  `usage:"In interactive mode download changes in addition to uploading" short:"b"`
-	Wait              *bool `usage:"Wait for app to become ready before command exiting (default: true)"`
-	Quiet             bool  `usage:"Do not print status" short:"q"`
-	Update            bool  `usage:"Update the app if it already exists" short:"u"`
-	Replace           bool  `usage:"Replace the app with only defined values, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
-	HelpAdvanced      bool  `usage:"Show verbose help text"`
+	Wait         *bool `usage:"Wait for app to become ready before command exiting (default: true)"`
+	Quiet        bool  `usage:"Do not print status" short:"q"`
+	Update       bool  `usage:"Update the app if it already exists" short:"u"`
+	Replace      bool  `usage:"Replace the app with only defined values, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
+	HelpAdvanced bool  `usage:"Show verbose help text"`
 
 	out    io.Writer
 	client ClientFactory
@@ -261,16 +258,6 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	_, err = c.Info(cmd.Context())
 	if err != nil {
 		return err
-	}
-
-	if s.Dev {
-		return dev.Dev(cmd.Context(), c, &dev.Options{
-			ImageSource:       imageSource,
-			Run:               opts,
-			Replace:           s.Replace,
-			Dangerous:         s.Dangerous,
-			BidirectionalSync: s.BidirectionalSync,
-		})
 	}
 
 	defer func() {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -125,7 +125,7 @@ More Usages:
         acorn run --volume mydata:data .`
 
 var hideRunFlags = []string{"dangerous", "memory", "target-namespace", "secret", "volume", "region", "publish-all",
-	"publish", "link", "label", "interval", "env", "compute-class", "annotation"}
+	"publish", "link", "label", "interval", "env", "compute-class", "annotation", "update", "replace"}
 
 type Run struct {
 	RunArgs
@@ -229,7 +229,7 @@ func (s RunArgs) ToOpts() (client.AppRunOptions, error) {
 
 func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	if s.HelpAdvanced {
-		setAdvancedHelp(cmd)
+		setAdvancedHelp(cmd, hideRunFlags, AdvancedHelp)
 		return cmd.Help()
 	}
 	defer func() {
@@ -375,12 +375,12 @@ func toggleHiddenFlags(cmd *cobra.Command, flagsToHide []string, hide bool) {
 	}
 }
 
-func setAdvancedHelp(cmd *cobra.Command) {
+func setAdvancedHelp(cmd *cobra.Command, hideRunFlags []string, advancedHelp string) {
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		fmt.Println(cmd.Short + "\n")
 		// toggle advanced flags on before printing flags out in cmd.UsageString
 		toggleHiddenFlags(cmd, hideRunFlags, false)
 		fmt.Println(cmd.UsageString())
-		fmt.Println(AdvancedHelp)
+		fmt.Println(advancedHelp)
 	})
 }

--- a/pkg/cli/testdata/run/acorn_run_help.txt
+++ b/pkg/cli/testdata/run/acorn_run_help.txt
@@ -53,7 +53,5 @@ Flags:
   -o, --output string     Output API request without creating app (json, yaml)
       --profile strings   Profile to assign default values
   -q, --quiet             Do not print status
-      --replace           Replace the app with only defined values, resetting undefined fields to default values
-  -u, --update            Update the app if it already exists
       --wait              Wait for app to become ready before command exiting (default: true)
 


### PR DESCRIPTION
for #1358

This PR changes the outputs of `--help` and `--help-advanced` for `acorn run` and `acorn update` in the following ways:

- `acorn run`
  - `--update` and `--replace` moved from `--help` to `--help-advanced`
  - `--dev` and `--bidirectional-sync` fully removed as supported arguments (users should use the `acorn dev` command instead)
- `acorn update`
  - `--help-advanced` added as a way of showing flags that were previously hidden and had no means of showing them
  - `--image` is now shown in the main `--help` and not in `--help-advanced`

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

