### PR TITLE
Create external service even if no ports specified (#1757)

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -148,10 +148,6 @@ func toRefService(ctx context.Context, c kclient.Client, cfg *apiv1.Config, serv
 		servicePorts = ports.ToServicePorts(targetService.Spec.Ports)
 	}
 
-	if len(servicePorts) == 0 {
-		return nil, missing, nil
-	}
-
 	newService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        service.Name,


### PR DESCRIPTION
Ports are not required to be set for services of type "external."
Therefore, create the service even if no ports are specified.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [x] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Issue: https://github.com/acorn-io/acorn/issues/1757