### PR TITLE
Fix: Allow execing into jobs

### DIFF
--- a/pkg/server/registry/apigroups/acorn/containers/exec.go
+++ b/pkg/server/registry/apigroups/acorn/containers/exec.go
@@ -108,6 +108,9 @@ func (c *ContainerExec) Connect(ctx context.Context, id string, options runtime.
 	}
 
 	containerName := container.Spec.ContainerName
+	if containerName == "" {
+		containerName = container.Spec.JobName
+	}
 	if container.Spec.SidecarName != "" {
 		containerName = container.Spec.SidecarName
 	}


### PR DESCRIPTION
When execing, you need to specify which container in the pod you're
execing into. We were relying only on the
containerReplica.spec.containerName field for this, but in the case of a
job, that field is blank and jobName is set. This changes accounts for
that scenario.

Signed-off-by: Craig Jellick <craig@acorn.io>
