### PR TITLE
fix: ImageAllowRules to allow images by ID or build (#1684)

### DIFF
--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -9,7 +9,6 @@ import (
 
 var (
 	PrefixErrRulesNeeded = "rules needed: "
-	PrefixErrNotAllowed  = "is not allowed by any ImageAllowRule in this project"
 )
 
 type ErrRulesNeeded struct {

--- a/pkg/imageallowrules/helpers.go
+++ b/pkg/imageallowrules/helpers.go
@@ -2,6 +2,7 @@ package imageallowrules
 
 import (
 	"fmt"
+	"strings"
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	imagename "github.com/google/go-containerregistry/pkg/name"
@@ -46,7 +47,7 @@ func buildImageScope(image imagename.Reference, scope string) (string, error) {
 	case SimpleImageScopeRepository:
 		is = fmt.Sprintf("%s/%s:**", image.Context().RegistryStr(), image.Context().RepositoryStr())
 	case SimpleImageScopeExact:
-		is = image.Name()
+		is = strings.TrimSuffix(image.Name(), ":")
 	case SimpleImageScopeAll:
 		is = "**"
 	default:

--- a/pkg/imageallowrules/imageallowrules_test.go
+++ b/pkg/imageallowrules/imageallowrules_test.go
@@ -76,6 +76,12 @@ func TestImageCovered(t *testing.T) {
 			image:       "index.docker.io/library/foo/alpine:v1.0.1",
 			shouldMatch: false,
 		},
+		{
+			name:        "match by full ID",
+			pattern:     "e67e444786a869161b26fa00f4993bbdeba3da677043e0bead8747d7a05eb150",
+			image:       "e67e444786a869161b26fa00f4993bbdeba3da677043e0bead8747d7a05eb150",
+			shouldMatch: true,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -85,7 +91,7 @@ func TestImageCovered(t *testing.T) {
 				t.Fatalf("failed to parse image %s: %v", tc.image, err)
 			}
 
-			match := imageCovered(ref, name.Digest{}, v1.ImageAllowRuleInstance{
+			match := imageCovered(ref, "", v1.ImageAllowRuleInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "testns",

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -703,5 +703,10 @@ func (s *Validator) getImageDetails(ctx context.Context, namespace string, profi
 }
 
 func (s *Validator) checkImageAllowed(ctx context.Context, namespace, image string) error {
-	return imageallowrules.CheckImageAllowed(ctx, s.client, namespace, image, "")
+	digest, _, err := s.resolveLocalImage(ctx, namespace, image)
+	if err != nil {
+		return err
+	}
+	err = imageallowrules.CheckImageAllowed(ctx, s.client, namespace, image, digest)
+	return err
 }

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -707,6 +707,5 @@ func (s *Validator) checkImageAllowed(ctx context.Context, namespace, image stri
 	if err != nil {
 		return err
 	}
-	err = imageallowrules.CheckImageAllowed(ctx, s.client, namespace, image, digest)
-	return err
+	return imageallowrules.CheckImageAllowed(ctx, s.client, namespace, image, digest)
 }


### PR DESCRIPTION
Ref #1684

Before, IARs would only match images with full registry/repo:tag reference.
Now you can also use short/long IDs and built images.

Signed-off-by: Thorsten Klein <tk@thklein.io>### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

