### PR TITLE
Don't record "null" AppSpecUpdate events

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apps/events.go
+++ b/pkg/server/registry/apigroups/acorn/apps/events.go
@@ -184,5 +184,11 @@ func jsonPatch(from, to any) (json.RawMessage, error) {
 		return nil, err
 	}
 
+	if len(patch) < 1 {
+		// Marshaling an empty patch yields "null", which is harder to reason about.
+		// Return nil instead.
+		return nil, nil
+	}
+
 	return json.Marshal(patch)
 }


### PR DESCRIPTION
Stop recording events for app updates that don't modify the spec.

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
