### PR TITLE
Don't treat deleted apps as stopped

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	cuelang.org/go v0.5.0
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2
-	github.com/acorn-io/baaah v0.0.0-20230606174542-9492a5c4791a
+	github.com/acorn-io/baaah v0.0.0-20230612001310-e46073700d8b
 	github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2 h1:EOJgnBhPm3ckljwIUHUFmATuyNtZs7HQhp/EvSUfMDc=
 github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
-github.com/acorn-io/baaah v0.0.0-20230606174542-9492a5c4791a h1:26L2Lxsuliwh6u/zne+ZJxTteC5N6nvkzOISoy+pePw=
-github.com/acorn-io/baaah v0.0.0-20230606174542-9492a5c4791a/go.mod h1:qGYUWUlv0fMWOT2qu7muOGGhrx0GU9W9hTXc1GWyyhA=
+github.com/acorn-io/baaah v0.0.0-20230612001310-e46073700d8b h1:CPQwBBuA5VOMFvvwndcjcKSXKbcbt19SNT9TR5jn2hg=
+github.com/acorn-io/baaah v0.0.0-20230612001310-e46073700d8b/go.mod h1:LtwaWrYK/VuGptWxeD5Sgl0sgJV1ksicpTzyLilow1U=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500 h1:tiM36bM+iMWuW9HM+YlM1GfNDXC7f565z8Be5epO0qM=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500/go.mod h1:y6aYj2dF/SlU205bDfA43Y5c9sa/aYr4X5GDqYJzJTU=
 github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78 h1:5zs9L/CXNkuTdJSbhFWczAorbmx67nqlqswx5CQi7XI=

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -19,6 +19,10 @@ type App struct {
 	Status v1.AppInstanceStatus `json:"status,omitempty"`
 }
 
+func (in *App) GetStopped() bool {
+	return in.Spec.Stop != nil && *in.Spec.Stop && in.DeletionTimestamp.IsZero()
+}
+
 func (in *App) GetRegion() string {
 	if in.Spec.Region != "" {
 		return in.Spec.Region

--- a/pkg/apis/internal.acorn.io/v1/appinstance.go
+++ b/pkg/apis/internal.acorn.io/v1/appinstance.go
@@ -105,8 +105,8 @@ type AppInstanceSpec struct {
 	Memory              MemoryMap        `json:"memory,omitempty"`
 }
 
-func (in *AppInstanceSpec) GetStopped() bool {
-	return in.Stop != nil && *in.Stop
+func (in *AppInstance) GetStopped() bool {
+	return in.Spec.Stop != nil && *in.Spec.Stop && in.DeletionTimestamp.IsZero()
 }
 
 func (in *AppInstanceSpec) GetAutoUpgrade() bool {

--- a/pkg/awspermissions/awspermissions.go
+++ b/pkg/awspermissions/awspermissions.go
@@ -300,7 +300,7 @@ func AWSAnnotations(ctx context.Context, c kclient.Client, app *v1.AppInstance, 
 		return nil, err
 	}
 
-	if app.Spec.GetStopped() {
+	if app.GetStopped() {
 		// strip privileges for stopped app
 		return nil, nil
 	}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -257,6 +257,10 @@ func (s *Run) Run(cmd *cobra.Command, args []string) (err error) {
 
 	defer func() {
 		if err == nil && (s.Wait == nil || *s.Wait) && app != nil {
+			app, getErr := c.AppGet(cmd.Context(), app.Name)
+			if getErr == nil && (app.GetStopped() || !app.DeletionTimestamp.IsZero()) {
+				return
+			}
 			_ = wait.App(cmd.Context(), c, app.Name, s.Quiet)
 		}
 	}()

--- a/pkg/controller/appdefinition/acorn.go
+++ b/pkg/controller/appdefinition/acorn.go
@@ -134,7 +134,7 @@ func toAcorn(appInstance *v1.AppInstance, tag name.Reference, pullSecrets *PullS
 			Profiles:            acorn.Profiles,
 			DeployArgs:          acorn.DeployArgs,
 			Publish:             acorn.Publish,
-			Stop:                appInstance.Spec.Stop,
+			Stop:                typed.Pointer(appInstance.GetStopped()),
 			Environment:         append(acorn.Environment, appInstance.Spec.Environment...),
 			Permissions:         trimPermPrefix(appInstance.Spec.Permissions, acornName),
 			AutoUpgrade:         acorn.AutoUpgrade,

--- a/pkg/controller/appdefinition/testdata/acorn/basic/expected.golden
+++ b/pkg/controller/appdefinition/testdata/acorn/basic/expected.golden
@@ -96,6 +96,7 @@ spec:
   services:
   - service: app-name.myService
     target: targetApp
+  stop: false
   volumes:
   - accessModes:
     - readWriteOnce

--- a/pkg/controller/appdefinition/testdata/acorn/labels/expected.golden
+++ b/pkg/controller/appdefinition/testdata/acorn/labels/expected.golden
@@ -125,6 +125,7 @@ spec:
     value: outervalue
   - key: override1
     value: outervalue
+  stop: false
 status:
   appImage:
     imageData: {}

--- a/pkg/controller/appdefinition/testdata/globalenv/expected.golden
+++ b/pkg/controller/appdefinition/testdata/globalenv/expected.golden
@@ -136,6 +136,7 @@ spec:
   - name: from-cli-name
     value: from-cli-value
   image: acorn-image-name
+  stop: false
 status:
   appImage:
     imageData: {}

--- a/pkg/controller/appstatus/containers.go
+++ b/pkg/controller/appstatus/containers.go
@@ -92,7 +92,7 @@ func (a *appStatusRenderer) readContainers() error {
 	}
 
 	a.app.Status.AppStatus.Stopped = false
-	if !isTransitioning && a.app.Spec.GetStopped() {
+	if !isTransitioning && a.app.GetStopped() {
 		allZero := true
 		for _, v := range a.app.Status.AppStatus.Containers {
 			if v.DesiredReplicaCount != 0 {

--- a/pkg/server/registry/apigroups/acorn/images/strategy.go
+++ b/pkg/server/registry/apigroups/acorn/images/strategy.go
@@ -51,7 +51,7 @@ func (s *Strategy) validateDelete(ctx context.Context, obj types.Object) error {
 	for _, app := range apps.Items {
 		if app.Status.AppImage.Digest != "" && app.Status.AppImage.Digest == img.Digest {
 			name := publicname.Get(&app)
-			if app.Spec.GetStopped() {
+			if app.GetStopped() {
 				name = name + " (stopped)"
 			}
 			return apierrors.NewInvalid(schema.GroupKind{

--- a/pkg/services/acorn.go
+++ b/pkg/services/acorn.go
@@ -20,7 +20,7 @@ import (
 )
 
 func publishMode(app *v1.AppInstance) v1.PublishMode {
-	if app.Spec.GetStopped() {
+	if app.GetStopped() {
 		return v1.PublishModeNone
 	}
 	return app.Spec.PublishMode


### PR DESCRIPTION
If an app is stopped and being finalized we do not want to treat it as
stopped, this is so that all containers and jobs run if there is a
delete job needed.

Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

