### PR TITLE
Add env values "acorn run -e ARG" style to a secret

### DIFF
--- a/pkg/cli/dev.go
+++ b/pkg/cli/dev.go
@@ -53,7 +53,7 @@ func (s *Dev) Run(cmd *cobra.Command, args []string) error {
 
 	imageSource := imagesource.NewImageSource(s.File, args, s.Profile, nil)
 
-	opts, err := s.ToOpts()
+	opts, err := s.ToOpts(cmd.Context(), c)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -22,24 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRunArgs_Env(t *testing.T) {
-	os.Setenv("x222", "y333")
-	runArgs := RunArgs{
-		UpdateArgs: UpdateArgs{
-			Env: []string{"x222", "y=1"},
-		},
-	}
-	opts, err := runArgs.ToOpts()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, "x222", opts.Env[0].Name)
-	assert.Equal(t, "y333", opts.Env[0].Value)
-	assert.Equal(t, "y", opts.Env[1].Name)
-	assert.Equal(t, "1", opts.Env[1].Value)
-}
-
 func TestRun(t *testing.T) {
 	baseMock := func(f *mocks.MockClient) {
 		f.EXPECT().AppGet(gomock.Any(), gomock.Any()).DoAndReturn(

--- a/pkg/env/parse.go
+++ b/pkg/env/parse.go
@@ -1,0 +1,53 @@
+package env
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
+	"github.com/acorn-io/acorn/pkg/client"
+	"github.com/acorn-io/baaah/pkg/randomtoken"
+)
+
+func ParseEnvForCLIAndCreateSecret(ctx context.Context, client client.Client, s ...string) (result []v1.NameValue, _ error) {
+	random, err := randomtoken.Generate()
+	if err != nil {
+		return nil, err
+	}
+	secretName := "shell-env-" + random[:8]
+	secretValues := map[string][]byte{}
+	for _, s := range s {
+		k, v, ok := strings.Cut(s, "=")
+		if ok {
+			result = append(result, v1.NameValue{
+				Name:  k,
+				Value: v,
+			})
+		} else {
+			v = os.Getenv(k)
+			if v == "" {
+				result = append(result, v1.NameValue{
+					Name:  k,
+					Value: v,
+				})
+			} else {
+				result = append(result, v1.NameValue{
+					Name:  k,
+					Value: fmt.Sprintf("@{secrets.external:%s.%s}", secretName, k),
+				})
+				secretValues[k] = []byte(v)
+			}
+		}
+	}
+
+	if len(secretValues) > 0 {
+		_, err := client.SecretCreate(ctx, secretName, "", secretValues)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
Signed-off-by: Darren Shepherd <darren@acorn.io>

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

