### PR TITLE
Support getting events by name (#1631)

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_events.md
+++ b/docs/docs/100-reference/01-command-line/acorn_events.md
@@ -6,7 +6,7 @@ title: "acorn events"
 List events about Acorn resources
 
 ```
-acorn events [flags]
+acorn events [flags] [EVENT_NAME]
 ```
 
 ### Examples
@@ -17,6 +17,9 @@ acorn events [flags]
 
   # List events across all projects
   acorn -A events
+
+  # Get a single event by name
+  acorn events 4b2ba097badf2031c4718609b9179fb5
 
   # List the last 10 events 
   acorn events --tail 10

--- a/pkg/apis/api.acorn.io/v1/scheme.go
+++ b/pkg/apis/api.acorn.io/v1/scheme.go
@@ -89,7 +89,7 @@ func AddToSchemeWithGV(scheme *runtime.Scheme, schemeGroupVersion schema.GroupVe
 		gvk := schemeGroupVersion.WithKind("Event")
 		flcf := func(label, value string) (string, string, error) {
 			switch label {
-			case "details":
+			case "details", "metadata.name", "metadata.namespace":
 				return label, value, nil
 			}
 			return "", "", fmt.Errorf("unsupported field selection [%s]", label)

--- a/pkg/channels/channels.go
+++ b/pkg/channels/channels.go
@@ -21,7 +21,7 @@ func Send[T any](ctx context.Context, to chan<- T, msgs ...T) error {
 	return nil
 }
 
-// ForEach passes each message recieved from a channel to a function.
+// ForEach passes each message received from a channel to a function.
 //
 // It blocks until the given context is closed or the function returns an error.
 func ForEach[T any](ctx context.Context, in <-chan T, do func(T) error) error {
@@ -29,7 +29,12 @@ func ForEach[T any](ctx context.Context, in <-chan T, do func(T) error) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case msg := <-in:
+		case msg, ok := <-in:
+			if !ok {
+				// Channel is closed, msg is zero value.
+				// Bail out.
+				return nil
+			}
 			if err := do(msg); err != nil {
 				return err
 			}
@@ -37,7 +42,7 @@ func ForEach[T any](ctx context.Context, in <-chan T, do func(T) error) error {
 	}
 }
 
-// Forward sends messages recieved from one channel to another.
+// Forward sends messages received from one channel to another.
 //
 // It blocks until the given context is closed.
 func Forward[T any](ctx context.Context, from <-chan T, to chan<- T) error {

--- a/pkg/cli/events.go
+++ b/pkg/cli/events.go
@@ -10,15 +10,19 @@ import (
 
 func NewEvent(c CommandContext) *cobra.Command {
 	cmd := cli.Command(&Events{client: c.ClientFactory}, cobra.Command{
-		Use:          "events [flags]",
-		SilenceUsage: true,
-		Short:        "List events about Acorn resources",
-		Args:         cobra.MaximumNArgs(0),
+		Use:               "events [flags] [EVENT_NAME]",
+		SilenceUsage:      true,
+		Short:             "List events about Acorn resources",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: newCompletion(c.ClientFactory, eventsCompletion).complete,
 		Example: `# List all events in the current project
   acorn events
 
   # List events across all projects
   acorn -A events
+
+  # Get a single event by name
+  acorn events 4b2ba097badf2031c4718609b9179fb5
 
   # List the last 10 events 
   acorn events --tail 10
@@ -53,6 +57,10 @@ func (e *Events) Run(cmd *cobra.Command, args []string) error {
 		Tail:    e.Tail,
 		Follow:  e.Follow,
 		Details: e.Details,
+	}
+
+	if len(args) > 0 {
+		opts.Name = args[0]
 	}
 
 	events, err := c.EventStream(cmd.Context(), opts)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -326,15 +326,22 @@ type EventStreamOptions struct {
 	Tail            int    `json:"tail,omitempty"`
 	Follow          bool   `json:"follow,omitempty"`
 	Details         bool   `json:"details,omitempty"`
+	Name            string `json:"name,omitempty"`
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
 
 func (o EventStreamOptions) ListOptions() *kclient.ListOptions {
+	fieldSet := make(fields.Set)
+	if o.Name != "" {
+		fieldSet["metadata.name"] = o.Name
+	}
+	if o.Details {
+		fieldSet["details"] = strconv.FormatBool(o.Details)
+	}
+
 	return &kclient.ListOptions{
-		Limit: int64(o.Tail),
-		FieldSelector: fields.Set{
-			"details": strconv.FormatBool(o.Details),
-		}.AsSelector(),
+		Limit:         int64(o.Tail),
+		FieldSelector: fieldSet.AsSelector(),
 		Raw: &metav1.ListOptions{
 			ResourceVersion: o.ResourceVersion,
 		},


### PR DESCRIPTION
## Description

Add an optional positional arg, and dynamic completion, to the acorn events subcommand to support getting an individual event by name.

## UX

```sh
$ # dynamic completions
$ acorn events <TAB>
-- completions --
4b2ba097badf2031c4718609b9179fb5  94b795130f38024b8f8abf3e1221cdff

$ acorn events 4b2ba097badf2031c4718609b9179fb5 
SOURCE               NAME                               TYPE        ACTOR          OBSERVED                                  DESCRIPTION
app/billowing-leaf   4b2ba097badf2031c4718609b9179fb5   AppCreate   system:admin   2023-06-14 10:54:12.310491212 -0400 EDT   App acorn/billowing-leaf created
```

## Addresses

https://github.com/acorn-io/acorn/issues/1631