### PR TITLE
Ensure that a built image is properly marked as not remote (#1662)

### DIFF
--- a/pkg/controller/data.go
+++ b/pkg/controller/data.go
@@ -47,7 +47,7 @@ func (c *Controller) initData(ctx context.Context) error {
 				Resources: []string{"services"},
 			},
 			{
-				Verbs:     []string{"get", "create", "patch"},
+				Verbs:     []string{"get", "create", "patch", "update"},
 				APIGroups: []string{v1.SchemeGroupVersion.Group},
 				Resources: []string{"imageinstances"},
 			},


### PR DESCRIPTION
If a user pulls an image from a remote repository and then builds the same image locally, then the image will be marked as "remote" even though it does exist locally (because it was built). This change will properly mark locally built images as not remote.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

