### PR TITLE
Disable NetworkPolicies by default

### DIFF
--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -427,7 +427,7 @@ type Config struct {
 	PropagateProjectAnnotations    []string        `json:"propagateProjectAnnotations" name:"propagate-project-annotation" usage:"The list of keys of annotations to propagate from acorn project to app namespaces"`
 	PropagateProjectLabels         []string        `json:"propagateProjectLabels" name:"propagate-project-label" usage:"The list of keys of labels to propagate from acorn project to app namespaces"`
 	ManageVolumeClasses            *bool           `json:"manageVolumeClasses" name:"manage-volume-classes" usage:"Manually manage volume classes rather than sync with storage classes, setting to 'true' will delete Acorn-created volume classes"`
-	NetworkPolicies                *bool           `json:"networkPolicies" name:"network-policies" usage:"Create Kubernetes NetworkPolicies which block cross-project network traffic (default true)"`
+	NetworkPolicies                *bool           `json:"networkPolicies" name:"network-policies" usage:"Create Kubernetes NetworkPolicies which block cross-project network traffic (default false)"`
 	IngressControllerNamespace     *string         `json:"ingressControllerNamespace" name:"ingress-controller-namespace" usage:"The namespace where the ingress controller runs - used to secure published HTTP ports with NetworkPolicies."`
 	AllowTrafficFromNamespace      []string        `json:"allowTrafficFromNamespace" name:"allow-traffic-from-namespace" usage:"Namespaces that are allowed to send network traffic to all Acorn apps"`
 	ServiceLBAnnotations           []string        `json:"serviceLBAnnotations" name:"service-lb-annotation" usage:"Annotation to add to the service of type LoadBalancer. Defaults to empty. (example key=value)"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,7 +98,7 @@ func complete(ctx context.Context, c *apiv1.Config, getter kclient.Reader) error
 		c.UseCustomCABundle = new(bool)
 	}
 	if c.NetworkPolicies == nil {
-		c.NetworkPolicies = &[]bool{true}[0]
+		c.NetworkPolicies = &[]bool{false}[0]
 	}
 	if c.IngressControllerNamespace == nil {
 		c.IngressControllerNamespace = new(string)


### PR DESCRIPTION
We need to make it very clear to users in the next release notes that this is happening.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

