### PR TITLE
Ignore remote ImageInstances when resolving image for nested Acorns (#1775)

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -382,7 +382,7 @@ func resolveLocalImage(ctx *buildContext, imageName string) (string, error) {
 		return "", err
 	}
 
-	if image.Digest != "" {
+	if !image.Remote && image.Digest != "" {
 		pushTarget, err := imagename.ParseReference(ctx.pushRepo)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
for #1775

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

