### PR TITLE
Add string interpolation for image name and VCS commit sha

### DIFF
--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -169,6 +169,10 @@ func (i *Interpolator) resolveApp(keyName string) (string, bool, error) {
 			}
 			return tag.Digest(i.app.Status.AppImage.Digest).String(), true, nil
 		}
+	case "imageName":
+		return i.app.Status.AppImage.Name, true, nil
+	case "commitSha":
+		return i.app.Status.AppImage.VCS.Revision, true, nil
 	}
 	return "", false, nil
 }


### PR DESCRIPTION
I'll need this for another issue I'm working on. This will allow me to create Acorns with environment variables providing me more information about the app image they are using.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

