### PR TITLE
Support new @{} style interpolation in template secret values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace (
 require (
 	cuelang.org/go v0.5.0
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2
+	github.com/acorn-io/aml v0.0.0-20230612000521-a812941e7fab
 	github.com/acorn-io/baaah v0.0.0-20230612001310-e46073700d8b
 	github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500
 	github.com/acorn-io/namegenerator v0.0.0-20220915160418-9e3d5a0ffe78

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2 h1:EOJgnBhPm3ckljwIUHUFmATuyNtZs7HQhp/EvSUfMDc=
-github.com/acorn-io/aml v0.0.0-20230602194851-bd1a8baecfc2/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
+github.com/acorn-io/aml v0.0.0-20230612000521-a812941e7fab h1:ZJQSAT306ILs8ZDGBMuPJeQN8OCP4bPLhTBw/vHLY+s=
+github.com/acorn-io/aml v0.0.0-20230612000521-a812941e7fab/go.mod h1:UEx5RRLFjryCEHN2pM59+d8A0mPJ3VAxggJOTzPymwg=
 github.com/acorn-io/baaah v0.0.0-20230612001310-e46073700d8b h1:CPQwBBuA5VOMFvvwndcjcKSXKbcbt19SNT9TR5jn2hg=
 github.com/acorn-io/baaah v0.0.0-20230612001310-e46073700d8b/go.mod h1:LtwaWrYK/VuGptWxeD5Sgl0sgJV1ksicpTzyLilow1U=
 github.com/acorn-io/mink v0.0.0-20230523184405-ceaaa366d500 h1:tiM36bM+iMWuW9HM+YlM1GfNDXC7f565z8Be5epO0qM=

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -146,6 +146,8 @@ func generateTemplate(secrets map[string]*corev1.Secret, req router.Request, app
 		return nil, err
 	}
 
+	tempInterpolator := NewInterpolator(req.Ctx, req.Client, appInstance)
+
 	for _, entry := range typed.Sorted(secret.Data) {
 		var (
 			template       = string(entry.Value)
@@ -181,6 +183,11 @@ func generateTemplate(secrets map[string]*corev1.Secret, req router.Request, app
 
 			return images.ResolveTag(tag, digest.Image)
 		})
+
+		template, err := tempInterpolator.replace(template)
+		if err != nil {
+			return nil, err
+		}
 
 		secret.Data[entry.Key] = []byte(template)
 	}


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

