### PR TITLE
Add support for local Acorn images in nested Acorns (#1605)

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -243,6 +243,9 @@ func TestBuildNestedAcornWithLocalImage(t *testing.T) {
 	// build the Nginx image
 	source := imagesource.NewImageSource("./testdata/nested/nginx.Acornfile", []string{}, []string{}, []string{})
 	image, _, err := source.GetImageAndDeployArgs(helper.GetCTX(t), c)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = c.ImageTag(helper.GetCTX(t), image, "localnginx:latest")
 	if err != nil {
 		t.Fatal(err)

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -272,5 +272,5 @@ func TestBuildNestedAcornWithLocalImage(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error when referencing local image in another project, got nil")
 	}
-	assert.Contains(t, err.Error(), "could not find local image localnginx:latest")
+	assert.Contains(t, err.Error(), "missing registry host in the tag [localnginx:latest]")
 }

--- a/integration/build/testdata/nested/nested.Acornfile
+++ b/integration/build/testdata/nested/nested.Acornfile
@@ -1,0 +1,1 @@
+acorns: nginx: image: "localnginx:latest"

--- a/integration/build/testdata/nested/nginx.Acornfile
+++ b/integration/build/testdata/nested/nginx.Acornfile
@@ -1,0 +1,8 @@
+containers: nginx: {
+	image: "ghcr.io/acorn-io/images-mirror/nginx:latest"
+	ports: "80/http"
+	files: "/usr/share/nginx/html/index.html": """
+		Nginx Acorn
+
+		"""
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -200,17 +200,14 @@ func buildAcorns(ctx *buildContext, acorns map[string]v1.AcornBuilderSpec) (map[
 				continue
 			}
 
-			var (
-				id  string
-				err error
-			)
-			if isImageRemote(ctx, acornImage.Image) {
-				id, err = pullImage(ctx, acornImage.Image)
-			} else {
-				id, err = resolveLocalImage(ctx, acornImage.Image)
-			}
+			// first attempt to resolve the image locally
+			id, err := resolveLocalImage(ctx, acornImage.Image)
 			if err != nil {
-				return nil, nil, err
+				// see if it can be pulled from a remote registry
+				id, err = pullImage(ctx, acornImage.Image)
+				if err != nil {
+					return nil, nil, err
+				}
 			}
 
 			result[key] = v1.ImageData{

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -361,16 +361,6 @@ func pullImage(ctx *buildContext, image string) (id string, err error) {
 	return pushTarget.Context().Digest(digest.String()).String(), nil
 }
 
-func isImageRemote(ctx *buildContext, image string) bool {
-	ref, err := images2.ParseReferenceNoDefault(image)
-	if err != nil {
-		return false
-	}
-
-	_, err = remote.Index(ref, ctx.remoteOpts...)
-	return err == nil
-}
-
 func resolveLocalImage(ctx *buildContext, image string) (string, error) {
 	c, err := k8sclient.Default()
 	if err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -197,13 +197,12 @@ func buildAcorns(ctx *buildContext, acorns map[string]v1.AcornBuilderSpec) (map[
 				})
 				continue
 			}
-			isRemote, err := isImageRemote(ctx, acornImage.Image)
-			if err != nil {
-				return nil, nil, err
-			}
 
-			var id string
-			if isRemote {
+			var (
+				id  string
+				err error
+			)
+			if isImageRemote(ctx, acornImage.Image) {
 				id, err = pullImage(ctx, acornImage.Image)
 			} else {
 				id, err = resolveLocalImage(ctx, acornImage.Image)
@@ -363,18 +362,18 @@ func pullImage(ctx *buildContext, image string) (id string, err error) {
 	return pushTarget.Context().Digest(digest.String()).String(), nil
 }
 
-func isImageRemote(ctx *buildContext, image string) (bool, error) {
+func isImageRemote(ctx *buildContext, image string) bool {
 	ref, err := images2.ParseReferenceNoDefault(image)
 	if err != nil {
-		return false, nil
+		return false
 	}
 
 	_, err = remote.Index(ref, ctx.remoteOpts...)
 	if err != nil {
-		return false, nil
+		return false
 	}
 
-	return true, nil
+	return true
 }
 
 func resolveLocalImage(ctx *buildContext, image string) (string, error) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -424,7 +424,7 @@ imageLoop:
 
 		return pushTarget.Context().Digest(digest).String(), nil
 	}
-	return "", fmt.Errorf("could not find local image with id %s", image)
+	return "", fmt.Errorf("could not find local image %s", image)
 }
 
 func progressClose(progress chan ggcrv1.Update) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -419,7 +419,6 @@ imageLoop:
 		}
 	}
 
-	fmt.Printf("digest: %s", digest)
 	if digest != "" {
 		pushTarget, err := imagename.ParseReference(ctx.pushRepo)
 		if err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -369,11 +369,7 @@ func isImageRemote(ctx *buildContext, image string) bool {
 	}
 
 	_, err = remote.Index(ref, ctx.remoteOpts...)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 func resolveLocalImage(ctx *buildContext, image string) (string, error) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -390,7 +390,7 @@ func resolveLocalImage(ctx *buildContext, imageName string) (string, error) {
 
 		return pushTarget.Context().Digest(image.Digest).String(), nil
 	}
-	return "", fmt.Errorf("could not find local image %s", image)
+	return "", fmt.Errorf("could not find local image %s", imageName)
 }
 
 func progressClose(progress chan ggcrv1.Update) {

--- a/pkg/buildserver/server.go
+++ b/pkg/buildserver/server.go
@@ -126,7 +126,7 @@ func (s *Server) build(ctx context.Context, messages buildclient.Messages, token
 	if err != nil {
 		return nil, err
 	}
-	image, err := build.Build(ctx, messages, token.PushRepo, token.Build.Spec, keychain)
+	image, err := build.Build(ctx, s.client, messages, token.PushRepo, token.Build.Spec, keychain)
 	if err != nil {
 		_ = s.recordBuildError(ctx, &token.Build, err)
 		return nil, err

--- a/pkg/buildserver/server.go
+++ b/pkg/buildserver/server.go
@@ -126,7 +126,7 @@ func (s *Server) build(ctx context.Context, messages buildclient.Messages, token
 	if err != nil {
 		return nil, err
 	}
-	image, err := build.Build(ctx, messages, token.PushRepo, token.Build.Spec, keychain)
+	image, err := build.Build(ctx, messages, token.PushRepo, token.Build.Namespace, token.Build.Spec, keychain)
 	if err != nil {
 		_ = s.recordBuildError(ctx, &token.Build, err)
 		return nil, err

--- a/pkg/buildserver/server.go
+++ b/pkg/buildserver/server.go
@@ -126,7 +126,7 @@ func (s *Server) build(ctx context.Context, messages buildclient.Messages, token
 	if err != nil {
 		return nil, err
 	}
-	image, err := build.Build(ctx, s.client, messages, token.PushRepo, token.Build.Spec, keychain)
+	image, err := build.Build(ctx, messages, token.PushRepo, token.Build.Spec, keychain)
 	if err != nil {
 		_ = s.recordBuildError(ctx, &token.Build, err)
 		return nil, err

--- a/pkg/controller/data.go
+++ b/pkg/controller/data.go
@@ -47,7 +47,7 @@ func (c *Controller) initData(ctx context.Context) error {
 				Resources: []string{"services"},
 			},
 			{
-				Verbs:     []string{"get", "create", "patch", "update"},
+				Verbs:     []string{"get", "create", "patch", "update", "list"},
 				APIGroups: []string{v1.SchemeGroupVersion.Group},
 				Resources: []string{"imageinstances"},
 			},

--- a/pkg/controller/data.go
+++ b/pkg/controller/data.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/config"
 	"github.com/acorn-io/acorn/pkg/system"
@@ -47,7 +48,7 @@ func (c *Controller) initData(ctx context.Context) error {
 				Resources: []string{"services"},
 			},
 			{
-				Verbs:     []string{"get", "create", "patch", "update", "list"},
+				Verbs:     []string{"get", "create", "patch", "update"},
 				APIGroups: []string{v1.SchemeGroupVersion.Group},
 				Resources: []string{"imageinstances"},
 			},
@@ -60,6 +61,11 @@ func (c *Controller) initData(ctx context.Context) error {
 				Verbs:     []string{"update"},
 				APIGroups: []string{v1.SchemeGroupVersion.Group},
 				Resources: []string{"acornimagebuildinstances/status"},
+			},
+			{
+				Verbs:     []string{"get", "list", "watch"},
+				APIGroups: []string{apiv1.SchemeGroupVersion.Group},
+				Resources: []string{"images"},
 			},
 		},
 	}, &rbacv1.ClusterRoleBinding{


### PR DESCRIPTION
for #1605

There are some things that I don't love about this approach, but this is what I have for now. I would love any feedback or suggestions. I left comments on sections of the code for additional explanation or to express my doubts.

This change causes nested Acorns to prioritize local images over remote images. So if the image specified in the Acornfile matches the ID/Name or tag of an image in the same project as the build, the local image will be used. Otherwise, it will attempt to pull it from the remote registry if it is specified.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

