### PR TITLE
Add "-c CONTAINER_NAME" to "acorn logs"

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_logs.md
+++ b/docs/docs/100-reference/01-command-line/acorn_logs.md
@@ -6,16 +6,17 @@ title: "acorn logs"
 Log all workloads from an app
 
 ```
-acorn logs [flags] [APP_NAME|CONTAINER_NAME]
+acorn logs [flags] [APP_NAME|CONTAINER_REPLICA_NAME]
 ```
 
 ### Options
 
 ```
-  -f, --follow         Follow log output
-  -h, --help           help for logs
-  -s, --since string   Show logs since timestamp (e.g. 42m for 42 minutes)
-  -n, --tail int       Number of lines in log output
+  -c, --container string   Container name or Job name within app to follow
+  -f, --follow             Follow log output
+  -h, --help               help for logs
+  -s, --since string       Show logs since timestamp (e.g. 42m for 42 minutes)
+  -n, --tail int           Number of lines in log output
 ```
 
 ### Options inherited from parent commands

--- a/pkg/apis/api.acorn.io/v1/conversion.go
+++ b/pkg/apis/api.acorn.io/v1/conversion.go
@@ -52,6 +52,11 @@ func convert_url_Values_To__LogOptions(in *url.Values, out *LogOptions, s conver
 			return err
 		}
 	}
+	if values, ok := map[string][]string(*in)["container"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_string(&values, &out.Container, s); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -169,6 +169,7 @@ type LogOptions struct {
 	Tail             *int64 `json:"tailLines,omitempty"`
 	Follow           bool   `json:"follow,omitempty"`
 	ContainerReplica string `json:"containerReplica,omitempty"`
+	Container        string `json:"container,omitempty"`
 	Since            string `json:"since,omitempty"`
 }
 

--- a/pkg/cli/log.go
+++ b/pkg/cli/log.go
@@ -12,7 +12,7 @@ import (
 func NewLogs(c CommandContext) *cobra.Command {
 	logs := &Logs{client: c.ClientFactory}
 	return cli.Command(logs, cobra.Command{
-		Use:               "logs [flags] [APP_NAME|CONTAINER_NAME]",
+		Use:               "logs [flags] [APP_NAME|CONTAINER_REPLICA_NAME]",
 		SilenceUsage:      true,
 		Short:             "Log all workloads from an app",
 		Args:              cobra.MaximumNArgs(1),
@@ -21,10 +21,11 @@ func NewLogs(c CommandContext) *cobra.Command {
 }
 
 type Logs struct {
-	Follow bool   `short:"f" usage:"Follow log output"`
-	Since  string `short:"s" usage:"Show logs since timestamp (e.g. 42m for 42 minutes)"`
-	Tail   int64  `short:"n" usage:"Number of lines in log output"`
-	client ClientFactory
+	Follow    bool   `short:"f" usage:"Follow log output"`
+	Since     string `short:"s" usage:"Show logs since timestamp (e.g. 42m for 42 minutes)"`
+	Tail      int64  `short:"n" usage:"Number of lines in log output"`
+	Container string `short:"c" usage:"Container name or Job name within app to follow"`
+	client    ClientFactory
 }
 
 func (s *Logs) Run(cmd *cobra.Command, args []string) error {
@@ -51,8 +52,9 @@ func (s *Logs) Run(cmd *cobra.Command, args []string) error {
 		tailLines = &s.Tail
 	}
 	return log.Output(cmd.Context(), c, args[0], &client.LogOptions{
-		Follow: s.Follow,
-		Tail:   tailLines,
-		Since:  s.Since,
+		Follow:    s.Follow,
+		Container: s.Container,
+		Tail:      tailLines,
+		Since:     s.Since,
 	})
 }

--- a/pkg/controller/networkpolicy/networkpolicy.go
+++ b/pkg/controller/networkpolicy/networkpolicy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/acorn-io/acorn/pkg/system"
 	"github.com/acorn-io/baaah/pkg/name"
 	"github.com/acorn-io/baaah/pkg/router"
+	"github.com/acorn-io/baaah/pkg/typed"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -105,7 +106,9 @@ func ForIngress(req router.Request, resp router.Response) error {
 		}
 	}
 
-	for svcName, ports := range svcNameToPorts {
+	for _, entry := range typed.Sorted(svcNameToPorts) {
+		svcName, ports := entry.Key, entry.Value
+
 		// get the Service from k8s
 		svc := corev1.Service{}
 		err = req.Get(&svc, ingress.Namespace, svcName)

--- a/pkg/controller/networkpolicy/testdata/networkpolicy/ingress/expected.golden
+++ b/pkg/controller/networkpolicy/testdata/networkpolicy/ingress/expected.golden
@@ -4,6 +4,38 @@ metadata:
   creationTimestamp: null
   labels:
     acorn.io/managed: "true"
+  name: acorn-my-app-my-service-nginx-9090-9090
+  namespace: my-app-namespace
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: acorn-system
+    ports:
+    - port: 9090
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      acorn.io/app-name: my-app
+      acorn.io/app-namespace: acorn
+      acorn.io/managed: "true"
+      port-number.acorn.io/9090: "true"
+      service-name.acorn.io/nginx-9090: "true"
+  policyTypes:
+  - Ingress
+status: {}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    acorn.io/managed: "true"
   name: acorn-my-app-my-service-service-7777-9999-10000
   namespace: my-app-namespace
 spec:
@@ -27,38 +59,6 @@ spec:
       acorn.io/managed: "true"
       port-number.acorn.io/9999: "true"
       service-name.acorn.io/service-7777: "true"
-  policyTypes:
-  - Ingress
-status: {}
-
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    acorn.io/managed: "true"
-  name: acorn-my-app-my-service-nginx-9090-9090
-  namespace: my-app-namespace
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: traefik
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: acorn-system
-    ports:
-    - port: 9090
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      acorn.io/app-name: my-app
-      acorn.io/app-namespace: acorn
-      acorn.io/managed: "true"
-      port-number.acorn.io/9090: "true"
-      service-name.acorn.io/nginx-9090: "true"
   policyTypes:
   - Ingress
 status: {}

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -3520,6 +3520,12 @@ func schema_pkg_apis_apiacornio_v1_LogOptions(ref common.ReferenceCallback) comm
 							Format: "",
 						},
 					},
+					"container": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"since": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/pkg/server/registry/apigroups/acorn/apps/logs.go
+++ b/pkg/server/registry/apigroups/acorn/apps/logs.go
@@ -72,6 +72,7 @@ func (i *Logs) Connect(ctx context.Context, id string, options runtime.Object, r
 			Tail:             opts.Tail,
 			Follow:           opts.Follow,
 			ContainerReplica: opts.ContainerReplica,
+			Container:        opts.Container,
 		})
 		if err != nil {
 			output <- log.Message{


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

