### PR TITLE
Disable pruning for endpoints on the rendering handler for ServiceInstances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 replace (
 	cuelang.org/go => cuelang.org/go v0.4.3
-	github.com/acorn-io/baaah => ../baaah
 	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220121014307-40bb9831756f+incompatible
 	github.com/rancher/apiserver => github.com/acorn-io/apiserver-1 v0.0.0-20220608053213-0ffc3be57697
 	k8s.io/client-go => k8s.io/client-go v0.27.2
@@ -14,7 +13,7 @@ require (
 	cuelang.org/go v0.5.0
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2
-	github.com/acorn-io/baaah v0.0.0-20230529210224-9b11179ad5be
+	github.com/acorn-io/baaah v0.0.0-20230602202522-a5f622203991
 	github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	cuelang.org/go v0.5.0
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2
-	github.com/acorn-io/baaah v0.0.0-20230602202522-a5f622203991
+	github.com/acorn-io/baaah v0.0.0-20230602211452-d2a7c8e5c38e
 	github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 replace (
 	cuelang.org/go => cuelang.org/go v0.4.3
+	github.com/acorn-io/baaah => ../baaah
 	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220121014307-40bb9831756f+incompatible
 	github.com/rancher/apiserver => github.com/acorn-io/apiserver-1 v0.0.0-20220608053213-0ffc3be57697
 	k8s.io/client-go => k8s.io/client-go v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,6 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2 h1:EOJgnBhPm3ckljwIUHUFmATuyNtZs7HQhp/EvSUfMDc=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
-github.com/acorn-io/baaah v0.0.0-20230529210224-9b11179ad5be h1:rTHelG955EmnW0/iPXgrHz2ndIZEpeljoxXbYHyxxkk=
-github.com/acorn-io/baaah v0.0.0-20230529210224-9b11179ad5be/go.mod h1:rA7YPlf5YdLABSULZu43zawnjBs50hCU8iGU5yTHG4g=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500 h1:tiM36bM+iMWuW9HM+YlM1GfNDXC7f565z8Be5epO0qM=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500/go.mod h1:y6aYj2dF/SlU205bDfA43Y5c9sa/aYr4X5GDqYJzJTU=
 github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78 h1:5zs9L/CXNkuTdJSbhFWczAorbmx67nqlqswx5CQi7XI=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2 h1:EOJgnBhPm3ckljwIUHUFmATuyNtZs7HQhp/EvSUfMDc=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
-github.com/acorn-io/baaah v0.0.0-20230602202522-a5f622203991 h1:Sc6wxc3ELCe3y789R+miuMfP0RA9D4Nn7NbNdgdYPEQ=
-github.com/acorn-io/baaah v0.0.0-20230602202522-a5f622203991/go.mod h1:rA7YPlf5YdLABSULZu43zawnjBs50hCU8iGU5yTHG4g=
+github.com/acorn-io/baaah v0.0.0-20230602211452-d2a7c8e5c38e h1:/HOPHRx02nDMaOkIpoyBhHAPGNV/cmYV+NmFXhVFDQ0=
+github.com/acorn-io/baaah v0.0.0-20230602211452-d2a7c8e5c38e/go.mod h1:rA7YPlf5YdLABSULZu43zawnjBs50hCU8iGU5yTHG4g=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500 h1:tiM36bM+iMWuW9HM+YlM1GfNDXC7f565z8Be5epO0qM=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500/go.mod h1:y6aYj2dF/SlU205bDfA43Y5c9sa/aYr4X5GDqYJzJTU=
 github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78 h1:5zs9L/CXNkuTdJSbhFWczAorbmx67nqlqswx5CQi7XI=

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2 h1:EOJgnBhPm3ckljwIUHUFmATuyNtZs7HQhp/EvSUfMDc=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
+github.com/acorn-io/baaah v0.0.0-20230602202522-a5f622203991 h1:Sc6wxc3ELCe3y789R+miuMfP0RA9D4Nn7NbNdgdYPEQ=
+github.com/acorn-io/baaah v0.0.0-20230602202522-a5f622203991/go.mod h1:rA7YPlf5YdLABSULZu43zawnjBs50hCU8iGU5yTHG4g=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500 h1:tiM36bM+iMWuW9HM+YlM1GfNDXC7f565z8Be5epO0qM=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500/go.mod h1:y6aYj2dF/SlU205bDfA43Y5c9sa/aYr4X5GDqYJzJTU=
 github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78 h1:5zs9L/CXNkuTdJSbhFWczAorbmx67nqlqswx5CQi7XI=

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -80,7 +80,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper, recorder
 
 	router.Type(&v1.DevSessionInstance{}).HandlerFunc(devsession.ExpireDevSession)
 
-	router.Type(&v1.ServiceInstance{}).WithoutPruneTypes(&corev1.Endpoints{}, &discoveryv1.EndpointSlice{}).HandlerFunc(service.RenderServices)
+	router.Type(&v1.ServiceInstance{}).DisablePruningForTypes(&corev1.Endpoints{}, &discoveryv1.EndpointSlice{}).HandlerFunc(service.RenderServices)
 
 	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.SetRegion)
 	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.DeployBuilder)

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/controller/devsession"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"github.com/acorn-io/acorn/pkg/controller/acornimagebuildinstance"
 	"github.com/acorn-io/acorn/pkg/controller/appdefinition"
@@ -79,7 +80,7 @@ func routes(router *router.Router, registryTransport http.RoundTripper, recorder
 
 	router.Type(&v1.DevSessionInstance{}).HandlerFunc(devsession.ExpireDevSession)
 
-	router.Type(&v1.ServiceInstance{}).HandlerFunc(service.RenderServices)
+	router.Type(&v1.ServiceInstance{}).WithoutPruneTypes(&corev1.Endpoints{}, &discoveryv1.EndpointSlice{}).HandlerFunc(service.RenderServices)
 
 	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.SetRegion)
 	router.Type(&v1.BuilderInstance{}).HandlerFunc(builder.DeployBuilder)

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -11,6 +11,7 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -47,6 +48,7 @@ func AddToScheme(scheme *runtime.Scheme) error {
 	errs = append(errs, rbacv1.AddToScheme(scheme))
 	errs = append(errs, authv1.AddToScheme(scheme))
 	errs = append(errs, apiextensionv1.AddToScheme(scheme))
+	errs = append(errs, discoveryv1.AddToScheme(scheme))
 	return merr.NewErrors(errs...)
 }
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -92,7 +92,7 @@ func toAddressService(service *v1.ServiceInstance) (result []kclient.Object) {
 				Name:        newService.Name,
 				Namespace:   newService.Namespace,
 				Labels:      newService.Labels,
-				Annotations: newService.Annotations,
+				Annotations: endpointsAnnotations,
 			},
 			Subsets: []corev1.EndpointSubset{
 				{

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -79,12 +79,13 @@ func toAddressService(service *v1.ServiceInstance) (result []kclient.Object) {
 	} else {
 		newService.Spec.Type = corev1.ServiceTypeClusterIP
 
-		// The baaah route we are on does not prune Endpoints,
-		// so we need to add this annotation to override it.
 		endpointsAnnotations := make(map[string]string, len(newService.Annotations)+1)
 		for k, v := range newService.Annotations {
 			endpointsAnnotations[k] = v
 		}
+
+		// The baaah route we are on does not prune Endpoints,
+		// so we need to add this annotation to override it.
 		endpointsAnnotations[apply.AnnotationPrune] = "true"
 
 		result = append(result, &corev1.Endpoints{

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -81,7 +81,10 @@ func toAddressService(service *v1.ServiceInstance) (result []kclient.Object) {
 
 		// The baaah route we are on does not prune Endpoints,
 		// so we need to add this annotation to override it.
-		endpointsAnnotations := newService.GetAnnotations()
+		endpointsAnnotations := make(map[string]string, len(newService.Annotations)+1)
+		for k, v := range newService.Annotations {
+			endpointsAnnotations[k] = v
+		}
 		endpointsAnnotations[apply.AnnotationPrune] = "true"
 
 		result = append(result, &corev1.Endpoints{

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/labels"
 	"github.com/acorn-io/acorn/pkg/ports"
 	"github.com/acorn-io/acorn/pkg/ref"
+	"github.com/acorn-io/baaah/pkg/apply"
 	"github.com/acorn-io/baaah/pkg/router"
 	"github.com/acorn-io/baaah/pkg/typed"
 	corev1 "k8s.io/api/core/v1"
@@ -77,6 +78,12 @@ func toAddressService(service *v1.ServiceInstance) (result []kclient.Object) {
 		newService.Spec.ExternalName = service.Spec.Address
 	} else {
 		newService.Spec.Type = corev1.ServiceTypeClusterIP
+
+		// The baaah route we are on does not prune Endpoints,
+		// so we need to add this annotation to override it.
+		endpointsAnnotations := newService.GetAnnotations()
+		endpointsAnnotations[apply.AnnotationPrune] = "true"
+
 		result = append(result, &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        newService.Name,


### PR DESCRIPTION
Due to recent AppStatus changes, we are now watching Endpoints a little bit, which was causing baaah to prune them, which led to networking issues. Changing this route to disable pruning for Endpoints (and EndpointSlices in case those ever come up in the future) fixes this problem.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

