### PR TITLE
Fix `acorn update` so that it won't unexpectedly change the app image (#1738)

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -313,20 +313,18 @@ func (s *Run) update(ctx context.Context, c client.Client, imageSource imagesour
 		return nil, false, err
 	}
 
-	if !imageSource.IsImageSet() {
-		// If there is no image set, then lookup the existing app and use the image of the current app
-		imageSource = imageSource.WithImage(app.Status.AppImage.ID)
-	}
-
-	image, deployArgs, err := imageSource.GetImageAndDeployArgs(ctx, c)
-	if err != nil {
-		return nil, false, err
-	}
-
 	updateOpts := opts.ToUpdate()
 	updateOpts.Replace = s.Replace
-	updateOpts.Image = image
-	updateOpts.DeployArgs = deployArgs
+
+	if imageSource.IsImageSet() {
+		image, deployArgs, err := imageSource.GetImageAndDeployArgs(ctx, c)
+		if err != nil {
+			return nil, false, err
+		}
+		updateOpts.Image = image
+		updateOpts.DeployArgs = deployArgs
+	}
+
 	app, err = rulerequest.PromptUpdate(ctx, c, s.Dangerous, app.Name, updateOpts)
 	if err != nil {
 		return nil, false, err

--- a/pkg/client/app.go
+++ b/pkg/client/app.go
@@ -106,7 +106,8 @@ func ToAppUpdate(ctx context.Context, c Client, name string, opts *AppUpdateOpti
 		return app, nil
 	}
 
-	if opts.Image != "" {
+	// only change app.Spec.Image if the user specified a different image
+	if opts.Image != "" && opts.Image != app.Spec.Image {
 		img, tag, err := FindImage(ctx, c, opts.Image)
 		if err != nil && !errors.As(err, &images.ErrImageNotFound{}) {
 			return nil, err

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -58,12 +58,16 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 		var (
 			resolved string
 			err      error
+			isLocal  bool
 		)
 		if !appInstance.Status.AvailableAppImageRemote {
-			resolved, _, err = client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
+			resolved, isLocal, err = client.resolve(req.Ctx, req.Client, appInstance.Namespace, target)
 			if err != nil {
 				cond.Error(err)
 				return nil
+			} else if !isLocal {
+				// force pull from remote, since the only local image we found was marked remote, and there might be a newer version
+				resolved = target
 			}
 		} else {
 			resolved = target

--- a/pkg/controller/appdefinition/pullappimage.go
+++ b/pkg/controller/appdefinition/pullappimage.go
@@ -54,7 +54,7 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 			return nil
 		}
 
-		// skip the attempt to locally resolve if we already know that the image will be remote
+		// Skip the attempt to locally resolve if we already know that the image will be remote
 		var (
 			resolved string
 			err      error
@@ -65,8 +65,9 @@ func pullAppImage(transport http.RoundTripper, client pullClient) router.Handler
 			if err != nil {
 				cond.Error(err)
 				return nil
-			} else if !isLocal {
-				// force pull from remote, since the only local image we found was marked remote, and there might be a newer version
+			}
+			if !isLocal {
+				// Force pull from remote, since the only local image we found was marked remote, and there might be a newer version
 				resolved = target
 			}
 		} else {


### PR DESCRIPTION
for #1738

This PR fixes all three scenarios in that issue. In general, this is the behavior that I observed while testing these changes:

- Running `acorn update` without `--image` or `--pull` will not change the app's image.
- Running `acorn update --image <same image as already specified when the app was first run>` will also not change the app's image
- Running `acorn update --image <some different image>` will change the app's image to the new one that was specified
- Running `acorn update --pull` will take the `app.spec.image` (which matches exactly what the user specified as the image when they originally ran `acorn run`) and re-resolve it, prioritizing local images first. If a new image is found, the app is updated to the new image.

I put some comments in the PR to explain some of the changes.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

