### PR TITLE
Correctly report status for Acorn services that don't have k8s services (#1689)

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/service.go
+++ b/pkg/apis/internal.acorn.io/v1/service.go
@@ -29,6 +29,7 @@ type ServiceInstance struct {
 type ServiceInstanceStatus struct {
 	Conditions []Condition `json:"conditions,omitempty"`
 	Endpoints  []Endpoint  `json:"endpoints,omitempty"`
+	HasService bool        `json:"hasService,omitempty"`
 }
 
 func (in *ServiceInstance) ShortID() string {

--- a/pkg/controller/service/service.go
+++ b/pkg/controller/service/service.go
@@ -18,12 +18,14 @@ func RenderServices(req router.Request, resp router.Response) error {
 		return err
 	}
 	resp.Objects(objs...)
+	svcInstance.Status.HasService = len(objs) > 0
 
 	objs, err = publish.ServiceLoadBalancer(req, svcInstance)
 	if err != nil {
 		return err
 	}
 	resp.Objects(objs...)
+	svcInstance.Status.HasService = svcInstance.Status.HasService || len(objs) > 0
 
 	objs, err = publish.Ingress(req, svcInstance)
 	if err != nil {
@@ -31,5 +33,6 @@ func RenderServices(req router.Request, resp router.Response) error {
 	}
 	resp.Objects(objs...)
 
+	resp.Objects(svcInstance)
 	return nil
 }

--- a/pkg/controller/service/service_test.go
+++ b/pkg/controller/service/service_test.go
@@ -105,3 +105,7 @@ func TestBindNoProtocol(t *testing.T) {
 func TestRouter(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/router", RenderServices)
 }
+
+func TestSecret(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/secret", RenderServices)
+}

--- a/pkg/controller/service/testdata/ingress/basic/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/ingress/basic/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,48 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: oneimage
+  namespace: app-created-namespace
+  uid: 1234567890abcdef
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  publish:
+    - hostname: localhost
+    - hostname: ci1.acorn.not
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+  container: oneimage
+  ports:
+    - targetPort: 81
+      publish: true
+      protocol: http
+    - port: 90
+      targetPort: 91
+      publish: true
+      protocol: tcp
+    - targetPort: 92
+      publish: true
+      protocol: tcp
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: oneimage-app-name-a5b0aade.local.oss-acorn.io
+    publishProtocol: https
+  - address: ci1.acorn.not
+    publishProtocol: https
+  - address: localhost
+    publishProtocol: https
+  hasService: true

--- a/pkg/controller/service/testdata/ingress/clusterdomainport/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/ingress/clusterdomainport/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,36 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: oneimage
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+  container: oneimage
+  default: true
+  ports:
+    - port: 80
+      targetPort: 81
+      publish: true
+      protocol: http
+      name: "80"
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: oneimage.app-name.app-namespace.local.oss-acorn.io
+    publishProtocol: http
+  hasService: true

--- a/pkg/controller/service/testdata/ingress/labels/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/ingress/labels/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,47 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: con1
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "con1"
+    "acorn.io/managed": "true"
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "con1"
+    "acorn.io/managed": "true"
+    "allconsl1": "value"
+    "conl1": "value"
+    "conl3": "value"
+    "globall1": "value"
+    "globall2": "value"
+  annotations:
+    "allconsa1": "value"
+    "cona1": "value"
+    "cona3": "value"
+    "globala1": "value"
+    "globala2": "value"
+  default: true
+  container: con1
+  ports:
+    - port: 80
+      targetPort: 81
+      publish: true
+      protocol: http
+      name: "80"
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: con1-app-name-2aaa2251.local.oss-acorn.io
+    publishProtocol: http
+  hasService: true

--- a/pkg/controller/service/testdata/ingress/letsencrypt/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/ingress/letsencrypt/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,40 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app1
+  namespace: app-created-namespace
+  uid: 1234567890abcdef
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "app1"
+    "acorn.io/managed": "true"
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "app1"
+    "acorn.io/managed": "true"
+  container: app1
+  publish:
+    - hostname: ci1.acorn.not
+  ports:
+    - port: 80
+      targetPort: 81
+      publish: true
+      protocol: http
+      name: "80"
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: app1-app-name-04396c88.local.oss-acorn.io
+    publishProtocol: https
+  - address: ci1.acorn.not
+    publishProtocol: https
+  hasService: true

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-1/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-1/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,47 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: con1
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "con1"
+    "acorn.io/managed": "true"
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "con1"
+    "acorn.io/managed": "true"
+    "allconsl1": "value"
+    "conl1": "value"
+    "conl3": "value"
+    "globall1": "value"
+    "globall2": "value"
+  annotations:
+    "allconsa1": "value"
+    "cona1": "value"
+    "cona3": "value"
+    "globala1": "value"
+    "globala2": "value"
+  default: true
+  container: con1
+  ports:
+    - port: 80
+      targetPort: 81
+      publish: true
+      protocol: http
+      name: "80"
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: con1-app-name-2aaa2251.local.oss-acorn.io
+    publishProtocol: http
+  hasService: true

--- a/pkg/controller/service/testdata/ingress/prefix/prefix-2/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/ingress/prefix/prefix-2/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,47 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: con1
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "con1"
+    "acorn.io/managed": "true"
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  default: true
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "con1"
+    "acorn.io/managed": "true"
+    "allconsl1": "value"
+    "conl1": "value"
+    "conl3": "value"
+    "globall1": "value"
+    "globall2": "value"
+  annotations:
+    "allconsa1": "value"
+    "cona1": "value"
+    "cona3": "value"
+    "globala1": "value"
+    "globala2": "value"
+  container: con1
+  ports:
+    - port: 80
+      targetPort: 81
+      publish: true
+      protocol: http
+      name: "80"
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: con1-app-name-2aaa2251.local.oss-acorn.io
+    publishProtocol: http
+  hasService: true

--- a/pkg/controller/service/testdata/router/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/router/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,50 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: router-name
+  namespace: app-created-namespace
+  uid: 1234567890abcdef
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/router-name: router-name
+spec:
+  publishMode: all
+  appName: app-name
+  appNamespace: app-namespace
+  default: true
+  routes:
+    - pathType: exact
+      path: /foo
+      targetServiceName: foo-target
+      targetServicePort: 1234
+    - pathType: prefix
+      path: /zzzz
+      targetServiceName: zzz-target
+      targetServicePort: 8080
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/router-name: router-name
+  ports:
+    - name: "80"
+      port: 80
+      protocol: http
+      targetPort: 8080
+  containerLabels:
+    acorn.io/app-name: app-name
+    acorn.io/router-name: router-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+status:
+  hasService: true
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: router-name-app-name-3de5df49.local.oss-acorn.io
+    publishProtocol: http

--- a/pkg/controller/service/testdata/secret/existing.yaml
+++ b/pkg/controller/service/testdata/secret/existing.yaml
@@ -1,0 +1,31 @@
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: app-name
+  namespace: app-namespace
+  uid: 1234567890abcdef
+spec:
+  image: test
+  publishMode: all
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: test
+  appSpec:
+    routers:
+      router-name:
+        routes:
+          - pathType: exact
+            path: /foo
+            targetServiceName: foo-target
+            targetServicePort: 1234
+          - pathType: prefix
+            path: /zzzz
+            targetServiceName: zzz-target
+            targetServicePort: 8080
+  conditions:
+    - type: defined
+      reason: Success
+      status: "True"
+      success: true
+---

--- a/pkg/controller/service/testdata/secret/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/secret/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,29 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: router-name
+  namespace: app-created-namespace
+  uid: 1234567890abcdef
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/router-name: router-name
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  default: true
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/router-name: router-name
+  secrets:
+    - my-secret
+    - my-other-secret
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined

--- a/pkg/controller/service/testdata/secret/input.yaml
+++ b/pkg/controller/service/testdata/secret/input.yaml
@@ -1,0 +1,23 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: router-name
+  namespace: app-created-namespace
+  uid: 1234567890abcdef
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/router-name: router-name
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  default: true
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/router-name: router-name
+  secrets:
+    - my-secret
+    - my-other-secret

--- a/pkg/controller/service/testdata/service/basic/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/service/basic/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,45 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: oneimage
+  namespace: app-created-namespace
+  uid: 1234567890abcdef
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  publish:
+    - hostname: localhost
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+  container: oneimage
+  ports:
+    - port: 80
+      targetPort: 81
+      protocol: http
+      publish: true
+      name: "80"
+    - port: 90
+      targetPort: 91
+      publish: true
+      protocol: tcp
+      name: "90"
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+  - address: oneimage-app-name-a5b0aade.local.oss-acorn.io
+    publishProtocol: http
+  - address: localhost
+    publishProtocol: http
+  hasService: true

--- a/pkg/controller/service/testdata/service/bind-no-protocol/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/service/bind-no-protocol/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,32 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: oneimage
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+  uid: 1234567890abcdef
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  publish:
+    - publish: true
+      port: 80
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+  container: oneimage
+  ports:
+    - port: 80
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  hasService: true

--- a/pkg/controller/service/testdata/service/tcp-http-overlap/expected.yaml.d/serviceinstance.yaml
+++ b/pkg/controller/service/testdata/service/tcp-http-overlap/expected.yaml.d/serviceinstance.yaml
@@ -1,0 +1,41 @@
+kind: ServiceInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  name: oneimage
+  namespace: app-created-namespace
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+  uid: 1234567890abcdef
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  publish:
+    - hostname: localhost
+  labels:
+    "acorn.io/app-namespace": "app-namespace"
+    "acorn.io/app-name": "app-name"
+    "acorn.io/container-name": "oneimage"
+    "acorn.io/managed": "true"
+  container: oneimage
+  ports:
+    - port: 80
+      publish: true
+      protocol: tcp
+    - port: 80
+      protocol: http
+      publish: true
+status:
+  conditions:
+  - reason: Success
+    status: "True"
+    success: true
+    type: defined
+  endpoints:
+    - address: oneimage-app-name-a5b0aade.local.oss-acorn.io
+      publishProtocol: http
+    - address: localhost
+      publishProtocol: http
+  hasService: true

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -9712,6 +9712,12 @@ func schema_pkg_apis_internalacornio_v1_ServiceInstanceStatus(ref common.Referen
 							},
 						},
 					},
+					"hasService": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
If an Acorn service didn't have an associated Kubernetes service, then the Acorn service would not be reported as ready. After this change, we track whether an Acorn service should have a Kubernetes service so that we don't take it into account when we report its status.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

