### PR TITLE
Refactor Resources struct and its helper functions

### DIFF
--- a/pkg/apis/internal.admin.acorn.io/v1/resources.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources.go
@@ -43,19 +43,28 @@ func (current *Resources) Add(incoming Resources) {
 
 // Remove will remove the resources of another Resources struct from the current one.
 func (current *Resources) Remove(incoming Resources, all bool) {
-	current.Apps -= incoming.Apps
-	current.Containers -= incoming.Containers
-	current.Jobs -= incoming.Jobs
-	current.Volumes -= incoming.Volumes
-	current.Images -= incoming.Images
-	current.Projects -= incoming.Projects
+	// Do not allow resources to go below 0
+	nonNegativeSubtract := func(currentVal, incomingVal int) int {
+		difference := currentVal - incomingVal
+		if difference < 0 {
+			difference = 0
+		}
+		return difference
+	}
+
+	current.Apps = nonNegativeSubtract(current.Apps, incoming.Apps)
+	current.Containers = nonNegativeSubtract(current.Containers, incoming.Containers)
+	current.Jobs = nonNegativeSubtract(current.Jobs, incoming.Jobs)
+	current.Volumes = nonNegativeSubtract(current.Volumes, incoming.Volumes)
+	current.Images = nonNegativeSubtract(current.Images, incoming.Images)
+	current.Projects = nonNegativeSubtract(current.Projects, incoming.Projects)
 
 	current.Memory.Sub(incoming.Memory)
 	current.CPU.Sub(incoming.CPU)
 
 	// Only remove persistent resources if all is true.
 	if all {
-		current.Secrets -= incoming.Secrets
+		current.Secrets = nonNegativeSubtract(current.Secrets, incoming.Secrets)
 		current.VolumeStorage.Sub(incoming.VolumeStorage)
 	}
 }
@@ -65,37 +74,32 @@ func (current *Resources) Remove(incoming Resources, all bool) {
 // an aggregated error will be returned with all exceeded resources.
 func (current *Resources) Fits(incoming Resources) error {
 	exceededResources := []string{}
-	if current.Apps <= incoming.Apps {
-		exceededResources = append(exceededResources, "Apps")
-	}
-	if current.Containers <= incoming.Containers {
-		exceededResources = append(exceededResources, "Containers")
-	}
-	if current.Jobs <= incoming.Jobs {
-		exceededResources = append(exceededResources, "Jobs")
-	}
-	if current.Volumes <= incoming.Volumes {
-		exceededResources = append(exceededResources, "Volumes")
-	}
-	if current.Secrets <= incoming.Secrets {
-		exceededResources = append(exceededResources, "Secrets")
-	}
-	if current.Images <= incoming.Images {
-		exceededResources = append(exceededResources, "Images")
-	}
-	if current.Projects <= incoming.Projects {
-		exceededResources = append(exceededResources, "Projects")
+
+	// Define function for checking int resources to keep code DRY
+	checkResource := func(resource string, currentVal, incomingVal int) {
+		if currentVal <= incomingVal {
+			exceededResources = append(exceededResources, resource)
+		}
 	}
 
-	if current.VolumeStorage.Cmp(incoming.VolumeStorage) <= 0 {
-		exceededResources = append(exceededResources, "VolumeStorage")
+	// Define function for checking quantity resources to keep code DRY
+	checkQuantityResource := func(resource string, currentVal, incomingVal resource.Quantity) {
+		if currentVal.Cmp(incomingVal) <= 0 {
+			exceededResources = append(exceededResources, resource)
+		}
 	}
-	if current.Memory.Cmp(incoming.Memory) <= 0 {
-		exceededResources = append(exceededResources, "Memory")
-	}
-	if current.CPU.Cmp(incoming.CPU) <= 0 {
-		exceededResources = append(exceededResources, "Cpu")
-	}
+
+	checkResource("Apps", current.Apps, incoming.Apps)
+	checkResource("Containers", current.Containers, incoming.Containers)
+	checkResource("Jobs", current.Jobs, incoming.Jobs)
+	checkResource("Volumes", current.Volumes, incoming.Volumes)
+	checkResource("Secrets", current.Secrets, incoming.Secrets)
+	checkResource("Images", current.Images, incoming.Images)
+	checkResource("Projects", current.Projects, incoming.Projects)
+
+	checkQuantityResource("VolumeStorage", current.VolumeStorage, incoming.VolumeStorage)
+	checkQuantityResource("Memory", current.Memory, incoming.Memory)
+	checkQuantityResource("Cpu", current.CPU, incoming.CPU)
 
 	// Build an aggregated error message for the exceeded resources
 	if len(exceededResources) > 0 {
@@ -105,40 +109,36 @@ func (current *Resources) Fits(incoming Resources) error {
 	return nil
 }
 
-// ToString will return a string representation of the Resources struct.
+// NonEmptyString will return a string representation of the non-empty
+// Resources within the struct.
 func (current *Resources) NonEmptyString() string {
-	resources := []string{}
-	if current.Apps > 0 {
-		resources = append(resources, "Apps")
-	}
-	if current.Containers > 0 {
-		resources = append(resources, "Containers")
-	}
-	if current.Jobs > 0 {
-		resources = append(resources, "Jobs")
-	}
-	if current.Volumes > 0 {
-		resources = append(resources, "Volumes")
-	}
-	if current.Secrets > 0 {
-		resources = append(resources, "Secrets")
-	}
-	if current.Images > 0 {
-		resources = append(resources, "Images")
-	}
-	if current.Projects > 0 {
-		resources = append(resources, "Images")
+	var resources []string
+
+	// Define function for checking int resources to keep code DRY
+	checkResource := func(resource string, value int) {
+		if value > 0 {
+			resources = append(resources, resource)
+		}
 	}
 
-	if !current.VolumeStorage.IsZero() {
-		resources = append(resources, "VolumeStorage")
+	// Define function for checking quantity resources to keep code DRY
+	checkQuantityResource := func(resource string, currentVal resource.Quantity) {
+		if !currentVal.IsZero() {
+			resources = append(resources, resource)
+		}
 	}
-	if !current.Memory.IsZero() {
-		resources = append(resources, "Memory")
-	}
-	if !current.CPU.IsZero() {
-		resources = append(resources, "CPU")
-	}
+
+	checkResource("Apps", current.Apps)
+	checkResource("Containers", current.Containers)
+	checkResource("Jobs", current.Jobs)
+	checkResource("Volumes", current.Volumes)
+	checkResource("Secrets", current.Secrets)
+	checkResource("Images", current.Images)
+	checkResource("Projects", current.Projects)
+
+	checkQuantityResource("VolumeStorage", current.VolumeStorage)
+	checkQuantityResource("Memory", current.Memory)
+	checkQuantityResource("Cpu", current.CPU)
 
 	return strings.Join(resources, ", ")
 }

--- a/pkg/apis/internal.admin.acorn.io/v1/resources.go
+++ b/pkg/apis/internal.admin.acorn.io/v1/resources.go
@@ -11,12 +11,15 @@ import (
 // external controllers to programmatically set the resources easier. Calls to
 // its functions are mutating.
 type Resources struct {
+	Unlimited bool `json:"unlimited,omitempty"`
+
 	Apps       int `json:"apps,omitempty"`
 	Containers int `json:"containers,omitempty"`
 	Jobs       int `json:"jobs,omitempty"`
 	Volumes    int `json:"volumes,omitempty"`
 	Secrets    int `json:"secrets,omitempty"`
 	Images     int `json:"images,omitempty"`
+	Projects   int `json:"projects,omitempty"`
 
 	VolumeStorage resource.Quantity `json:"volumeStorage,omitempty"`
 	Memory        resource.Quantity `json:"memory,omitempty"`
@@ -31,6 +34,7 @@ func (current *Resources) Add(incoming Resources) {
 	current.Volumes += incoming.Volumes
 	current.Secrets += incoming.Secrets
 	current.Images += incoming.Images
+	current.Projects += incoming.Projects
 
 	current.VolumeStorage.Add(incoming.VolumeStorage)
 	current.Memory.Add(incoming.Memory)
@@ -44,6 +48,7 @@ func (current *Resources) Remove(incoming Resources, all bool) {
 	current.Jobs -= incoming.Jobs
 	current.Volumes -= incoming.Volumes
 	current.Images -= incoming.Images
+	current.Projects -= incoming.Projects
 
 	current.Memory.Sub(incoming.Memory)
 	current.CPU.Sub(incoming.CPU)
@@ -60,87 +65,95 @@ func (current *Resources) Remove(incoming Resources, all bool) {
 // an aggregated error will be returned with all exceeded resources.
 func (current *Resources) Fits(incoming Resources) error {
 	exceededResources := []string{}
-	if current.Apps < incoming.Apps {
+	if current.Apps <= incoming.Apps {
 		exceededResources = append(exceededResources, "Apps")
 	}
-	if current.Containers < incoming.Containers {
+	if current.Containers <= incoming.Containers {
 		exceededResources = append(exceededResources, "Containers")
 	}
-	if current.Jobs < incoming.Jobs {
+	if current.Jobs <= incoming.Jobs {
 		exceededResources = append(exceededResources, "Jobs")
 	}
-	if current.Volumes < incoming.Volumes {
+	if current.Volumes <= incoming.Volumes {
 		exceededResources = append(exceededResources, "Volumes")
 	}
-	if current.Secrets < incoming.Secrets {
+	if current.Secrets <= incoming.Secrets {
 		exceededResources = append(exceededResources, "Secrets")
 	}
-	if current.Images < incoming.Images {
+	if current.Images <= incoming.Images {
 		exceededResources = append(exceededResources, "Images")
 	}
+	if current.Projects <= incoming.Projects {
+		exceededResources = append(exceededResources, "Projects")
+	}
 
-	if current.VolumeStorage.Cmp(incoming.VolumeStorage) < 0 {
+	if current.VolumeStorage.Cmp(incoming.VolumeStorage) <= 0 {
 		exceededResources = append(exceededResources, "VolumeStorage")
 	}
-	if current.Memory.Cmp(incoming.Memory) < 0 {
+	if current.Memory.Cmp(incoming.Memory) <= 0 {
 		exceededResources = append(exceededResources, "Memory")
 	}
-	if current.CPU.Cmp(incoming.CPU) < 0 {
+	if current.CPU.Cmp(incoming.CPU) <= 0 {
 		exceededResources = append(exceededResources, "Cpu")
 	}
 
 	// Build an aggregated error message for the exceeded resources
 	if len(exceededResources) > 0 {
-		return fmt.Errorf("exceeded quota for resources: %s", strings.Join(exceededResources, ", "))
+		return fmt.Errorf("quota would be exceeded for resources: %s", strings.Join(exceededResources, ", "))
 	}
 
 	return nil
 }
 
 // ToString will return a string representation of the Resources struct.
-func (current *Resources) ToString() string {
+func (current *Resources) NonEmptyString() string {
 	resources := []string{}
 	if current.Apps > 0 {
-		resources = append(resources, fmt.Sprintf("Apps:%v", current.Apps))
+		resources = append(resources, "Apps")
 	}
 	if current.Containers > 0 {
-		resources = append(resources, fmt.Sprintf("Containers:%v", current.Containers))
+		resources = append(resources, "Containers")
 	}
 	if current.Jobs > 0 {
-		resources = append(resources, fmt.Sprintf("Jobs:%v", current.Jobs))
+		resources = append(resources, "Jobs")
 	}
 	if current.Volumes > 0 {
-		resources = append(resources, fmt.Sprintf("Volumes:%v", current.Volumes))
+		resources = append(resources, "Volumes")
 	}
 	if current.Secrets > 0 {
-		resources = append(resources, fmt.Sprintf("Secrets:%v", current.Secrets))
+		resources = append(resources, "Secrets")
 	}
 	if current.Images > 0 {
-		resources = append(resources, fmt.Sprintf("Images:%v", current.Images))
+		resources = append(resources, "Images")
+	}
+	if current.Projects > 0 {
+		resources = append(resources, "Images")
 	}
 
 	if !current.VolumeStorage.IsZero() {
-		resources = append(resources, fmt.Sprintf("VolumeStorage:%v", current.VolumeStorage))
+		resources = append(resources, "VolumeStorage")
 	}
 	if !current.Memory.IsZero() {
-		resources = append(resources, fmt.Sprintf("Memory:%v", current.Memory))
+		resources = append(resources, "Memory")
 	}
 	if !current.CPU.IsZero() {
-		resources = append(resources, fmt.Sprintf("CPU:%v", current.CPU))
+		resources = append(resources, "CPU")
 	}
 
-	return strings.Join(resources, ",")
+	return strings.Join(resources, ", ")
 }
 
 // Equals will check if the current Resources struct is equal to another. This is useful
 // to avoid needing to do a deep equal on the entire struct.
 func (current *Resources) Equals(incoming Resources) bool {
-	return current.Apps == incoming.Apps &&
+	return current.Unlimited == incoming.Unlimited &&
+		current.Apps == incoming.Apps &&
 		current.Containers == incoming.Containers &&
 		current.Jobs == incoming.Jobs &&
 		current.Volumes == incoming.Volumes &&
 		current.Secrets == incoming.Secrets &&
 		current.Images == incoming.Images &&
+		current.Projects == incoming.Projects &&
 		current.VolumeStorage.Cmp(incoming.VolumeStorage) == 0 &&
 		current.Memory.Cmp(incoming.Memory) == 0 &&
 		current.CPU.Cmp(incoming.CPU) == 0

--- a/pkg/controller/quota/quota.go
+++ b/pkg/controller/quota/quota.go
@@ -53,7 +53,7 @@ func WaitForAllocation(req router.Request, resp router.Response) error {
 		4. Exists and has successfully allocated the resources requested.
 	*/
 	if quotaRequest.Status.FailedResources != nil {
-		status.Error(fmt.Errorf("failed to provision the following resources: %v", quotaRequest.Status.FailedResources.ToString()))
+		status.Error(fmt.Errorf("failed to provision the following resources: %v", quotaRequest.Status.FailedResources.NonEmptyString()))
 	} else if cond := quotaRequest.Status.Condition(adminv1.QuotaRequestCondition); cond.Error {
 		status.Error(fmt.Errorf("error occurred while trying to allocate quota: %v", cond.Message))
 	} else if err != nil || !quotaRequest.Spec.Resources.Equals(quotaRequest.Status.AllocatedResources) {

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -11837,6 +11837,12 @@ func schema_pkg_apis_internaladminacornio_v1_Resources(ref common.ReferenceCallb
 				Description: "Resources is a struct separate from the QuotaRequestInstanceSpec to allow for external controllers to programmatically set the resources easier. Calls to its functions are mutating.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"unlimited": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"apps": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
@@ -11868,6 +11874,12 @@ func schema_pkg_apis_internaladminacornio_v1_Resources(ref common.ReferenceCallb
 						},
 					},
 					"images": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
+					"projects": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
 							Format: "int32",


### PR DESCRIPTION
Donnie brought up a good point about why these resources aren't represented in the runtime `Resources` struct. I am adding those and also making some UX improvements for them.
### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

