### PR TITLE
Stop processing tags on app creation (#1502)

### DIFF
--- a/pkg/controller/images/images.go
+++ b/pkg/controller/images/images.go
@@ -13,7 +13,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateImages(req router.Request, resp router.Response) error {
+func CreateImages(req router.Request, _ router.Response) error {
 	app := req.Object.(*v1.AppInstance)
 	if app.Status.AppImage.ID == "" || app.Status.AppImage.Digest == "" {
 		return nil
@@ -103,14 +103,15 @@ func createImageForSelf(req router.Request, app *v1.AppInstance) (*v1.ImageInsta
 				return image, nil
 			}
 		}
-	}
 
-	// remove tag from existing images
-	if err := removeTag(req, app, imageName); err != nil {
-		return nil, err
-	}
+		// If a new image is built with the same tag as the image used for this app,
+		// then we don't want to take the tag from the newly built image.
+		if found, err := checkExistingImages(req, app, imageName); err != nil {
+			return nil, err
+		} else if found {
+			return image, nil
+		}
 
-	if update {
 		tags := []string{imageName}
 		for _, tag := range image.Tags {
 			if tag == ref.Context().String() {
@@ -139,35 +140,22 @@ func createImageForSelf(req router.Request, app *v1.AppInstance) (*v1.ImageInsta
 	return image, req.Client.Create(req.Ctx, image)
 }
 
-func removeTag(req router.Request, app *v1.AppInstance, tag string) error {
+func checkExistingImages(req router.Request, app *v1.AppInstance, tag string) (bool, error) {
 	images := &v1.ImageInstanceList{}
 	err := req.List(images, &kclient.ListOptions{
 		Namespace: app.Namespace,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	for _, image := range images.Items {
-		if len(image.Tags) == 0 {
-			continue
-		}
-
-		newTags := make([]string, 0, len(image.Tags))
 		for _, existingTag := range image.Tags {
 			if existingTag == tag {
-				continue
-			}
-			newTags = append(newTags, existingTag)
-		}
-
-		if len(newTags) != len(image.Tags) {
-			image.Tags = newTags
-			if err := req.Client.Update(req.Ctx, &image); err != nil {
-				return err
+				return true, nil
 			}
 		}
 	}
 
-	return nil
+	return false, nil
 }

--- a/pkg/images/operations.go
+++ b/pkg/images/operations.go
@@ -61,6 +61,11 @@ func PullAppImage(ctx context.Context, c client.Reader, namespace, image, nested
 		return nil, err
 	}
 
+	if !tags.SHAPattern.MatchString(image) {
+		// Use the tag name so that it normalized. For example, docker.io replaced with index.docker.io
+		image = tag.Name()
+	}
+
 	if nestedDigest != "" {
 		tag, err = imagename.NewDigest(tag.Context().String() + "@" + nestedDigest)
 		if err != nil {


### PR DESCRIPTION
Based on which image was pulled when setting an image for an app, the handler would append tags to the current image and (attempt to) remove tags from other images. This causes confusion in the following scenario:
1. Create an app from an image tag.
2. Build an image with the same tag as above.
3. Depending on the tag, you may have two images with the same tag or the image created in step one would remain tagged and the built image would not.

The outcomes in step 3 are confusing. Therefore, after these changes, the app handler will not try to "take" a tag from an existing image. The idea is that if the desired tag exists when the app is run, then we would have used that image. If the image that the app is using doesn't  have the tag, then a new image must have been built and tagged, which "took over" the tag in question.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)