### PR TITLE
Get job output from exec, not terminationPath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,10 @@ COPY ./scripts/setup-binfmt /usr/local/bin
 COPY --from=helper /usr/local/bin/acorn-helper /usr/local/bin/
 VOLUME /var/lib/buildkit
 
-# NOTE: Requires buildkit: DOCKER_BUILDKIT=1
-COPY <<EOF /usr/local/bin/acorn-helper-init
-#!/bin/sh
-cp -f /usr/local/bin/acorn-helper /.acorn/acorn-helper
-EOF
-RUN chmod +x /usr/local/bin/acorn-helper-init
+COPY /scripts/acorn-helper-init /usr/local/bin
+COPY /scripts/acorn-job-helper-init /usr/local/bin
+COPY /scripts/acorn-job-helper-shutdown /usr/local/bin
+COPY /scripts/acorn-job-get-output /usr/local/bin
 CMD []
 ENTRYPOINT ["/usr/local/bin/acorn"]
 

--- a/pkg/apis/internal.acorn.io/v1/appstatus.go
+++ b/pkg/apis/internal.acorn.io/v1/appstatus.go
@@ -101,6 +101,7 @@ type ContainerStatus struct {
 	CommonStatus           `json:",inline"`
 	ReadyReplicaCount      int32                       `json:"readyCount,omitempty"`
 	DesiredReplicaCount    int32                       `json:"readyDesiredCount,omitempty"`
+	RunningReplicaCount    int32                       `json:"runningReplicaCount,omitempty"`
 	UpToDateReplicaCount   int32                       `json:"upToDateCount,omitempty"`
 	MaxReplicaRestartCount int32                       `json:"maxReplicaRestartCount,omitempty"`
 	Dependencies           map[string]DependencyStatus `json:"dependencies,omitempty"`

--- a/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/computeclass/job/expected.golden
@@ -71,7 +71,9 @@ spec:
           requests:
             cpu: 1m
             memory: 1Mi
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -89,19 +91,38 @@ spec:
           requests:
             cpu: 1m
             memory: 1Mi
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/filter-user-labels/expected.golden
@@ -216,13 +216,32 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: job-name-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: job-name
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
@@ -274,7 +293,7 @@ type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/labels/expected.golden
@@ -210,13 +210,32 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: job-name-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: job-name
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
@@ -266,7 +285,7 @@ type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/deployspec/no-user-labels/expected.golden
@@ -149,13 +149,32 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: job-name-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: job-name
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
@@ -196,7 +215,7 @@ type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/basic/expected.golden
@@ -57,7 +57,9 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -70,19 +72,38 @@ spec:
           tcpSocket:
             port: 91
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-create-app/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-create-app/expected.golden
@@ -52,19 +52,38 @@ spec:
         image: create-only-image
         name: create-only
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: create-only-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: create-only
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-delete-app/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-delete-app/expected.golden
@@ -52,19 +52,38 @@ spec:
         image: delete-only-image
         name: delete-only
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: delete
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: delete-only-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: delete-only
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-start-app/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-start-app/expected.golden
@@ -52,19 +52,38 @@ spec:
         image: update-only-image
         name: update-only
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: update
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: update-only-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: update-only
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-stop-app/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-stop-app/expected.golden
@@ -52,19 +52,38 @@ spec:
         image: stop-only-image
         name: stop-only
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: stop
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: stop-only-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: stop-only
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-update-app-with-create/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-update-app-with-create/expected.golden
@@ -52,13 +52,32 @@ spec:
         image: create-only-image
         name: create-only
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: create-only-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: create-only
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
@@ -116,19 +135,38 @@ spec:
         image: update-only-image
         name: update-only
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: update
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: update-only-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: update-only
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -142,7 +180,7 @@ type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-update-app/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-update-app/expected.golden
@@ -52,19 +52,38 @@ spec:
         image: update-only-image
         name: update-only
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: update
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: update-only-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: update-only
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/event-jobs-update-create-job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/event-jobs-update-create-job/expected.golden
@@ -52,19 +52,38 @@ spec:
         image: only-image
         name: job
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: update
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: job-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: job
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/job/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/job/labels/expected.golden
@@ -87,19 +87,38 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: job1-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: job1
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/memory/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/memory/job/expected.golden
@@ -61,7 +61,9 @@ spec:
             memory: 1Mi
           requests:
             memory: 1Mi
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -74,19 +76,38 @@ spec:
           tcpSocket:
             port: 91
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/both/expected.golden
@@ -327,7 +327,9 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -340,13 +342,32 @@ spec:
           tcpSocket:
             port: 91
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
@@ -400,7 +421,7 @@ type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/bothwithnopermissions/expected.golden
@@ -155,7 +155,9 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -168,13 +170,32 @@ spec:
           tcpSocket:
             port: 91
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
@@ -228,7 +249,7 @@ type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/job/expected.golden
@@ -149,7 +149,9 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -162,19 +164,38 @@ spec:
           tcpSocket:
             port: 91
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
+++ b/pkg/controller/appdefinition/testdata/permissions/multiplejobs/expected.golden
@@ -149,7 +149,9 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -162,13 +164,32 @@ spec:
           tcpSocket:
             port: 91
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: oneimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: oneimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
@@ -323,7 +344,9 @@ spec:
           tcpSocket:
             port: 81
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       - env:
         - name: ACORN_EVENT
           value: create
@@ -336,19 +359,38 @@ spec:
           tcpSocket:
             port: 91
         resources: {}
-        terminationMessagePath: /run/secrets/output
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
+      - command:
+        - /usr/local/bin/acorn-job-helper-init
+        env:
+        - name: ACORN_EVENT
+          value: create
+        image: ghcr.io/acorn-io/acorn:main
+        imagePullPolicy: IfNotPresent
+        name: acorn-job-output-helper
+        resources: {}
+        volumeMounts:
+        - mountPath: /run/secrets
+          name: acorn-job-output-helper
       enableServiceLinks: false
       imagePullSecrets:
       - name: twoimage-pull-1234567890ab
       restartPolicy: Never
       serviceAccountName: twoimage
       terminationGracePeriodSeconds: 5
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1M
+        name: acorn-job-output-helper
 status: {}
 
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -362,7 +404,7 @@ type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJPZz09In0sImluZGV4LmRvY2tlci5pbyI6eyJhdXRoIjoiT2c9PSJ9fX0=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/controller/appstatus/cli_status.go
+++ b/pkg/controller/appstatus/cli_status.go
@@ -64,7 +64,7 @@ func uptodate(app *v1.AppInstance) string {
 	)
 	for _, status := range app.Status.AppStatus.Containers {
 		uptodate += status.UpToDateReplicaCount
-		desired += status.DesiredReplicaCount
+		desired += status.RunningReplicaCount
 	}
 	if uptodate != desired {
 		return fmt.Sprintf("%d/%d", uptodate, desired)
@@ -84,7 +84,7 @@ func healthy(app *v1.AppInstance) string {
 	)
 	for _, status := range app.Status.AppStatus.Containers {
 		desired += status.DesiredReplicaCount
-		ready += status.ReadyReplicaCount
+		ready += status.RunningReplicaCount
 	}
 	if ready != desired {
 		return fmt.Sprintf("%d/%d", ready, desired)

--- a/pkg/controller/appstatus/containers.go
+++ b/pkg/controller/appstatus/containers.go
@@ -52,10 +52,10 @@ func (a *appStatusRenderer) readContainers() error {
 		} else if err != nil {
 			return err
 		} else {
-			cs.UpToDate = dep.Annotations[labels.AcornAppGeneration] == strconv.Itoa(int(a.app.Generation)) &&
-				dep.Status.UpdatedReplicas == dep.Status.Replicas
+			cs.UpToDate = dep.Annotations[labels.AcornAppGeneration] == strconv.Itoa(int(a.app.Generation))
 			cs.ReadyReplicaCount = dep.Status.ReadyReplicas
-			cs.DesiredReplicaCount = dep.Status.Replicas
+			cs.RunningReplicaCount = dep.Status.Replicas
+			cs.DesiredReplicaCount = replicas(dep.Spec.Replicas)
 			cs.UpToDateReplicaCount = dep.Status.UpdatedReplicas
 			cs.Defined = true
 
@@ -151,4 +151,11 @@ func (a *appStatusRenderer) isDepReady(dep *appsv1.Deployment) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func replicas(replicas *int32) int32 {
+	if replicas == nil {
+		return 1
+	}
+	return *replicas
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -60,7 +60,10 @@ func New() (*Controller, error) {
 		return nil, err
 	}
 
-	routes(router, registryTransport, event.NewRecorder(client))
+	err = routes(router, cfg, registryTransport, event.NewRecorder(client))
+	if err != nil {
+		return nil, err
+	}
 
 	return &Controller{
 		Router: router,

--- a/pkg/controller/jobs/output.go
+++ b/pkg/controller/jobs/output.go
@@ -1,0 +1,176 @@
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/client/term"
+	"github.com/acorn-io/acorn/pkg/jobs"
+	"github.com/acorn-io/acorn/pkg/k8schannel"
+	"github.com/acorn-io/acorn/pkg/labels"
+	"github.com/acorn-io/acorn/pkg/streams"
+	"github.com/acorn-io/baaah/pkg/apply"
+	"github.com/acorn-io/baaah/pkg/router"
+	"github.com/acorn-io/baaah/pkg/urlbuilder"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getAppGeneration(ctx context.Context, c kclient.Client, namespace, jobName string) (string, error) {
+	job := batchv1.Job{}
+	if err := c.Get(ctx, router.Key(namespace, jobName), &job); apierrors.IsNotFound(err) {
+		cronJob := batchv1.CronJob{}
+		if err := c.Get(ctx, router.Key(namespace, jobName), &cronJob); err != nil {
+			return "", err
+		}
+		return cronJob.Annotations[labels.AcornAppGeneration], nil
+	} else if err != nil {
+		return "", err
+	}
+	return job.Annotations[labels.AcornAppGeneration], nil
+}
+
+type Handler struct {
+	Dialer *k8schannel.Dialer
+	Server *url.URL
+}
+
+func NewHandler(cfg *rest.Config) (*Handler, error) {
+	d, err := k8schannel.NewDialer(cfg, false)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(cfg.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Handler{
+		Dialer: d,
+		Server: u,
+	}, nil
+}
+
+func (h *Handler) runCommand(ctx context.Context, pod *corev1.Pod, command ...string) (map[string][]byte, error) {
+	execURL := urlbuilder.PathBuilder{
+		Prefix:      "/api",
+		APIGroup:    "",
+		APIVersion:  "v1",
+		Namespace:   pod.Namespace,
+		Name:        pod.Name,
+		Resource:    "pods",
+		Subresource: "exec",
+	}.URL(h.Server)
+	execURL.RawQuery = url.Values{
+		"stdout":    []string{"true"},
+		"stderr":    []string{"true"},
+		"container": []string{jobs.Helper},
+		"command":   command,
+	}.Encode()
+	conn, err := h.Dialer.DialContext(ctx, execURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &streams.Streams{
+		Output: streams.Output{
+			Out: &bytes.Buffer{},
+			Err: &bytes.Buffer{},
+		},
+		In: &bytes.Buffer{},
+	}
+
+	io := conn.ToExecIO(false)
+	code, err := term.Pipe(io, output)
+	if err != nil {
+		return nil, err
+	}
+
+	if code != 0 {
+		buf := bytes.NewBuffer(output.Out.(*bytes.Buffer).Bytes())
+		errBuf := bytes.NewBuffer(output.Err.(*bytes.Buffer).Bytes())
+		if buf.Len() > 0 && errBuf.Len() > 0 {
+			buf.WriteString("; ")
+		}
+		buf.Write(errBuf.Bytes())
+		return nil, fmt.Errorf("exit code %d: %s", code, buf)
+	}
+
+	return map[string][]byte{
+		"out": output.Out.(*bytes.Buffer).Bytes(),
+		"err": output.Err.(*bytes.Buffer).Bytes(),
+	}, nil
+}
+
+func (h *Handler) SaveJobOutput(req router.Request, resp router.Response) error {
+	pod := req.Object.(*corev1.Pod)
+	jobName := pod.Labels[labels.AcornJobName]
+
+	if jobName == "" || pod.Status.Phase != corev1.PodRunning {
+		return nil
+	}
+
+	spec := pod.Annotations[labels.AcornContainerSpec]
+	if spec == "" {
+		return nil
+	}
+
+	container := v1.Container{}
+	if err := json.Unmarshal([]byte(spec), &container); err != nil {
+		return err
+	}
+
+	names := sets.New[string](jobName)
+	for name := range container.Sidecars {
+		names.Insert(name)
+	}
+
+	for _, status := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
+		if status.State.Terminated != nil {
+			names.Delete(status.Name)
+		}
+	}
+
+	if names.Len() > 0 {
+		return nil
+	}
+
+	generation, err := getAppGeneration(req.Ctx, req.Client, pod.Namespace, jobName)
+	if err != nil {
+		return err
+	}
+
+	secretName := jobs.GetJobOutputSecretName(req.Ctx, pod.Namespace, jobName)
+
+	data, err := h.runCommand(req.Ctx, pod, "/usr/local/bin/acorn-job-get-output")
+	if err != nil {
+		return err
+	}
+
+	err = apply.New(req.Client).Ensure(req.Ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: pod.Namespace,
+			Labels: labels.ManagedByApp(pod.Labels[labels.AcornAppNamespace], pod.Labels[labels.AcornAppName],
+				labels.AcornAppGeneration, generation),
+		},
+		Data: data,
+	})
+	if err != nil {
+		return err
+	}
+
+	// ignore error, it always exits with exit code 137
+	_, _ = h.runCommand(req.Ctx, pod, "/usr/local/bin/acorn-job-helper-shutdown")
+	return nil
+}

--- a/pkg/dev/dev.go
+++ b/pkg/dev/dev.go
@@ -233,6 +233,7 @@ func updateApp(ctx context.Context, c client.Client, appName string, client v1.D
 	if err != nil {
 		return "", err
 	}
+	opts.Run.Permissions = app.Spec.Permissions
 	return app.Name, nil
 }
 

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -9,13 +9,10 @@ import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/appdefinition"
 	"github.com/acorn-io/acorn/pkg/encryption/nacl"
+	"github.com/acorn-io/baaah/pkg/name"
 	"github.com/acorn-io/baaah/pkg/router"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	klabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/strings/slices"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,17 +22,25 @@ var (
 	ErrJobNoOutput = errors.New("job has no output")
 )
 
+const (
+	Helper = "acorn-job-output-helper"
+)
+
+func GetJobOutputSecretName(ctx context.Context, namespace, jobName string) string {
+	return name.SafeHashConcatName(jobName, "output", namespace)
+}
+
 // GetOutputFor obj must be acorn internal v1.Secret, v1.Service, or string
-func GetOutputFor(ctx context.Context, c kclient.Client, appInstance *v1.AppInstance, name, serviceName string, obj interface{}) (job *batchv1.Job, err error) {
+func GetOutputFor(ctx context.Context, c kclient.Client, appInstance *v1.AppInstance, name, serviceName string, obj interface{}) (err error) {
 	defer func() {
 		if err != nil && !errors.Is(err, ErrJobNoOutput) && !errors.Is(err, ErrJobNotDone) {
 			err = errors.Join(err, ErrJobNotDone)
 		}
 	}()
 
-	job, data, err := GetOutput(ctx, c, appInstance, name)
+	data, err := getOutput(ctx, c, appInstance, name)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	switch v := obj.(type) {
@@ -43,26 +48,26 @@ func GetOutputFor(ctx context.Context, c kclient.Client, appInstance *v1.AppInst
 		*v = string(data)
 	case *v1.Secret:
 		if err := json.Unmarshal(data, v); err == nil && (v.Type != "" || len(v.Data) > 0) {
-			return job, nil
+			return nil
 		}
 		appSpec, err := asAppSpec(data)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		secret := appSpec.Secrets[serviceName]
 		secret.DeepCopyInto(v)
 	case *v1.Service:
 		appSpec, err := asAppSpec(data)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		svc := appSpec.Services[serviceName]
 		svc.DeepCopyInto(v)
 	default:
-		return nil, fmt.Errorf("invalid job output type %T", v)
+		return fmt.Errorf("invalid job output type %T", v)
 	}
 
-	return job, nil
+	return nil
 }
 
 func asAppSpec(data []byte) (*v1.AppSpec, error) {
@@ -73,7 +78,7 @@ func asAppSpec(data []byte) (*v1.AppSpec, error) {
 	return appDef.AppSpec()
 }
 
-func GetOutput(ctx context.Context, c kclient.Client, appInstance *v1.AppInstance, name string) (job *batchv1.Job, data []byte, err error) {
+func getOutput(ctx context.Context, c kclient.Client, appInstance *v1.AppInstance, name string) (data []byte, err error) {
 	defer func() {
 		if err == nil {
 			if nacl.IsAcornEncryptedData(data) {
@@ -82,90 +87,24 @@ func GetOutput(ctx context.Context, c kclient.Client, appInstance *v1.AppInstanc
 		}
 	}()
 
-	namespace := appInstance.Status.Namespace
+	secretName := GetJobOutputSecretName(ctx, appInstance.Status.Namespace, name)
+	secret := &corev1.Secret{}
 
-	if val, ok := appInstance.Status.AppSpec.Jobs[name]; ok {
-		if val.Schedule != "" {
-			name, err = getCronJobLatestJob(ctx, c, namespace, name)
-			if err != nil {
-				return nil, nil, err
-			}
-		}
+	if err := c.Get(ctx, router.Key(appInstance.Status.Namespace, secretName), secret); apierror.IsNotFound(err) {
+		return nil, ErrJobNotDone
+	} else if err != nil {
+		return nil, err
 	}
 
-	job = &batchv1.Job{}
-	err = c.Get(ctx, router.Key(namespace, name), job)
-	if err != nil {
-		return nil, nil, err
+	if len(secret.Data["err"]) > 0 {
+		return nil, errors.New(string(secret.Data["err"]))
 	}
 
-	if job.Status.Succeeded != 1 {
-		return nil, nil, ErrJobNotDone
+	if len(secret.Data["out"]) == 0 {
+		return nil, ErrJobNoOutput
 	}
 
-	sel, err := metav1.LabelSelectorAsSelector(job.Spec.Selector)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	pods := &corev1.PodList{}
-	err = c.List(ctx, pods, &kclient.ListOptions{
-		Namespace:     namespace,
-		LabelSelector: sel,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(pods.Items) == 0 {
-		return nil, nil, apierrors.NewNotFound(schema.GroupResource{
-			Resource: "pods",
-		}, "")
-	}
-
-	for _, pod := range pods.Items {
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Terminated == nil || status.State.Terminated.ExitCode != 0 {
-				continue
-			}
-			if len(status.State.Terminated.Message) > 0 {
-				return job, []byte(status.State.Terminated.Message), nil
-			}
-		}
-	}
-
-	return nil, nil, ErrJobNoOutput
-}
-
-func getCronJobLatestJob(ctx context.Context, c kclient.Client, namespace, name string) (jobName string, err error) {
-	cronJob := &batchv1.CronJob{}
-	err = c.Get(ctx, router.Key(namespace, name), cronJob)
-	if err != nil {
-		return "", err
-	}
-
-	l := klabels.SelectorFromSet(cronJob.Spec.JobTemplate.Labels)
-	if err != nil {
-		return "", err
-	}
-
-	var jobsFromCron batchv1.JobList
-	err = c.List(ctx, &jobsFromCron, &kclient.ListOptions{
-		Namespace:     namespace,
-		LabelSelector: l,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	for _, job := range jobsFromCron.Items {
-		if job.Status.CompletionTime != nil && cronJob.Status.LastSuccessfulTime != nil &&
-			job.Status.CompletionTime.Time == cronJob.Status.LastSuccessfulTime.Time {
-			return job.Name, nil
-		}
-	}
-
-	return "", ErrJobNotDone
+	return secret.Data["out"], nil
 }
 
 // ShouldRunForEvent returns true if the job is configured to run for the given event.

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -6787,6 +6787,12 @@ func schema_pkg_apis_internalacornio_v1_ContainerStatus(ref common.ReferenceCall
 							Format: "int32",
 						},
 					},
+					"runningReplicaCount": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"upToDateCount": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -58,7 +58,7 @@ var (
 
 func getTextSecretData(ctx context.Context, c kclient.Client, appInstance *v1.AppInstance, secretRef v1.Secret, secretName string) (*v1.Secret, error) {
 	var output string
-	_, err := jobs.GetOutputFor(ctx, c, appInstance, convert.ToString(secretRef.Params["job"]), secretName, &output)
+	err := jobs.GetOutputFor(ctx, c, appInstance, convert.ToString(secretRef.Params["job"]), secretName, &output)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func getTextSecretData(ctx context.Context, c kclient.Client, appInstance *v1.Ap
 
 func getJSONSecretData(ctx context.Context, c kclient.Client, appInstance *v1.AppInstance, secretRef v1.Secret, secretName string) (*v1.Secret, error) {
 	newSecret := &v1.Secret{}
-	_, err := jobs.GetOutputFor(ctx, c, appInstance, convert.ToString(secretRef.Params["job"]), secretName, newSecret)
+	err := jobs.GetOutputFor(ctx, c, appInstance, convert.ToString(secretRef.Params["job"]), secretName, newSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/acorn.go
+++ b/pkg/services/acorn.go
@@ -49,7 +49,7 @@ func forDefined(ctx context.Context, c kclient.Client, appInstance *v1.AppInstan
 		if service.GetJob() != "" {
 			service = *service.DeepCopy()
 			// Populate service from job output
-			_, err := jobs.GetOutputFor(ctx, c, appInstance, service.GetJob(), serviceName, &service)
+			err := jobs.GetOutputFor(ctx, c, appInstance, service.GetJob(), serviceName, &service)
 			if errors.Is(err, jobs.ErrJobNotDone) || errors.Is(err, jobs.ErrJobNoOutput) || apierror.IsNotFound(err) {
 				annotations[apply.AnnotationUpdate] = "false"
 				annotations[apply.AnnotationCreate] = "false"

--- a/scripts/acorn-helper-init
+++ b/scripts/acorn-helper-init
@@ -1,0 +1,2 @@
+#!/bin/sh
+cp -f /usr/local/bin/acorn-helper /.acorn/acorn-helper

--- a/scripts/acorn-job-get-output
+++ b/scripts/acorn-job-get-output
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -e /run/secrets/output ]; then
+    cat /run/secrets/output
+fi

--- a/scripts/acorn-job-helper-init
+++ b/scripts/acorn-job-helper-init
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkfifo /tmp/.fifo
+echo > /tmp/.fifo

--- a/scripts/acorn-job-helper-shutdown
+++ b/scripts/acorn-job-helper-shutdown
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat /tmp/.fifo


### PR DESCRIPTION
Previously job generated output was not securely stored
and was limited to 4k. It is not properly always stored
in a k8s secret and now limited to 1mb.
