### PR TITLE
Add -i back to `acorn run`

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_run.md
+++ b/docs/docs/100-reference/01-command-line/acorn_run.md
@@ -55,16 +55,18 @@ acorn run [flags] IMAGE|DIRECTORY [acorn args]
 ### Options
 
 ```
-      --auto-upgrade      Enabled automatic upgrades.
-  -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help              help for run
-      --help-advanced     Show verbose help text
-  -n, --name string       Name of app to create
-      --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string     Output API request without creating app (json, yaml)
-      --profile strings   Profile to assign default values
-  -q, --quiet             Do not print status
-      --wait              Wait for app to become ready before command exiting (default: true)
+      --auto-upgrade         Enabled automatic upgrades.
+  -b, --bidirectional-sync   In interactive mode download changes in addition to uploading
+  -i, --dev                  Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
+  -f, --file string          Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help                 help for run
+      --help-advanced        Show verbose help text
+  -n, --name string          Name of app to create
+      --notify-upgrade       If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string        Output API request without creating app (json, yaml)
+      --profile strings      Profile to assign default values
+  -q, --quiet                Do not print status
+      --wait                 Wait for app to become ready before command exiting (default: true)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/acorn/pkg/dev"
 	"github.com/acorn-io/acorn/pkg/imagesource"
 	"github.com/acorn-io/acorn/pkg/rulerequest"
 	"github.com/acorn-io/acorn/pkg/wait"
@@ -129,11 +130,13 @@ var hideRunFlags = []string{"dangerous", "memory", "target-namespace", "secret",
 
 type Run struct {
 	RunArgs
-	Wait         *bool `usage:"Wait for app to become ready before command exiting (default: true)"`
-	Quiet        bool  `usage:"Do not print status" short:"q"`
-	Update       bool  `usage:"Update the app if it already exists" short:"u"`
-	Replace      bool  `usage:"Replace the app with only defined values, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
-	HelpAdvanced bool  `usage:"Show verbose help text"`
+	Dev               bool  `usage:"Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit" short:"i"`
+	BidirectionalSync bool  `usage:"In interactive mode download changes in addition to uploading" short:"b"`
+	Wait              *bool `usage:"Wait for app to become ready before command exiting (default: true)"`
+	Quiet             bool  `usage:"Do not print status" short:"q"`
+	Update            bool  `usage:"Update the app if it already exists" short:"u"`
+	Replace           bool  `usage:"Replace the app with only defined values, resetting undefined fields to default values" json:"replace,omitempty"` // Replace sets patchMode to false, resulting in a full update, resetting all undefined fields to their defaults
+	HelpAdvanced      bool  `usage:"Show verbose help text"`
 
 	out    io.Writer
 	client ClientFactory
@@ -240,6 +243,16 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 	_, err = c.Info(cmd.Context())
 	if err != nil {
 		return err
+	}
+
+	if s.Dev {
+		return dev.Dev(cmd.Context(), c, &dev.Options{
+			ImageSource:       imageSource,
+			Run:               opts,
+			Replace:           s.Replace,
+			Dangerous:         s.Dangerous,
+			BidirectionalSync: s.BidirectionalSync,
+		})
 	}
 
 	defer func() {

--- a/pkg/cli/testdata/run/acorn_run_help.txt
+++ b/pkg/cli/testdata/run/acorn_run_help.txt
@@ -44,14 +44,16 @@ Examples:
    acorn update --confirm-upgrade myapp
 
 Flags:
-      --auto-upgrade      Enabled automatic upgrades.
-  -f, --file string       Name of the build file (default "DIRECTORY/Acornfile")
-  -h, --help              help for run
-      --help-advanced     Show verbose help text
-  -n, --name string       Name of app to create
-      --notify-upgrade    If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
-  -o, --output string     Output API request without creating app (json, yaml)
-      --profile strings   Profile to assign default values
-  -q, --quiet             Do not print status
-      --wait              Wait for app to become ready before command exiting (default: true)
+      --auto-upgrade         Enabled automatic upgrades.
+  -b, --bidirectional-sync   In interactive mode download changes in addition to uploading
+  -i, --dev                  Enable interactive dev mode: build image, stream logs/status in the foreground and stop on exit
+  -f, --file string          Name of the build file (default "DIRECTORY/Acornfile")
+  -h, --help                 help for run
+      --help-advanced        Show verbose help text
+  -n, --name string          Name of app to create
+      --notify-upgrade       If true and the app is configured for auto-upgrades, you will be notified in the CLI when an upgrade is available and must confirm it
+  -o, --output string        Output API request without creating app (json, yaml)
+      --profile strings      Profile to assign default values
+  -q, --quiet                Do not print status
+      --wait                 Wait for app to become ready before command exiting (default: true)
 


### PR DESCRIPTION
This adds `--dev/-i` and `--bidirectional-sync/-b` back to the `acorn run` command.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

