### PR TITLE
Give event timestamps microsecond precision (#1694)

### DIFF
--- a/pkg/apis/internal.acorn.io/v1/event.go
+++ b/pkg/apis/internal.acorn.io/v1/event.go
@@ -40,7 +40,7 @@ type EventInstance struct {
 	Description string `json:"description,omitempty"`
 
 	// Observed represents the time the Event was first observed.
-	Observed metav1.Time `json:"observed"`
+	Observed metav1.MicroTime `json:"observed" wrangler:"type=string"`
 
 	// Details provides additional information about the cluster at the time the Event occurred.
 	//

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -24,7 +24,7 @@ func PullAppImage(transport http.RoundTripper, recorder event.Recorder) router.H
 		recorder: recorder,
 		resolve:  tags.ResolveLocal,
 		pull:     images.PullAppImage,
-		now:      metav1.Now,
+		now:      metav1.NowMicro,
 	})
 }
 
@@ -36,7 +36,7 @@ type pullClient struct {
 	recorder event.Recorder
 	resolve  resolveImageFunc
 	pull     pullImageFunc
-	now      func() metav1.Time
+	now      func() metav1.MicroTime
 }
 
 func pullAppImage(transport http.RoundTripper, client pullClient) router.HandlerFunc {
@@ -186,7 +186,7 @@ func newImageSummary(appImage v1.AppImage) ImageSummary {
 	}
 }
 
-func recordPullEvent(ctx context.Context, recorder event.Recorder, observed metav1.Time, obj kclient.Object, autoUpgradeOn bool, err error, previousImage, targetImage v1.AppImage) {
+func recordPullEvent(ctx context.Context, recorder event.Recorder, observed metav1.MicroTime, obj kclient.Object, autoUpgradeOn bool, err error, previousImage, targetImage v1.AppImage) {
 	// Initialize with values for a success event
 	previous, target := newImageSummary(previousImage), newImageSummary(targetImage)
 	e := apiv1.Event{

--- a/pkg/controller/appdefinition/pullappimage_test.go
+++ b/pkg/controller/appdefinition/pullappimage_test.go
@@ -92,7 +92,7 @@ func withMeta[T kclient.Object](name, uid, resourceVersion string, obj T) T {
 
 func TestPullAppImageEvents(t *testing.T) {
 	// Test cases below this comment ensure the handler produces the correct events
-	now := metav1.Now()
+	now := metav1.NowMicro()
 	// Manual upgrade should record an event
 	testRecordPullEvent(t,
 		"ImageChange",
@@ -236,7 +236,7 @@ func pullImageTo(image *v1.AppImage, err error) pullImageFunc {
 	}
 }
 
-func testRecordPullEvent(t *testing.T, testName string, appInstance *v1.AppInstance, resolve resolveImageFunc, pull pullImageFunc, now metav1.Time, expect *apiv1.Event) {
+func testRecordPullEvent(t *testing.T, testName string, appInstance *v1.AppInstance, resolve resolveImageFunc, pull pullImageFunc, now metav1.MicroTime, expect *apiv1.Event) {
 	t.Helper()
 	var recording []*apiv1.Event
 	fakeRecorder := func(_ context.Context, e *apiv1.Event) error {
@@ -248,7 +248,7 @@ func testRecordPullEvent(t *testing.T, testName string, appInstance *v1.AppInsta
 		recorder: event.RecorderFunc(fakeRecorder),
 		resolve:  resolve,
 		pull:     pull,
-		now: func() metav1.Time {
+		now: func() metav1.MicroTime {
 			return now
 		},
 	})

--- a/pkg/event/id_test.go
+++ b/pkg/event/id_test.go
@@ -40,10 +40,10 @@ func TestContentID(t *testing.T) {
 			name:  "NotEqual/Diff/Observed",
 			equal: false,
 			a: apiv1.Event{
-				Observed: metav1.Now(),
+				Observed: metav1.NowMicro(),
 			},
 			b: apiv1.Event{
-				Observed: metav1.NewTime(metav1.Now().Add(time.Hour)),
+				Observed: metav1.NewMicroTime(metav1.Now().Add(time.Hour)),
 			},
 		},
 	} {

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -2738,7 +2738,7 @@ func schema_pkg_apis_apiacornio_v1_Event(ref common.ReferenceCallback) common.Op
 						SchemaProps: spec.SchemaProps{
 							Description: "Observed represents the time the Event was first observed.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
 					"details": {
@@ -2761,7 +2761,7 @@ func schema_pkg_apis_apiacornio_v1_Event(ref common.ReferenceCallback) common.Op
 			},
 		},
 		Dependencies: []string{
-			"github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1.EventSource", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1.EventSource", "k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -7308,7 +7308,7 @@ func schema_pkg_apis_internalacornio_v1_EventInstance(ref common.ReferenceCallba
 						SchemaProps: spec.SchemaProps{
 							Description: "Observed represents the time the Event was first observed.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
 					"details": {
@@ -7331,7 +7331,7 @@ func schema_pkg_apis_internalacornio_v1_EventInstance(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1.EventSource", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1.EventSource", "k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 

--- a/pkg/server/registry/apigroups/acorn/apps/events.go
+++ b/pkg/server/registry/apigroups/acorn/apps/events.go
@@ -83,7 +83,7 @@ func (s *eventRecordingStrategy) Create(ctx context.Context, obj types.Object) (
 		Details:     details,
 		Description: fmt.Sprintf("App %s/%s created", obj.GetNamespace(), obj.GetName()),
 		Source:      event.ObjectSource(obj),
-		Observed:    metav1.Now(),
+		Observed:    metav1.NowMicro(),
 	}); err != nil {
 		logrus.Warnf("Failed to record event: %s", err.Error())
 	}
@@ -116,7 +116,7 @@ func (s *eventRecordingStrategy) Delete(ctx context.Context, obj types.Object) (
 		Details:     details,
 		Description: fmt.Sprintf("App %s/%s deleted", obj.GetNamespace(), obj.GetName()),
 		Source:      event.ObjectSource(obj),
-		Observed:    metav1.Now(),
+		Observed:    metav1.NowMicro(),
 	}); err != nil {
 		logrus.Warnf("Failed to record event: %s", err.Error())
 	}
@@ -170,7 +170,7 @@ func (s *eventRecordingStrategy) Update(ctx context.Context, obj types.Object) (
 		Details:     details,
 		Description: fmt.Sprintf("Spec field updated for App %s/%s", obj.GetNamespace(), obj.GetName()),
 		Source:      event.ObjectSource(obj),
-		Observed:    metav1.Now(),
+		Observed:    metav1.NowMicro(),
 	}); err != nil {
 		logrus.Warnf("Failed to record event: %s", err)
 	}


### PR DESCRIPTION
The `metav1.Time` type used as timestamps in acorn events were
being truncated to seconds precision when serialized. This
limitation meant that we didn't have the ability to order events
that occur within the same second; e.g. resource contention between
controllers, flapping, etc.

To this end, switch to `metadata.MicroTime`.

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
