### PR TITLE
Add TTL for Events (#1708)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_install.md
+++ b/docs/docs/100-reference/01-command-line/acorn_install.md
@@ -31,6 +31,7 @@ acorn install
       --cluster-domain strings                          The externally addressable cluster domain (default .oss-acorn.io)
       --controller-replicas int                         acorn-controller deployment replica count
       --controller-service-account-annotation strings   annotation to apply to the acorn-system service account
+      --event-ttl string                                Amount of time an Acorn event will be stored before being deleted (default '168h' - 7 days)
       --features strings                                Enable or disable features. (example foo=true,bar=false)
   -h, --help                                            help for install
       --http-endpoint-pattern string                    Go template for formatting application http endpoints. Valid variables to use are: App, Container, Namespace, Hash and ClusterDomain. (default pattern is {{hashConcat 8 .Container .App .Namespace | truncate}}.{{.ClusterDomain}})

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -427,6 +427,7 @@ type Config struct {
 	AllowTrafficFromNamespace      []string        `json:"allowTrafficFromNamespace" name:"allow-traffic-from-namespace" usage:"Namespaces that are allowed to send network traffic to all Acorn apps"`
 	ServiceLBAnnotations           []string        `json:"serviceLBAnnotations" name:"service-lb-annotation" usage:"Annotation to add to the service of type LoadBalancer. Defaults to empty. (example key=value)"`
 	AWSIdentityProviderARN         *string         `json:"awsIdentityProviderArn" name:"aws-identity-provider-arn" usage:"ARN of cluster's OpenID Connect provider registered in AWS"`
+	EventTTL                       *string         `json:"eventTTL" name:"event-ttl" usage:"Amount of time an Acorn event will be stored before being deleted (default '168h' - 7 days)"`
 	Features                       map[string]bool `json:"features" name:"features" boolmap:"true" usage:"Enable or disable features. (example foo=true,bar=false)"`
 }
 

--- a/pkg/apis/api.acorn.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/api.acorn.io/v1/zz_generated.deepcopy.go
@@ -521,6 +521,11 @@ func (in *Config) DeepCopyInto(out *Config) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EventTTL != nil {
+		in, out := &in.EventTTL, &out.EventTTL
+		*out = new(string)
+		**out = **in
+	}
 	if in.Features != nil {
 		in, out := &in.Features, &out.Features
 		*out = make(map[string]bool, len(*in))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -368,6 +368,10 @@ func merge(oldConfig, newConfig *apiv1.Config) *apiv1.Config {
 		mergedConfig.AWSIdentityProviderARN = newConfig.AWSIdentityProviderARN
 	}
 
+	if newConfig.EventTTL != nil {
+		mergedConfig.EventTTL = newConfig.EventTTL
+	}
+
 	return &mergedConfig
 }
 

--- a/pkg/controller/eventinstance/eventinstance.go
+++ b/pkg/controller/eventinstance/eventinstance.go
@@ -1,0 +1,91 @@
+package eventinstance
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/config"
+	"github.com/acorn-io/baaah/pkg/router"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const defaultTTL = 168 * time.Hour // 7 days
+
+func GCExpired() router.HandlerFunc {
+	// last stores pre-parsed TTLs from the configuration.
+	last := new(struct {
+		mu  sync.Mutex
+		raw string
+		ttl time.Duration
+	})
+
+	return handler{
+		getTTL: func(ctx context.Context, getter kclient.Reader) (time.Duration, error) {
+			cfg, err := config.Get(ctx, getter)
+			if err != nil {
+				return 0, err
+			}
+
+			cfgTTL := cfg.EventTTL
+			if cfgTTL == nil || *cfgTTL == "" {
+				return defaultTTL, nil
+			}
+
+			last.mu.Lock()
+			defer last.mu.Unlock()
+
+			if last.raw != *cfgTTL {
+				// This is a new TTL, parse and memoize
+				ttl, err := time.ParseDuration(*cfgTTL)
+				if err != nil {
+					return 0, err
+				}
+
+				last.raw, last.ttl = *cfgTTL, ttl
+			}
+
+			return last.ttl, nil
+		},
+	}.gcExpired
+}
+
+// ttlFunc is a function that returns the TTL to use for event expiration.
+type ttlFunc func(context.Context, kclient.Reader) (time.Duration, error)
+
+type handler struct {
+	getTTL ttlFunc
+}
+
+func (h handler) gcExpired(req router.Request, resp router.Response) error {
+	e := req.Object.(*v1.EventInstance)
+
+	// Get the currently configured TTL
+	ttl, err := h.getTTL(req.Ctx, req.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get event ttl: %w", err)
+	}
+
+	// Check expiration
+	if now, expiration := time.Now(), e.Observed.Add(ttl); now.Before(expiration) {
+		// Still fresh, wait until expiration
+		resp.RetryAfter(time.Until(expiration))
+		return nil
+	}
+
+	// Expired, delete the event
+	if err := req.Client.Delete(req.Ctx, e, kclient.Preconditions{
+		// Adding these preconditions prevents us from deleting an event based on old information.
+		// e.g. The observed time has been updated and the event is no longer expired.
+		UID:             &e.UID,
+		ResourceVersion: &e.ResourceVersion,
+	}); err != nil && !apierrors.IsNotFound(err) {
+		// Assume any error other than not found is transient, return error to requeue w/ backoff
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/controller/config"
 	"github.com/acorn-io/acorn/pkg/controller/defaults"
 	"github.com/acorn-io/acorn/pkg/controller/devsession"
+	"github.com/acorn-io/acorn/pkg/controller/eventinstance"
 	"github.com/acorn-io/acorn/pkg/controller/gc"
 	"github.com/acorn-io/acorn/pkg/controller/images"
 	"github.com/acorn-io/acorn/pkg/controller/ingress"
@@ -87,6 +88,9 @@ func routes(router *router.Router, registryTransport http.RoundTripper, recorder
 	router.Type(&v1.AcornImageBuildInstance{}).HandlerFunc(acornimagebuildinstance.MarkRecorded)
 
 	router.Type(&v1.ServiceInstance{}).HandlerFunc(gc.GCOrphans)
+
+	router.Type(&v1.EventInstance{}).HandlerFunc(eventinstance.GCExpired())
+
 	router.Type(&batchv1.Job{}).Selector(managedSelector).HandlerFunc(jobs.JobCleanup)
 	router.Type(&rbacv1.ClusterRole{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)
 	router.Type(&rbacv1.ClusterRoleBinding{}).Selector(managedSelector).HandlerFunc(gc.GCOrphans)

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -1909,6 +1909,12 @@ func schema_pkg_apis_apiacornio_v1_Config(ref common.ReferenceCallback) common.O
 							Format: "",
 						},
 					},
+					"eventTTL": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"features": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"object"},
@@ -1925,7 +1931,7 @@ func schema_pkg_apis_apiacornio_v1_Config(ref common.ReferenceCallback) common.O
 						},
 					},
 				},
-				Required: []string{"ingressClassName", "clusterDomains", "letsEncrypt", "letsEncryptEmail", "letsEncryptTOSAgree", "setPodSecurityEnforceProfile", "podSecurityEnforceProfile", "httpEndpointPattern", "internalClusterDomain", "acornDNS", "acornDNSEndpoint", "autoUpgradeInterval", "recordBuilds", "publishBuilders", "builderPerProject", "internalRegistryPrefix", "ignoreUserLabelsAndAnnotations", "allowUserLabels", "allowUserAnnotations", "workloadMemoryDefault", "workloadMemoryMaximum", "useCustomCABundle", "propagateProjectAnnotations", "propagateProjectLabels", "manageVolumeClasses", "networkPolicies", "ingressControllerNamespace", "allowTrafficFromNamespace", "serviceLBAnnotations", "awsIdentityProviderArn", "features"},
+				Required: []string{"ingressClassName", "clusterDomains", "letsEncrypt", "letsEncryptEmail", "letsEncryptTOSAgree", "setPodSecurityEnforceProfile", "podSecurityEnforceProfile", "httpEndpointPattern", "internalClusterDomain", "acornDNS", "acornDNSEndpoint", "autoUpgradeInterval", "recordBuilds", "publishBuilders", "builderPerProject", "internalRegistryPrefix", "ignoreUserLabelsAndAnnotations", "allowUserLabels", "allowUserAnnotations", "workloadMemoryDefault", "workloadMemoryMaximum", "useCustomCABundle", "propagateProjectAnnotations", "propagateProjectLabels", "manageVolumeClasses", "networkPolicies", "ingressControllerNamespace", "allowTrafficFromNamespace", "serviceLBAnnotations", "awsIdentityProviderArn", "eventTTL", "features"},
 			},
 		},
 	}


### PR DESCRIPTION
- Introduce a TTL (Time To Live) for events and ensure that any event
existing for a longer period of time than that TTL is deleted.
- Expose an EventTTL config field
- Default TTL to 168 hours (7 days)

Vanquishes #1708 

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
