### PR TITLE
Add name validation to acorn update --pull to block nested acorns

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apps/pull.go
+++ b/pkg/server/registry/apigroups/acorn/apps/pull.go
@@ -60,7 +60,7 @@ func (s *PullAppImageStrategy) New() types.Object {
 func (v PullAppImageNameValidator) ValidateName(ctx context.Context, obj runtime.Object) (result field.ErrorList) {
 	appPullImage := obj.(*apiv1.AppPullImage)
 	if len(strings.Split(appPullImage.Name, ".")) == 2 {
-		result = append(result, field.Invalid(field.NewPath("metadata", "name"), appPullImage.Name, "invalid name\nTo update a nested Acorn or a service, update the parent Acorn instead."))
+		result = append(result, field.Invalid(field.NewPath("metadata", "name"), appPullImage.Name, "To update a nested Acorn or a service, update the parent Acorn instead."))
 		return result
 	}
 	return nil

--- a/pkg/server/registry/apigroups/acorn/apps/pull.go
+++ b/pkg/server/registry/apigroups/acorn/apps/pull.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"strings"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
@@ -9,6 +10,8 @@ import (
 	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	"github.com/acorn-io/mink/pkg/stores"
 	"github.com/acorn-io/mink/pkg/types"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,8 +22,11 @@ func NewPullAppImage(c client.WithWatch) rest.Storage {
 		WithCreate(&PullAppImageStrategy{
 			client: c,
 		}).
+		WithValidateName(PullAppImageNameValidator{}).
 		Build()
 }
+
+type PullAppImageNameValidator struct{}
 
 type PullAppImageStrategy struct {
 	client client.WithWatch
@@ -49,4 +55,13 @@ func (s *PullAppImageStrategy) Create(ctx context.Context, obj types.Object) (ty
 
 func (s *PullAppImageStrategy) New() types.Object {
 	return &apiv1.AppPullImage{}
+}
+
+func (v PullAppImageNameValidator) ValidateName(ctx context.Context, obj runtime.Object) (result field.ErrorList) {
+	appPullImage := obj.(*apiv1.AppPullImage)
+	if len(strings.Split(appPullImage.Name, ".")) == 2 {
+		result = append(result, field.Invalid(field.NewPath("metadata", "name"), appPullImage.Name, "invalid name\nTo update a nested Acorn or a service, update the parent Acorn instead."))
+		return result
+	}
+	return nil
 }

--- a/pkg/server/registry/apigroups/acorn/apps/validator.go
+++ b/pkg/server/registry/apigroups/acorn/apps/validator.go
@@ -158,7 +158,7 @@ func (s *Validator) ValidateUpdate(ctx context.Context, obj, old runtime.Object)
 	oldParams := old.(*apiv1.App)
 
 	if len(strings.Split(newParams.Name, ".")) == 2 && newParams.Name == oldParams.Name && newParams.Labels[labels.AcornParentAcornName] != "" {
-		result = append(result, field.Invalid(field.NewPath("metadata", "name"), newParams.Name, "invalid name\nTo update a nested Acorn or a service, update the parent Acorn instead."))
+		result = append(result, field.Invalid(field.NewPath("metadata", "name"), newParams.Name, "To update a nested Acorn or a service, update the parent Acorn instead."))
 		return result
 	}
 


### PR DESCRIPTION
context: https://github.com/acorn-io/acorn/issues/1710#issuecomment-1579387475

for: #1710

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

