### PR TITLE
Add "Sandbox" field to Region type

### DIFF
--- a/pkg/apis/api.acorn.io/v1/region.go
+++ b/pkg/apis/api.acorn.io/v1/region.go
@@ -24,6 +24,7 @@ type Region struct {
 type RegionSpec struct {
 	Description string `json:"description,omitempty"`
 	RegionName  string `json:"regionName,omitempty"`
+	Sandbox     bool   `json:"sandbox,omitempty"`
 }
 
 type RegionStatus struct {

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -3850,6 +3850,12 @@ func schema_pkg_apis_apiacornio_v1_RegionSpec(ref common.ReferenceCallback) comm
 							Format: "",
 						},
 					},
+					"sandbox": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This adds the ability to specify if a Region references a Sandbox cluster or not.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

