### PR TITLE
Add a unit test for nested acorn

### DIFF
--- a/pkg/controller/appdefinition/acorn_test.go
+++ b/pkg/controller/appdefinition/acorn_test.go
@@ -10,3 +10,7 @@ import (
 func TestAcornLabels(t *testing.T) {
 	tester.DefaultTest(t, scheme.Scheme, "testdata/acorn/labels", DeploySpec)
 }
+
+func TestAcornBasic(t *testing.T) {
+	tester.DefaultTest(t, scheme.Scheme, "testdata/acorn/basic", DeploySpec)
+}

--- a/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/appinstance.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/appinstance.yaml
@@ -1,0 +1,91 @@
+# This AppInstance is created from the nested Acorn.
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+    acorn.io/original-image: foo
+  labels:
+    acorn.io/acorn-name: acorn-name
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/parent-acorn-name: app-name
+    acorn.io/public-name: app-name.acorn-name
+  name: app-name-acorn-name-01b5d4ac
+  namespace: app-namespace
+spec:
+  image: foo
+  deployArgs:
+    myArg: value
+  autoUpgrade: true
+  notifyUpgrade: true
+  autoUpgradeInterval: "1m"
+  secrets:
+    - target: target
+      secret: app-name.secret
+  volumes:
+    - volume: vol
+      target: target
+      accessModes:
+        - readWriteOnce
+        - readWriteMany
+      size: 1Gi
+      class: volclass
+  ports:
+    - port: 4444
+      protocol: http
+  environment:
+    - name: MY_VAR
+      value: my-value
+  profiles:
+    - profileOne
+    - profileTwo
+---
+# This is the "outer" AppInstance. It should appear the same as input, except for a success condition
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  uid: 1234567890abcdef
+  name: app-name
+  namespace: app-namespace
+spec:
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: foo
+  appSpec:
+    acorns:
+      acorn-name:
+        image: foo
+        deployArgs:
+          myArg: value
+        autoUpgrade: true
+        notifyUpgrade: true
+        autoUpgradeInterval: "1m"
+        secrets:
+          - target: target
+            secret: secret
+        volumes:
+          - volume: vol
+            target: target
+            accessModes:
+              - readWriteOnce
+              - readWriteMany
+            size: 1Gi
+            class: volclass
+        publish:
+          - port: 4444
+            protocol: http
+        environment:
+          - name: MY_VAR
+            value: my-value
+        profiles:
+          - profileOne
+          - profileTwo
+  conditions:
+    - reason: Success
+      status: "True"
+      success: true
+      type: defined

--- a/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/pvc.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.vol
+    acorn.io/volume-name: vol
+  name: vol
+  namespace: app-created-namespace
+spec:
+  accessModes:
+  - ReadWriteOnce
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/secret.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    acorn.io/managed: "true"
+    acorn.io/pull-secret: "true"
+  name: acorn-name-pull-1234567890ab
+  namespace: app-created-namespace
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJpbmRleC5kb2NrZXIuaW8iOnsiYXV0aCI6Ik9nPT0ifX19
+type: kubernetes.io/dockerconfigjson

--- a/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/service.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/basic/expected.yaml.d/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: internal.acorn.io/v1
+kind: ServiceInstance
+metadata:
+  annotations:
+    acorn.io/app-generation: "0"
+  labels:
+    acorn.io/acorn-name: acorn-name
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"
+    acorn.io/public-name: app-name.acorn-name
+  name: acorn-name
+  namespace: app-created-namespace
+spec:
+  appName: app-name
+  appNamespace: app-namespace
+  default: true
+  external: app-name.acorn-name
+  labels:
+    acorn.io/acorn-name: acorn-name
+    acorn.io/app-name: app-name
+    acorn.io/app-namespace: app-namespace
+    acorn.io/managed: "true"

--- a/pkg/controller/appdefinition/testdata/acorn/basic/input.yaml
+++ b/pkg/controller/appdefinition/testdata/acorn/basic/input.yaml
@@ -1,0 +1,43 @@
+# This basic test just ensures that the nested Acorn configured in this AppInstance receives the correct configuration
+# in the resulting AppInstance created for it.
+kind: AppInstance
+apiVersion: internal.acorn.io/v1
+metadata:
+  uid: 1234567890abcdef
+  name: app-name
+  namespace: app-namespace
+spec:
+  image: test
+status:
+  namespace: app-created-namespace
+  appImage:
+    id: foo
+  appSpec:
+    acorns:
+      acorn-name:
+        image: foo
+        deployArgs:
+          myArg: value
+        autoUpgrade: true
+        notifyUpgrade: true
+        autoUpgradeInterval: "1m"
+        secrets:
+          - target: target
+            secret: secret
+        volumes:
+          - volume: vol
+            target: target
+            accessModes:
+              - readWriteOnce
+              - readWriteMany
+            size: 1Gi
+            class: volclass
+        publish:
+          - port: 4444
+            protocol: http
+        environment:
+          - name: MY_VAR
+            value: my-value
+        profiles:
+          - profileOne
+          - profileTwo


### PR DESCRIPTION
This adds a new unit test for basic configuration options for Nested Acorns.

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

