### PR TITLE
Revert "fix: resolvelocal should always return full ID if image is found (#1682)"

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -86,6 +86,9 @@ func ResolveLocal(ctx context.Context, c kclient.Client, namespace, image string
 		}
 	} else if err != nil {
 		return "", false, err
+	} else if !localImage.Remote {
+		// The name will match the name we used to lookup, so trim the digest
+		return strings.TrimPrefix(localImage.Digest, "sha256:"), true, nil
 	}
-	return strings.TrimPrefix(localImage.Digest, "sha256:"), !localImage.Remote, nil
+	return image, false, nil
 }


### PR DESCRIPTION
This reverts commit e74aea6c635ec181abb6c9d05df5c7a4432e7b00.
