### PR TITLE
Ensure logs -c CONTAINER_NAME only matches valid sidecars

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -421,9 +421,13 @@ func matchesContainer(pod *corev1.Pod, container corev1.Container, options *Opti
 		}
 	}
 
+	// user has selected a specific acorn container name (the name seen in the acornfile containers section)
 	if options != nil && options.Container != "" {
-		return pod.Labels[applabels.AcornContainerName] == options.Container ||
-			pod.Labels[applabels.AcornJobName] == options.Container
+		// Must match the acorn container name or job name on the pod
+		if pod.Labels[applabels.AcornContainerName] != options.Container &&
+			pod.Labels[applabels.AcornJobName] != options.Container {
+			return false
+		}
 	}
 
 	var validContainerNames []string


### PR DESCRIPTION
Service mesh and other injected sidecars would accidentally be
show if the user did `logs -c CONTAINER_NAME`. That has been fixed.

Signed-off-by: Darren Shepherd <darren@acorn.io>
