### PR TITLE
change: try to get existing image before converting to app (#1713)

### DIFF
--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -70,11 +70,14 @@ func ToApp(namespace, image string, opts *AppRunOptions) *apiv1.App {
 }
 
 func (c *DefaultClient) AppRun(ctx context.Context, image string, opts *AppRunOptions) (*apiv1.App, error) {
-	img, err := c.ImageGet(ctx, image)
+	img, tag, err := GetImageRef(ctx, c, image)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
-	} else if img != nil {
+	} else if err == nil && img != nil {
 		image = img.Name
+		if tag != "" {
+			image = tag
+		}
 	}
 	app := ToApp(c.Namespace, image, opts)
 	return app, translateErr(c.Client.Create(ctx, app))

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -70,6 +70,12 @@ func ToApp(namespace, image string, opts *AppRunOptions) *apiv1.App {
 }
 
 func (c *DefaultClient) AppRun(ctx context.Context, image string, opts *AppRunOptions) (*apiv1.App, error) {
+	img, err := c.ImageGet(ctx, image)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	} else if img != nil {
+		image = img.Name
+	}
 	app := ToApp(c.Namespace, image, opts)
 	return app, translateErr(c.Client.Create(ctx, app))
 }
@@ -96,6 +102,12 @@ func ToAppUpdate(ctx context.Context, c Client, name string, opts *AppUpdateOpti
 	}
 
 	if opts.Image != "" {
+		img, err := c.ImageGet(ctx, opts.Image)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		} else if img != nil {
+			opts.Image = img.Name
+		}
 		app.Spec.Image = opts.Image
 	}
 

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -108,7 +108,7 @@ func ToAppUpdate(ctx context.Context, c Client, name string, opts *AppUpdateOpti
 
 	if opts.Image != "" {
 		img, tag, err := FindImage(ctx, c, opts.Image)
-		if err != nil && !apierrors.IsNotFound(err) {
+		if err != nil && !errors.As(err, &images.ErrImageNotFound{}) {
 			return nil, err
 		} else if err == nil && img != nil {
 			opts.Image = img.Name

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -3,12 +3,14 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sort"
 	"strings"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/imageallowrules"
+	"github.com/acorn-io/acorn/pkg/images"
 	"github.com/acorn-io/acorn/pkg/publicname"
 	"github.com/acorn-io/acorn/pkg/run"
 	"github.com/acorn-io/acorn/pkg/scheme"
@@ -71,7 +73,7 @@ func ToApp(namespace, image string, opts *AppRunOptions) *apiv1.App {
 
 func (c *DefaultClient) AppRun(ctx context.Context, image string, opts *AppRunOptions) (*apiv1.App, error) {
 	img, tag, err := GetImageRef(ctx, c, image)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil && !errors.As(err, &images.ErrImageNotFound{}) {
 		return nil, err
 	} else if err == nil && img != nil {
 		image = img.Name

--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -229,3 +229,13 @@ func (c *DefaultClient) ImageList(ctx context.Context) ([]apiv1.Image, error) {
 
 	return result.Items, nil
 }
+
+// GetImageReference finds an image if exists and returns if it was found by tag
+func GetImageRef(ctx context.Context, c Client, name string) (*apiv1.Image, string, error) {
+	il, err := c.ImageList(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return images.FindImageMatch(apiv1.ImageList{Items: il}, name)
+}

--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -230,8 +230,8 @@ func (c *DefaultClient) ImageList(ctx context.Context) ([]apiv1.Image, error) {
 	return result.Items, nil
 }
 
-// GetImageReference finds an image if exists and returns if it was found by tag
-func GetImageRef(ctx context.Context, c Client, name string) (*apiv1.Image, string, error) {
+// FindImage finds an image if exists and returns whether it was found by tag
+func FindImage(ctx context.Context, c Client, name string) (*apiv1.Image, string, error) {
 	il, err := c.ImageList(ctx)
 	if err != nil {
 		return nil, "", err

--- a/pkg/rulerequest/handle.go
+++ b/pkg/rulerequest/handle.go
@@ -41,17 +41,17 @@ func PromptRun(ctx context.Context, c client.Client, dangerous bool, image strin
 		if err != nil {
 			return nil, err
 		}
-		var exImg *apiv1.Image
-		var exImgTag, exImgName string
+		var existingImg *apiv1.Image
+		var existingImgTag, existingImgName string
 
-		exImg, exImgTag, err = images.FindImageMatch(apiv1.ImageList{Items: il}, image)
+		existingImg, existingImgTag, err = images.FindImageMatch(apiv1.ImageList{Items: il}, image)
 		if err != nil && !errors.As(err, &images.ErrImageNotFound{}) {
 			return nil, err
 		} else if err == nil {
-			image = exImg.Name
-			exImgName = exImg.Name
-			if exImgTag != "" {
-				image = exImgTag
+			image = existingImg.Name
+			existingImgName = existingImg.Name
+			if existingImgTag != "" {
+				image = existingImgTag
 			}
 		}
 
@@ -59,7 +59,7 @@ func PromptRun(ctx context.Context, c client.Client, dangerous bool, image strin
 		if choice, promptErr := handleNotAllowed(dangerous, image); promptErr != nil {
 			return nil, fmt.Errorf("%s: %w", promptErr.Error(), err)
 		} else if choice != "NO" {
-			iarErr := createImageAllowRule(ctx, c, image, choice, exImgName) // exImgName to ensure that this exact image ID is allowed in addition to whatever pattern we're allowing
+			iarErr := createImageAllowRule(ctx, c, image, choice, existingImgName) // existingImgName to ensure that this exact image ID is allowed in addition to whatever pattern we're allowing
 			if iarErr != nil {
 				return nil, iarErr
 			}


### PR DESCRIPTION
The problem is that we pass the unprocessed user input into the AppSpec, which will make IAR checks fail since they match against full IDs if IDs are used, so partial ID inputs will make it fail verification and thus double-prompt users to create new IARs.

In addition to that, this PR now also adds the Image ID to the list of allowed images for every IAR that is generated from prompt, as otherwise running an app by repo-name and later by ID would result in another prompt, while that exact image was allowed before (just that time referenced by name).

Ref #1713 

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

