### PR TITLE
add: image remote boolean in `acorn images `output (#1746)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_image.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image.md
@@ -23,7 +23,7 @@ acorn images
   -c, --containers      Show containers for images
   -h, --help            help for image
       --no-trunc        Don't truncate IDs
-  -o, --output string   Output format (json, yaml, {{gotemplate}})
+  -o, --output string   Output format (wide, json, yaml, {{gotemplate}})
   -q, --quiet           Output only names
 ```
 

--- a/pkg/cli/builder/table/writer.go
+++ b/pkg/cli/builder/table/writer.go
@@ -17,6 +17,8 @@ type Writer interface {
 	Close() error
 	Err() error
 	AddFormatFunc(name string, f FormatFunc)
+	SetFormat(format string)
+	SetValues(values [][]string, quiet bool)
 }
 
 type writer struct {
@@ -38,6 +40,14 @@ func NewWriter(values [][]string, quiet bool, format string) Writer {
 
 	t.Writer = tabwriter.NewWriter(os.Stdout, 10, 1, 3, ' ', 0)
 
+	t.SetValues(values, quiet)
+
+	t.SetFormat(format)
+
+	return t
+}
+
+func (t *writer) SetValues(values [][]string, quiet bool) {
 	t.HeaderFormat, t.ValueFormat = SimpleFormat(values)
 
 	if quiet {
@@ -49,7 +59,9 @@ func NewWriter(values [][]string, quiet bool, format string) Writer {
 			}
 		}
 	}
+}
 
+func (t *writer) SetFormat(format string) {
 	switch customFormat := format; customFormat {
 	case "json":
 		t.HeaderFormat = ""
@@ -63,6 +75,7 @@ func NewWriter(values [][]string, quiet bool, format string) Writer {
 	case "aml":
 		t.HeaderFormat = ""
 		t.ValueFormat = "aml"
+	case "wide":
 	case "raw":
 	case "table":
 	default:
@@ -71,8 +84,6 @@ func NewWriter(values [][]string, quiet bool, format string) Writer {
 			t.HeaderFormat = ""
 		}
 	}
-
-	return t
 }
 
 func (t *writer) AddFormatFunc(name string, f FormatFunc) {

--- a/pkg/cli/builder/table/writer.go
+++ b/pkg/cli/builder/table/writer.go
@@ -75,9 +75,7 @@ func (t *writer) SetFormat(format string) {
 	case "aml":
 		t.HeaderFormat = ""
 		t.ValueFormat = "aml"
-	case "wide":
-	case "raw":
-	case "table":
+	case "wide", "raw", "table":
 	default:
 		if customFormat != "" {
 			t.ValueFormat = customFormat + "\n"

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -157,6 +157,7 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 			Digest:     image.Digest,
 			Tag:        "",
 			Repository: "",
+			Remote:     image.Remote,
 		}
 
 		// no tag set at all, so only print if --all is set
@@ -215,6 +216,7 @@ type imagePrint struct {
 	Digest     string `json:"digest,omitempty"`
 	Repository string `json:"repository,omitempty"`
 	Tag        string `json:"tag,omitempty"`
+	Remote     bool   `json:"remote,omitempty"`
 }
 
 type imageContainer struct {

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -36,7 +36,7 @@ type Image struct {
 	All        bool   `usage:"Include untagged images" short:"a" local:"true"`
 	Quiet      bool   `usage:"Output only names" short:"q" local:"true"`
 	NoTrunc    bool   `usage:"Don't truncate IDs" local:"true"`
-	Output     string `usage:"Output format (json, yaml, {{gotemplate}})" short:"o" local:"true"`
+	Output     string `usage:"Output format (wide, json, yaml, {{gotemplate}})" short:"o" local:"true"`
 	Containers bool   `usage:"Show containers for images" short:"c" local:"true"`
 	client     ClientFactory
 }
@@ -138,6 +138,10 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	out := table.NewWriter(tables.ImageAcorn, false, a.Output)
+	if a.Output == "wide" {
+		out.SetValues(tables.ImageAcornWide, false)
+	}
+
 	if a.Quiet {
 		out = table.NewWriter([][]string{
 			{"Name", "{{ .Name }}"},
@@ -216,7 +220,7 @@ type imagePrint struct {
 	Digest     string `json:"digest,omitempty"`
 	Repository string `json:"repository,omitempty"`
 	Tag        string `json:"tag,omitempty"`
-	Remote     bool   `json:"remote,omitempty"`
+	Remote     bool   `json:"remote,omitempty" table:"wide"`
 }
 
 type imageContainer struct {

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -50,7 +50,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   \ntesttag1     latest    found-image-   \ntesttag2     v1        found-image-   \n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
 		},
 		{
 			name: "acorn image --no-trunc", fields: fields{
@@ -69,7 +69,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID                      REMOTE\ntesttag      latest    found-image1234567            \ntesttag1     latest    found-image-two-tags1234567   \ntesttag2     v1        found-image-two-tags1234567   \n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1234567\ntesttag1     latest    found-image-two-tags1234567\ntesttag2     v1        found-image-two-tags1234567\n",
 		},
 		{
 			name: "acorn image -a", fields: fields{
@@ -88,7 +88,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   \n<none>       <none>    found-image-   \ntesttag1     latest    found-image-   \ntesttag2     v1        found-image-   \n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\n<none>       <none>    found-image-\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
 		},
 		{
 			name: "acorn image -c ", fields: fields{
@@ -186,7 +186,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   \n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\n",
 		},
 		{
 			name: "acorn image testtag1", fields: fields{
@@ -210,7 +210,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag1     latest    found-image-   \n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag1     latest    found-image-\n",
 		},
 		{
 			name: "acorn image digest", fields: fields{
@@ -233,7 +233,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag1     latest    found-image-   \ntesttag2     v1        found-image-   \n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
 		},
 		{
 			name: "acorn image registry specific tag", fields: fields{
@@ -256,7 +256,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY                    TAG       IMAGE-ID       REMOTE\nindex.docker.io/subdir/test   v1        registy12345   \n",
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\n",
 		},
 		{
 			name: "acorn image digest multi tag", fields: fields{
@@ -279,7 +279,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY                    TAG       IMAGE-ID       REMOTE\nindex.docker.io/subdir/test   v1        registy12345   \nindex.docker.io/subdir/test   v2        registy12345   \n",
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\nindex.docker.io/subdir/test   v2        registy12345\n",
 		},
 		{
 			name: "acorn image -c digest multi tag", fields: fields{
@@ -425,35 +425,6 @@ func TestImage(t *testing.T) {
 			},
 			wantErr: false,
 			wantOut: "Untagged foo:v1\n",
-		},
-		{
-			name: "acorn image testtag remote", fields: fields{
-				All:    false,
-				Quiet:  false,
-				Output: "",
-			},
-			commandContext: CommandContext{
-				ClientFactory: &testdata.MockClientFactory{
-					ImageList: []apiv1.Image{
-						{
-							ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
-							Tags:       []string{"testtag:latest"},
-							Digest:     "1234567890asdfghkl",
-							Remote:     true,
-						},
-					},
-				},
-
-				StdOut: w,
-				StdErr: w,
-				StdIn:  strings.NewReader("y\n"),
-			},
-			args: args{
-				args:   []string{"testtag"},
-				client: &testdata.MockClient{},
-			},
-			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   *\n",
 		},
 	}
 

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -50,7 +50,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   \ntesttag1     latest    found-image-   \ntesttag2     v1        found-image-   \n",
 		},
 		{
 			name: "acorn image --no-trunc", fields: fields{
@@ -69,7 +69,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1234567\ntesttag1     latest    found-image-two-tags1234567\ntesttag2     v1        found-image-two-tags1234567\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID                      REMOTE\ntesttag      latest    found-image1234567            \ntesttag1     latest    found-image-two-tags1234567   \ntesttag2     v1        found-image-two-tags1234567   \n",
 		},
 		{
 			name: "acorn image -a", fields: fields{
@@ -88,7 +88,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\n<none>       <none>    found-image-\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   \n<none>       <none>    found-image-   \ntesttag1     latest    found-image-   \ntesttag2     v1        found-image-   \n",
 		},
 		{
 			name: "acorn image -c ", fields: fields{
@@ -186,7 +186,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag      latest    found-image1\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   \n",
 		},
 		{
 			name: "acorn image testtag1", fields: fields{
@@ -210,7 +210,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag1     latest    found-image-\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag1     latest    found-image-   \n",
 		},
 		{
 			name: "acorn image digest", fields: fields{
@@ -233,7 +233,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY   TAG       IMAGE-ID\ntesttag1     latest    found-image-\ntesttag2     v1        found-image-\n",
+			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag1     latest    found-image-   \ntesttag2     v1        found-image-   \n",
 		},
 		{
 			name: "acorn image registry specific tag", fields: fields{
@@ -256,7 +256,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\n",
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID       REMOTE\nindex.docker.io/subdir/test   v1        registy12345   \n",
 		},
 		{
 			name: "acorn image digest multi tag", fields: fields{
@@ -279,7 +279,7 @@ func TestImage(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "REPOSITORY                    TAG       IMAGE-ID\nindex.docker.io/subdir/test   v1        registy12345\nindex.docker.io/subdir/test   v2        registy12345\n",
+			wantOut: "REPOSITORY                    TAG       IMAGE-ID       REMOTE\nindex.docker.io/subdir/test   v1        registy12345   \nindex.docker.io/subdir/test   v2        registy12345   \n",
 		},
 		{
 			name: "acorn image -c digest multi tag", fields: fields{
@@ -425,6 +425,35 @@ func TestImage(t *testing.T) {
 			},
 			wantErr: false,
 			wantOut: "Untagged foo:v1\n",
+		},
+		{
+			name: "acorn image testtag remote", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{
+					ImageList: []apiv1.Image{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "found-image1234567"},
+							Tags:       []string{"testtag:latest"},
+							Digest:     "1234567890asdfghkl",
+							Remote:     true,
+						},
+					},
+				},
+
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"testtag"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\ntesttag      latest    found-image1   *\n",
 		},
 	}
 

--- a/pkg/cli/images_test.go
+++ b/pkg/cli/images_test.go
@@ -426,6 +426,34 @@ func TestImage(t *testing.T) {
 			wantErr: false,
 			wantOut: "Untagged foo:v1\n",
 		},
+		{
+			name: "acorn image -o wide", fields: fields{
+				All:    false,
+				Quiet:  false,
+				Output: "",
+			},
+			commandContext: CommandContext{
+				ClientFactory: &testdata.MockClientFactory{
+					ImageList: []apiv1.Image{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "testimg123456"},
+							Tags:       []string{"foo/bar:latest"},
+							Digest:     "sha256:abcdef1234567890",
+							Remote:     true,
+						},
+					},
+				},
+				StdOut: w,
+				StdErr: w,
+				StdIn:  strings.NewReader("y\n"),
+			},
+			args: args{
+				args:   []string{"-o", "wide"},
+				client: &testdata.MockClient{},
+			},
+			wantErr: false,
+			wantOut: "REPOSITORY   TAG       IMAGE-ID       REMOTE\nfoo/bar      latest    testimg12345   *\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cli/testdata/all/all_test_i.txt
+++ b/pkg/cli/testdata/all/all_test_i.txt
@@ -16,7 +16,7 @@ NAME           TYPE      KEYS      CREATED
 found.secret             []        292y ago
 
 IMAGES:
-REPOSITORY   TAG       IMAGE-ID
-testtag      latest    found-image1
-testtag1     latest    found-image-
-testtag2     v1        found-image-
+REPOSITORY   TAG       IMAGE-ID       REMOTE
+testtag      latest    found-image1   
+testtag1     latest    found-image-   
+testtag2     v1        found-image-   

--- a/pkg/cli/testdata/all/all_test_i.txt
+++ b/pkg/cli/testdata/all/all_test_i.txt
@@ -16,7 +16,7 @@ NAME           TYPE      KEYS      CREATED
 found.secret             []        292y ago
 
 IMAGES:
-REPOSITORY   TAG       IMAGE-ID       REMOTE
-testtag      latest    found-image1   
-testtag1     latest    found-image-   
-testtag2     v1        found-image-   
+REPOSITORY   TAG       IMAGE-ID
+testtag      latest    found-image1
+testtag1     latest    found-image-
+testtag2     v1        found-image-

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -54,12 +54,14 @@ var (
 		{"Repository", "{{if eq .Repository \"\"}}<none>{{else}}{{.Repository}}{{end}}"},
 		{"Tag", "{{if eq .Tag \"\"}}<none>{{else}}{{.Tag}}{{end}}"},
 		{"Image-ID", "{{trunc .Name}}"},
+		{"Remote", "{{if .Remote }}{{boolToStar .Remote}}{{end}}"},
 	}
 
 	// Used for kubectl image related printing
 	Image = [][]string{
 		{"Image-ID", "{{trunc .Name}}"},
 		{"Tags", "{{if .Tags}}{{else}}<none>{{end}}{{range $index, $v := .Tags}}{{if $index}},{{end}}{{if eq $v \"\"}}<none>{{else}}{{$v}}{{end}}{{end}}"},
+		{"Remote", "{{if .Remote }}{{boolToStar .Remote}}{{end}}"},
 	}
 	ImageConverter = MustConverter(Image)
 

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -54,8 +54,15 @@ var (
 		{"Repository", "{{if eq .Repository \"\"}}<none>{{else}}{{.Repository}}{{end}}"},
 		{"Tag", "{{if eq .Tag \"\"}}<none>{{else}}{{.Tag}}{{end}}"},
 		{"Image-ID", "{{trunc .Name}}"},
-		{"Remote", "{{if .Remote }}{{boolToStar .Remote}}{{end}}"},
 	}
+
+	// Wide output, including optional information
+	ImageAcornWide = append(ImageAcorn, [][]string{
+		{"Remote", "{{if .Remote }}{{boolToStar .Remote}}{{end}}"},
+	}...,
+	)
+
+	ImageWideConverter = MustConverter(ImageAcornWide)
 
 	// Used for kubectl image related printing
 	Image = [][]string{


### PR DESCRIPTION
This also affects the kubectl output.
Alternatives described [in the linked issue](https://github.com/acorn-io/acorn/issues/1746#issuecomment-1589485533).
Examples also over[ in the linked issue](https://github.com/acorn-io/acorn/issues/1746#issuecomment-1589485533).

Ref #1746

```
$ acorn images
REPOSITORY                             TAG       IMAGE-ID
ghcr.io/acorn-io/library/hello-world   latest    1a6c64d2ccd0

$ acorn images -o wide
REPOSITORY                             TAG       IMAGE-ID       REMOTE
ghcr.io/acorn-io/library/hello-world   latest    1a6c64d2ccd0   *

$ acorn images -o json
{
    "name": "1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb",
    "digest": "sha256:1a6c64d2ccd0bb035f9c8196d3bfe72a7fdbddc4530dfcb3ab2a0ab8afb57eeb",
    "repository": "ghcr.io/acorn-io/library/hello-world",
    "tag": "latest",
    "remote": true
}
```

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

