### PR TITLE
Bump k3s to 1.27 in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           go-version: "1.20"
       - uses: debianmaster/actions-k3s@v1.0.5
         with:
-          version: 'v1.27.2+k3s1'
+          version: 'v1.27.2-k3s1'
       - run: make validate-code
       - run: make build
       - run: docker buildx install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           go-version: "1.20"
       - uses: debianmaster/actions-k3s@v1.0.5
         with:
-          version: 'v1.23.6-k3s1'
+          version: 'v1.27.2+k3s1'
       - run: make validate-code
       - run: make build
       - run: docker buildx install


### PR DESCRIPTION
Tests seem less flaky now. I ran the CI five times and nothing failed.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

