### PR TITLE
Create separate UpdateArgs struct in order to remove --name from the update command

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_update.md
+++ b/docs/docs/100-reference/01-command-line/acorn_update.md
@@ -18,7 +18,6 @@ acorn update [flags] APP_NAME [deploy flags]
   -h, --help              help for update
       --help-advanced     Show verbose help text
       --image string      Acorn image name
-  -n, --name string       Name of app to create
       --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
   -o, --output string     Output API request without creating app (json, yaml)
       --profile strings   Profile to assign default values

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -140,26 +140,8 @@ type Run struct {
 }
 
 type RunArgs struct {
-	Name            string   `usage:"Name of app to create" short:"n"`
-	Region          string   `usage:"Region in which to deploy the app, immutable"`
-	File            string   `short:"f" usage:"Name of the build file (default \"DIRECTORY/Acornfile\")"`
-	Volume          []string `usage:"Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)" short:"v" split:"false"`
-	Secret          []string `usage:"Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)" short:"s"`
-	Link            []string `usage:"Link external app as a service in the current app (format app-name:container-name)"`
-	PublishAll      *bool    `usage:"Publish all (true) or none (false) of the defined ports of application" short:"P"`
-	Publish         []string `usage:"Publish port of application (format [public:]private) (ex 81:80)" short:"p"`
-	Profile         []string `usage:"Profile to assign default values"`
-	Env             []string `usage:"Environment variables to set on running containers" short:"e"`
-	Label           []string `usage:"Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)" short:"l"`
-	Annotation      []string `usage:"Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)"`
-	Dangerous       bool     `usage:"Automatically approve all privileges requested by the application"`
-	Output          string   `usage:"Output API request without creating app (json, yaml)" short:"o"`
-	TargetNamespace string   `usage:"The name of the namespace to be created and deleted for the application resources"`
-	NotifyUpgrade   *bool    `usage:"If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it"`
-	AutoUpgrade     *bool    `usage:"Enabled automatic upgrades."`
-	Interval        string   `usage:"If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)"`
-	Memory          []string `usage:"Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)" short:"m"`
-	ComputeClass    []string `usage:"Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)"`
+	UpdateArgs
+	Name string `usage:"Name of app to create" short:"n"`
 }
 
 func (s RunArgs) ToOpts() (client.AppRunOptions, error) {

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -25,7 +25,9 @@ import (
 func TestRunArgs_Env(t *testing.T) {
 	os.Setenv("x222", "y333")
 	runArgs := RunArgs{
-		Env: []string{"x222", "y=1"},
+		UpdateArgs: UpdateArgs{
+			Env: []string{"x222", "y=1"},
+		},
 	}
 	opts, err := runArgs.ToOpts()
 	if err != nil {

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -114,25 +114,7 @@ func (s *Update) Run(cmd *cobra.Command, args []string) error {
 
 func (s *Update) getRunArgs(name string) RunArgs {
 	return RunArgs{
-		Name:            name,
-		Region:          s.UpdateArgs.Region,
-		File:            s.UpdateArgs.File,
-		Volume:          s.UpdateArgs.Volume,
-		Secret:          s.UpdateArgs.Secret,
-		Link:            s.UpdateArgs.Link,
-		PublishAll:      s.UpdateArgs.PublishAll,
-		Publish:         s.UpdateArgs.Publish,
-		Profile:         s.UpdateArgs.Profile,
-		Env:             s.UpdateArgs.Env,
-		Label:           s.UpdateArgs.Label,
-		Annotation:      s.UpdateArgs.Annotation,
-		Dangerous:       s.UpdateArgs.Dangerous,
-		Output:          s.UpdateArgs.Output,
-		TargetNamespace: s.UpdateArgs.TargetNamespace,
-		NotifyUpgrade:   s.UpdateArgs.NotifyUpgrade,
-		AutoUpgrade:     s.UpdateArgs.AutoUpgrade,
-		Interval:        s.UpdateArgs.Interval,
-		Memory:          s.UpdateArgs.Memory,
-		ComputeClass:    s.UpdateArgs.ComputeClass,
+		Name:       name,
+		UpdateArgs: s.UpdateArgs,
 	}
 }

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -24,8 +24,30 @@ func NewUpdate(c CommandContext) *cobra.Command {
 	return cmd
 }
 
+type UpdateArgs struct {
+	Region          string   `usage:"Region in which to deploy the app, immutable"`
+	File            string   `short:"f" usage:"Name of the build file (default \"DIRECTORY/Acornfile\")"`
+	Volume          []string `usage:"Bind an existing volume (format existing:vol-name,field=value) (ex: pvc-name:app-data)" short:"v" split:"false"`
+	Secret          []string `usage:"Bind an existing secret (format existing:sec-name) (ex: sec-name:app-secret)" short:"s"`
+	Link            []string `usage:"Link external app as a service in the current app (format app-name:container-name)"`
+	PublishAll      *bool    `usage:"Publish all (true) or none (false) of the defined ports of application" short:"P"`
+	Publish         []string `usage:"Publish port of application (format [public:]private) (ex 81:80)" short:"p"`
+	Profile         []string `usage:"Profile to assign default values"`
+	Env             []string `usage:"Environment variables to set on running containers" short:"e"`
+	Label           []string `usage:"Add labels to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)" short:"l"`
+	Annotation      []string `usage:"Add annotations to the app and the resources it creates (format [type:][name:]key=value) (ex k=v, containers:k=v)"`
+	Dangerous       bool     `usage:"Automatically approve all privileges requested by the application"`
+	Output          string   `usage:"Output API request without creating app (json, yaml)" short:"o"`
+	TargetNamespace string   `usage:"The name of the namespace to be created and deleted for the application resources"`
+	NotifyUpgrade   *bool    `usage:"If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it"`
+	AutoUpgrade     *bool    `usage:"Enabled automatic upgrades."`
+	Interval        string   `usage:"If configured for auto-upgrade, this is the time interval at which to check for new releases (ex: 1h, 5m)"`
+	Memory          []string `usage:"Set memory for a workload in the format of workload=memory. Only specify an amount to set all workloads. (ex foo=512Mi or 512Mi)" short:"m"`
+	ComputeClass    []string `usage:"Set computeclass for a workload in the format of workload=computeclass. Specify a single computeclass to set all workloads. (ex foo=example-class or example-class)"`
+}
+
 type Update struct {
-	RunArgs
+	UpdateArgs
 	Image          string `usage:"Acorn image name"`
 	ConfirmUpgrade bool   `usage:"When an auto-upgrade app is marked as having an upgrade available, pass this flag to confirm the upgrade. Used in conjunction with --notify-upgrade."`
 	Pull           bool   `usage:"Re-pull the app's image, which will cause the app to re-deploy if the image has changed"`
@@ -57,8 +79,6 @@ func (s *Update) Run(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	args = args[1:]
 
-	s.RunArgs.Name = name
-
 	if s.ConfirmUpgrade && s.Pull {
 		return fmt.Errorf("only --confirm-upgrade or --pull can be set at once")
 	}
@@ -82,7 +102,7 @@ func (s *Update) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	r := Run{
-		RunArgs: s.RunArgs,
+		RunArgs: s.getRunArgs(name),
 		Wait:    s.Wait,
 		Quiet:   s.Quiet,
 		Update:  true,
@@ -90,4 +110,29 @@ func (s *Update) Run(cmd *cobra.Command, args []string) error {
 		client:  s.client,
 	}
 	return r.Run(cmd, append([]string{s.Image}, args...))
+}
+
+func (s *Update) getRunArgs(name string) RunArgs {
+	return RunArgs{
+		Name:            name,
+		Region:          s.UpdateArgs.Region,
+		File:            s.UpdateArgs.File,
+		Volume:          s.UpdateArgs.Volume,
+		Secret:          s.UpdateArgs.Secret,
+		Link:            s.UpdateArgs.Link,
+		PublishAll:      s.UpdateArgs.PublishAll,
+		Publish:         s.UpdateArgs.Publish,
+		Profile:         s.UpdateArgs.Profile,
+		Env:             s.UpdateArgs.Env,
+		Label:           s.UpdateArgs.Label,
+		Annotation:      s.UpdateArgs.Annotation,
+		Dangerous:       s.UpdateArgs.Dangerous,
+		Output:          s.UpdateArgs.Output,
+		TargetNamespace: s.UpdateArgs.TargetNamespace,
+		NotifyUpgrade:   s.UpdateArgs.NotifyUpgrade,
+		AutoUpgrade:     s.UpdateArgs.AutoUpgrade,
+		Interval:        s.UpdateArgs.Interval,
+		Memory:          s.UpdateArgs.Memory,
+		ComputeClass:    s.UpdateArgs.ComputeClass,
+	}
 }


### PR DESCRIPTION
for #1358

This new UpdateArgs struct contains all the same fields as RunArgs except for `Name`.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

