### PR TITLE
Support auto-upgrade patterns in nested acorns

### DIFF
--- a/pkg/controller/appdefinition/acorn.go
+++ b/pkg/controller/appdefinition/acorn.go
@@ -79,14 +79,14 @@ func scopeLinks(app *v1.AppInstance, bindings v1.ServiceBindings) (result v1.Ser
 
 func toAcorn(appInstance *v1.AppInstance, tag name.Reference, pullSecrets *PullSecrets, acornName string, acorn v1.Acorn) *v1.AppInstance {
 	var image string
-	_, isPattern := autoupgrade.AutoUpgradePattern(acorn.Image)
+	pattern, isPattern := autoupgrade.AutoUpgradePattern(acorn.Image)
 	isPattern = isPattern && acorn.AutoUpgrade != nil && *acorn.AutoUpgrade
 	if isPattern {
 		image = acorn.Image
 
 		// remove the autoupgrade pattern from the end of the image for resolving the pull secret
 		// the registry is all that really matters for the pull secret so this is safe to do
-		pullSecrets.ForAcorn(acornName, image[:strings.LastIndex(image, ":")])
+		pullSecrets.ForAcorn(acornName, strings.TrimSuffix(image, ":"+pattern))
 	} else {
 		image = images.ResolveTag(tag, acorn.Image)
 		if strings.HasPrefix(acorn.Image, "sha256:") {

--- a/pkg/controller/appdefinition/acorn.go
+++ b/pkg/controller/appdefinition/acorn.go
@@ -80,7 +80,6 @@ func scopeLinks(app *v1.AppInstance, bindings v1.ServiceBindings) (result v1.Ser
 func toAcorn(appInstance *v1.AppInstance, tag name.Reference, pullSecrets *PullSecrets, acornName string, acorn v1.Acorn) *v1.AppInstance {
 	var image string
 	pattern, isPattern := autoupgrade.AutoUpgradePattern(acorn.Image)
-	isPattern = isPattern && acorn.AutoUpgrade != nil && *acorn.AutoUpgrade
 	if isPattern {
 		image = acorn.Image
 


### PR DESCRIPTION
for #1598

I verified that this works with both public and private container images.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

