### PR TITLE
Consistent json/yaml output no types

### DIFF
--- a/docs/docs/100-reference/01-command-line/acorn_image_details.md
+++ b/docs/docs/100-reference/01-command-line/acorn_image_details.md
@@ -19,7 +19,7 @@ acorn image details my-image
 
 ```
   -h, --help            help for details
-  -o, --output string   Output format (json, yaml, aml) (default "aml")
+  -o, --output string   Output format (json, yaml, aml) (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/apis/api.acorn.io/v1/types.go
+++ b/pkg/apis/api.acorn.io/v1/types.go
@@ -326,6 +326,14 @@ type Credential struct {
 	Username      string  `json:"username,omitempty"`
 	Password      *string `json:"password,omitempty"`
 	SkipChecks    bool    `json:"skipChecks,omitempty"`
+	LocalStorage  bool    `json:"localStorage,omitempty"`
+}
+
+func (c *Credential) GetPassword() string {
+	if c.Password == nil {
+		return ""
+	}
+	return *c.Password
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -56,10 +56,10 @@ func (a *App) Run(cmd *cobra.Command, args []string) error {
 		}
 		if len(args) > 0 {
 			if slices.Contains(args, app.Name) {
-				out.Write(app)
+				out.Write(&app)
 			}
 		} else {
-			out.Write(app)
+			out.Write(&app)
 		}
 	}
 

--- a/pkg/cli/builder/table/writer.go
+++ b/pkg/cli/builder/table/writer.go
@@ -1,19 +1,32 @@
 package table
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"text/template"
 
 	"github.com/acorn-io/aml"
 	"github.com/liggitt/tabwriter"
 	"golang.org/x/exp/maps"
+	"k8s.io/apimachinery/pkg/runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	yaml2 "sigs.k8s.io/yaml"
 )
 
 type Writer interface {
-	Write(obj any)
+	Write(obj kclient.Object)
+	// WriteFormatted will write a newly formatted object that follows the default
+	// pattern passed to the NewWriter function.  If the format has been overwritten
+	// by the use the formatted object will not be passed to the custom format, but
+	// instead the kclient.Object if not nil.  This gives consistency in that users custom
+	// formatting always applies to the source kclient.Object, not the intermediate formatted
+	// object that was created.
+	//
+	// sourceObj may be nil
+	WriteFormatted(formattedObj any, sourceObj kclient.Object)
 	Close() error
 	Err() error
 	Flush() error
@@ -24,10 +37,18 @@ type writer struct {
 	closed        bool
 	HeaderFormat  string
 	ValueFormat   string
-	err           error
+	errs          []error
 	headerPrinted bool
 	Writer        *tabwriter.Writer
+	buffered      []buffered
+	customFormat  bool
+	dataFormat    bool
 	funcMap       map[string]any
+}
+
+type buffered struct {
+	formatted any
+	obj       runtime.Object
 }
 
 type FormatFunc any
@@ -51,26 +72,16 @@ func NewWriter(values [][]string, quiet bool, format string) Writer {
 		}
 	}
 
-	switch customFormat := format; customFormat {
-	case "json":
+	switch {
+	case isDataFormat(format):
 		t.HeaderFormat = ""
-		t.ValueFormat = "json"
-	case "jsoncompact":
-		t.HeaderFormat = ""
-		t.ValueFormat = "jsoncompact"
-	case "yaml":
-		t.HeaderFormat = ""
-		t.ValueFormat = "yaml"
-	case "aml":
-		t.HeaderFormat = ""
-		t.ValueFormat = "aml"
-	case "raw":
-	case "table":
+		t.ValueFormat = format
+		t.dataFormat = true
+	case format == "" || format == "table":
 	default:
-		if customFormat != "" {
-			t.ValueFormat = customFormat + "\n"
-			t.HeaderFormat = ""
-		}
+		t.HeaderFormat = ""
+		t.ValueFormat = format + "\n"
+		t.customFormat = true
 	}
 
 	return t
@@ -87,90 +98,205 @@ func (t *writer) Err() error {
 func (t *writer) writeHeader() {
 	if t.HeaderFormat != "" && !t.headerPrinted {
 		t.headerPrinted = true
-		t.err = t.printTemplate(t.Writer, t.HeaderFormat, struct{}{})
-		if t.err != nil {
-			return
-		}
+		err := t.printTemplate(t.Writer, t.HeaderFormat, struct{}{})
+		_ = t.saveErr(err)
 	}
 }
 
-func (t *writer) Write(obj any) {
-	if t.err != nil {
+func (t *writer) Write(obj kclient.Object) {
+	t.WriteFormatted(nil, obj)
+}
+
+func (t *writer) WriteFormatted(formatted any, obj kclient.Object) {
+	if len(t.errs) > 0 || (obj == nil && formatted == nil) {
 		return
 	}
 
-	if obj, ok := obj.(kclient.Object); ok {
+	if obj != nil {
+		obj = obj.DeepCopyObject().(kclient.Object)
 		obj.SetManagedFields(nil)
 	}
 
 	t.writeHeader()
-	if t.err != nil {
+	if len(t.errs) > 0 {
 		return
 	}
 
-	switch t.ValueFormat {
-	case "json":
-		content, err := FormatJSON(obj)
-		t.err = err
-		if t.err != nil {
-			return
-		}
-		_, t.err = t.Writer.Write([]byte(content + "\n"))
-	case "jsoncompact":
-		content, err := FormatJSONCompact(obj)
-		t.err = err
-		if t.err != nil {
-			return
-		}
-		_, t.err = t.Writer.Write([]byte(content))
-	case "yaml":
-		content, err := FormatJSON(obj)
-		t.err = err
-		if t.err != nil {
-			return
-		}
-		converted, err := yaml2.JSONToYAML([]byte(content))
-		t.err = err
-		if t.err != nil {
-			return
-		}
-		_, t.err = t.Writer.Write([]byte("---\n"))
-		if t.err != nil {
-			return
-		}
-		_, t.err = t.Writer.Write(append(converted, []byte("\n")...))
-	case "aml":
-		content, err := aml.Marshal(obj)
-		t.err = err
-		if t.err != nil {
-			return
-		}
-		_, t.err = t.Writer.Write([]byte(string(content) + "\n"))
+	switch {
+	case t.dataFormat:
+		// write later
+		t.buffered = append(t.buffered, buffered{
+			formatted: formatted,
+			obj:       obj,
+		})
+	case t.customFormat:
+		// for a custom format prefer the kclient.Object over the formatted object
+		t.writeObject(obj, formatted)
 	default:
-		t.err = t.printTemplate(t.Writer, t.ValueFormat, obj)
+		// for default format prefer the formatted object over the kclient.Object
+		t.writeObject(formatted, obj)
+	}
+}
+
+// writeObject will write the first not nil entry with the table writer
+func (t *writer) writeObject(objs ...any) {
+	for _, obj := range objs {
+		if obj == nil {
+			continue
+		}
+		err := t.printTemplate(t.Writer, t.ValueFormat, obj)
+		_ = t.saveErr(err)
+		break
 	}
 }
 
 func (t *writer) Flush() error {
+	return t.flush(false)
+}
+
+func (t *writer) saveErr(err error) bool {
+	if err != nil {
+		t.errs = append(t.errs, err)
+	}
+	return err != nil
+}
+
+func (t *writer) writeDataObject(objs ...any) error {
+	for i, obj := range objs {
+		switch t.ValueFormat {
+		case "json":
+			if i > 0 {
+				_, err := t.Writer.Write([]byte("\n"))
+				if t.saveErr(err) {
+					continue
+				}
+			}
+			content, err := FormatJSON(obj)
+			if t.saveErr(err) {
+				continue
+			}
+			_, err = t.Writer.Write([]byte(content + "\n"))
+			if t.saveErr(err) {
+				continue
+			}
+		case "jsoncompact":
+			if i > 0 {
+				_, err := t.Writer.Write([]byte("\n"))
+				if t.saveErr(err) {
+					continue
+				}
+			}
+			content, err := FormatJSONCompact(obj)
+			if t.saveErr(err) {
+				continue
+			}
+			_, err = t.Writer.Write([]byte(content))
+			if t.saveErr(err) {
+				continue
+			}
+		case "yaml":
+			content, err := FormatJSON(obj)
+			if t.saveErr(err) {
+				continue
+			}
+
+			converted, err := yaml2.JSONToYAML([]byte(content))
+			if t.saveErr(err) {
+				continue
+			}
+
+			_, err = t.Writer.Write([]byte("---\n"))
+			if t.saveErr(err) {
+				continue
+			}
+			_, err = t.Writer.Write(append(converted, []byte("\n")...))
+			if t.saveErr(err) {
+				continue
+			}
+		case "aml":
+			content, err := aml.Marshal(obj)
+			if t.saveErr(err) {
+				continue
+			}
+			_, err = t.Writer.Write([]byte(string(content) + "\n"))
+			if t.saveErr(err) {
+				continue
+			}
+		default:
+			t.saveErr(fmt.Errorf("invalid format for writing data %s", t.ValueFormat))
+		}
+	}
+
+	return errors.Join(t.errs...)
+}
+
+func (t *writer) flush(closing bool) error {
+	if len(t.errs) > 0 {
+		return errors.Join(t.errs...)
+	}
+
+	defer func() {
+		t.buffered = nil
+	}()
+
+	// buffered object only exist for data formats
+	if len(t.buffered) > 0 {
+		var (
+			objs []any
+			seen = map[any]struct{}{}
+		)
+		for _, buffered := range t.buffered {
+			objToWrite := any(buffered.obj)
+			if objToWrite == nil {
+				objToWrite = buffered.formatted
+			}
+			if objToWrite != nil {
+				if _, ok := seen[reflect.ValueOf(objToWrite)]; ok {
+					continue
+				}
+				seen[reflect.ValueOf(objToWrite)] = struct{}{}
+				objs = append(objs, objToWrite)
+			}
+		}
+
+		if closing {
+			// if we are closing, then we want to print objects its in a proper list
+			// data structure
+			err := t.writeDataObject(map[string]any{
+				"items": objs,
+			})
+			if err != nil {
+				return err
+			}
+		} else {
+			// if we are not closing, then we want to print objects in a stream fashion, which is
+			// just objects at the top level
+			err := t.writeDataObject(objs...)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return t.Writer.Flush()
 }
 
 func (t *writer) Close() error {
 	if t.closed {
-		return t.err
+		return errors.Join(t.errs...)
 	}
-	if t.err != nil {
-		return t.err
+	if len(t.errs) > 0 {
+		return errors.Join(t.errs...)
 	}
 
 	defer func() {
 		t.closed = true
 	}()
 	t.writeHeader()
-	if t.err != nil {
-		return t.err
+	if len(t.errs) > 0 {
+		return errors.Join(t.errs...)
 	}
-	return t.Flush()
+	return t.flush(true)
 }
 
 func (t *writer) printTemplate(out io.Writer, templateContent string, obj any) error {
@@ -180,4 +306,13 @@ func (t *writer) printTemplate(out io.Writer, templateContent string, obj any) e
 	}
 
 	return tmpl.Execute(out, obj)
+}
+
+func isDataFormat(format string) bool {
+	switch format {
+	case "aml", "json", "jsoncompact", "yaml":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/cli/check.go
+++ b/pkg/cli/check.go
@@ -51,7 +51,7 @@ func (a *Check) Run(cmd *cobra.Command, args []string) error {
 	if !a.Quiet {
 		out := table.NewWriter(tables.CheckResult, a.Quiet, a.Output)
 		for _, r := range checkresult {
-			out.Write(&r)
+			out.WriteFormatted(&r, nil)
 		}
 		if err := out.Err(); err != nil {
 			fmt.Println(err)

--- a/pkg/cli/computeclasses.go
+++ b/pkg/cli/computeclasses.go
@@ -50,7 +50,7 @@ func (a *ComputeClass) Run(cmd *cobra.Command, args []string) error {
 
 	for _, cc := range computeClasses {
 		if len(args) == 0 || slices.Contains(args, cc.Name) {
-			out.Write(cc)
+			out.Write(&cc)
 		}
 	}
 

--- a/pkg/cli/containers.go
+++ b/pkg/cli/containers.go
@@ -69,7 +69,7 @@ func (a *Container) Run(cmd *cobra.Command, args []string) error {
 		}
 		for _, container := range containers {
 			if slices.Contains(args, container.Name) {
-				out.Write(container)
+				out.Write(&container)
 			}
 		}
 	}

--- a/pkg/cli/credential.go
+++ b/pkg/cli/credential.go
@@ -59,11 +59,11 @@ func (a *Credential) Run(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			if slices.Contains(args, credential.ServerAddress) {
 				found = true
-				out.Write(credential)
+				out.Write(&credential)
 			}
 		} else {
 			found = true
-			out.Write(credential)
+			out.Write(&credential)
 		}
 	}
 

--- a/pkg/cli/credential_login.go
+++ b/pkg/cli/credential_login.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/acorn-io/acorn/pkg/config"
@@ -123,10 +124,10 @@ func (a *CredentialLogin) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = store.Add(cmd.Context(), credentials.Credential{
+	err = store.Add(cmd.Context(), apiv1.Credential{
 		ServerAddress: serverAddress,
 		Username:      a.Username,
-		Password:      a.Password,
+		Password:      &a.Password,
 		LocalStorage:  a.LocalStorage,
 	}, a.SkipChecks)
 	if err != nil {

--- a/pkg/cli/credential_logout.go
+++ b/pkg/cli/credential_logout.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/acorn-io/acorn/pkg/config"
@@ -57,7 +58,7 @@ func (a *CredentialLogout) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = store.Remove(cmd.Context(), credentials2.Credential{
+	err = store.Remove(cmd.Context(), apiv1.Credential{
 		ServerAddress: args[0],
 		LocalStorage:  a.LocalStorage,
 	})

--- a/pkg/cli/events.go
+++ b/pkg/cli/events.go
@@ -70,7 +70,7 @@ func (e *Events) Run(cmd *cobra.Command, args []string) error {
 
 	out := table.NewWriter(tables.Event, false, e.Output)
 	for event := range events {
-		out.Write(event)
+		out.Write(&event)
 
 		if !opts.Follow {
 			// Wait to flush until all events have been written.

--- a/pkg/cli/images.go
+++ b/pkg/cli/images.go
@@ -161,7 +161,7 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 
 		// no tag set at all, so only print if --all is set
 		if len(image.Tags) == 0 && a.All {
-			out.Write(imagePrint)
+			out.WriteFormatted(imagePrint, &image)
 			continue
 		}
 
@@ -189,16 +189,16 @@ func (a *Image) Run(cmd *cobra.Command, args []string) error {
 					// it's a tag, so add the tag output
 					imagePrint.Tag = ntag.TagStr()
 				}
-				out.Write(imagePrint)
+				out.WriteFormatted(imagePrint, &image)
 			} else if tagToMatch == imageTagRef.Name() || repoToMatch == imageTagRef.Context().Name() {
 				// > searching by tag
 				if ntag, ok := imageTagRef.(name.Tag); ok {
 					// it's a tag, so add the tag output
 					imagePrint.Tag = ntag.TagStr()
-					out.Write(imagePrint)
+					out.WriteFormatted(imagePrint, &image)
 				} else if _, ok := imageTagRef.(name.Digest); ok {
 					// it's a digest, so print without a tag
-					out.Write(imagePrint)
+					out.WriteFormatted(imagePrint, &image)
 				}
 			}
 
@@ -257,7 +257,7 @@ func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Cl
 			if len(imageContainer.Tags) == 0 && a.All {
 				imageContainerPrint.Tag = "<none>"
 				imageContainerPrint.Repo = "<none>"
-				out.Write(imageContainerPrint)
+				out.WriteFormatted(imageContainerPrint, &image)
 				continue
 			}
 			for _, tag := range imageContainer.Tags {
@@ -271,7 +271,7 @@ func printContainerImages(images []apiv1.Image, ctx context.Context, c client.Cl
 						imageContainerPrint.Repo = imageParsedTag.RegistryStr() + "/"
 					}
 					imageContainerPrint.Repo += imageParsedTag.RepositoryStr()
-					out.Write(imageContainerPrint)
+					out.WriteFormatted(imageContainerPrint, &image)
 					imageContainerPrint.Repo = ""
 				}
 			}

--- a/pkg/cli/images_detail.go
+++ b/pkg/cli/images_detail.go
@@ -1,13 +1,11 @@
 package cli
 
 import (
-	"fmt"
-
 	cli "github.com/acorn-io/acorn/pkg/cli/builder"
+	"github.com/acorn-io/acorn/pkg/cli/builder/table"
 	"github.com/acorn-io/acorn/pkg/client"
 	"github.com/acorn-io/acorn/pkg/config"
 	"github.com/acorn-io/acorn/pkg/credentials"
-	"github.com/acorn-io/aml"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +25,7 @@ func NewImageDetails(c CommandContext) *cobra.Command {
 
 type ImageDetails struct {
 	client ClientFactory
-	Output string `usage:"Output format (json, yaml, aml)" short:"o" local:"true" default:"aml"`
+	Output string `usage:"Output format (json, yaml, aml)" short:"o" local:"true" default:"yaml"`
 }
 
 func (a *ImageDetails) Run(cmd *cobra.Command, args []string) error {
@@ -69,14 +67,8 @@ func (a *ImageDetails) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	switch a.Output {
-	case "aml":
-		out, err := aml.Marshal(image.AppImage)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("%s\n", out)
-	}
+	w := table.NewWriter(nil, false, a.Output)
+	w.WriteFormatted(image.AppImage, nil)
 
-	return nil
+	return w.Close()
 }

--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -77,7 +77,7 @@ func (s *Info) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	out := table.NewWriter(tables.Info, false, s.Output)
-	out.Write(InfoCLIResponse{
+	out.WriteFormatted(InfoCLIResponse{
 		Client: struct {
 			Version bversion.Version  `json:"version,omitempty"`
 			CLI     *config.CLIConfig `json:"cli,omitempty"`
@@ -86,7 +86,11 @@ func (s *Info) Run(cmd *cobra.Command, _ []string) error {
 			CLI:     cfg.Sanitize(),
 		},
 		Projects: projectInfo,
-	})
+	}, nil)
+	// This is somewhat of a hack that forces this single item to print
+	if err := out.Flush(); err != nil {
+		return err
+	}
 	return out.Err()
 }
 

--- a/pkg/cli/project.go
+++ b/pkg/cli/project.go
@@ -106,11 +106,11 @@ func (a *Project) Run(cmd *cobra.Command, args []string) error {
 					supportedRegions[i] = supportedRegion + "*"
 				}
 			}
-			out.Write(projectEntry{
+			out.WriteFormatted(projectEntry{
 				Name:    projectItem.FullName,
 				Default: defaultProject == projectItem.FullName,
 				Regions: supportedRegions,
-			})
+			}, projectItem.Project)
 		}
 	}
 

--- a/pkg/cli/regions.go
+++ b/pkg/cli/regions.go
@@ -51,7 +51,7 @@ func (a *Regions) Run(cmd *cobra.Command, args []string) error {
 	for _, region := range regions {
 		if len(args) > 0 {
 			if slices.Contains(args, region.Name) {
-				out.Write(region)
+				out.Write(&region)
 			}
 		} else {
 			out.Write(&region)

--- a/pkg/cli/secret.go
+++ b/pkg/cli/secret.go
@@ -44,7 +44,7 @@ func (a *Secret) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		out.Write(*secret)
+		out.Write(secret)
 		return out.Err()
 	}
 
@@ -56,10 +56,10 @@ func (a *Secret) Run(cmd *cobra.Command, args []string) error {
 	for _, secret := range secrets {
 		if len(args) > 0 {
 			if slices.Contains(args, secret.Name) {
-				out.Write(secret)
+				out.Write(&secret)
 			}
 		} else {
-			out.Write(secret)
+			out.Write(&secret)
 		}
 	}
 

--- a/pkg/cli/secret_encrypt.go
+++ b/pkg/cli/secret_encrypt.go
@@ -101,7 +101,7 @@ func (e *Encrypt) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	out.Write(output)
+	out.WriteFormatted(output, nil)
 
 	return out.Err()
 }

--- a/pkg/cli/secret_expose.go
+++ b/pkg/cli/secret_expose.go
@@ -60,12 +60,12 @@ func (a *Reveal) Run(cmd *cobra.Command, args []string) error {
 
 	for _, secret := range matchedSecrets {
 		for _, entry := range typed.Sorted(secret.Data) {
-			out.Write(&revealEntry{
+			out.WriteFormatted(&revealEntry{
 				Name:  secret.Name,
 				Type:  secret.Type,
 				Key:   entry.Key,
 				Value: string(entry.Value),
-			})
+			}, &secret)
 		}
 	}
 

--- a/pkg/cli/secret_test.go
+++ b/pkg/cli/secret_test.go
@@ -67,7 +67,7 @@ func TestSecret(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "{\n    \"metadata\": {\n        \"name\": \"found.secret\",\n        \"creationTimestamp\": null\n    }\n}\n\n",
+			wantOut: "{\n    \"items\": [\n        {\n            \"metadata\": {\n                \"name\": \"found.secret\",\n                \"creationTimestamp\": null\n            }\n        }\n    ]\n}\n\n",
 		},
 		{
 			name: "acorn secret -o yaml", fields: fields{
@@ -86,7 +86,7 @@ func TestSecret(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "---\nmetadata:\n  creationTimestamp: null\n  name: found.secret\n\n",
+			wantOut: "---\nitems:\n- metadata:\n    creationTimestamp: null\n    name: found.secret\n\n",
 		},
 		{
 			name: "acorn secret found.secret", fields: fields{

--- a/pkg/cli/testdata/all/all_test_json.txt
+++ b/pkg/cli/testdata/all/all_test_json.txt
@@ -1,74 +1,94 @@
 
 APPS:
 {
-    "metadata": {
-        "name": "found",
-        "creationTimestamp": null
-    },
-    "spec": {
-        "secrets": [
-            {
-                "secret": "found.secret",
-                "target": "found"
+    "items": [
+        {
+            "metadata": {
+                "name": "found",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "secrets": [
+                    {
+                        "secret": "found.secret",
+                        "target": "found"
+                    }
+                ]
+            },
+            "status": {
+                "columns": {},
+                "appImage": {
+                    "imageData": {},
+                    "vcs": {}
+                },
+                "appSpec": {},
+                "appStatus": {},
+                "defaults": {}
             }
-        ]
-    },
-    "status": {
-        "columns": {},
-        "appImage": {
-            "imageData": {},
-            "vcs": {}
-        },
-        "appSpec": {},
-        "appStatus": {},
-        "defaults": {}
-    }
+        }
+    ]
 }
 
 
 CONTAINERS:
 {
-    "metadata": {
-        "name": "found.container",
-        "creationTimestamp": null
-    },
-    "spec": {
-        "probes": null,
-        "appName": "found"
-    },
-    "status": {
-        "columns": {},
-        "state": {},
-        "lastState": {},
-        "ready": false,
-        "restartCount": 0,
-        "image": "",
-        "imageID": ""
-    }
+    "items": [
+        {
+            "metadata": {
+                "name": "found.container",
+                "creationTimestamp": null
+            },
+            "spec": {
+                "probes": null,
+                "appName": "found"
+            },
+            "status": {
+                "columns": {},
+                "state": {},
+                "lastState": {},
+                "ready": false,
+                "restartCount": 0,
+                "image": "",
+                "imageID": ""
+            }
+        }
+    ]
 }
 
 
 VOLUMES:
 {
-    "metadata": {
-        "name": "found.vol",
-        "creationTimestamp": null
-    },
-    "spec": {},
-    "status": {
-        "appName": "found",
-        "appPublicName": "found",
-        "volumeName": "vol",
-        "columns": {}
-    }
+    "items": [
+        {
+            "metadata": {
+                "name": "found.vol",
+                "creationTimestamp": null,
+                "labels": {
+                    "acorn.io/app-name": "found",
+                    "acorn.io/volume-name": "vol"
+                }
+            },
+            "spec": {},
+            "status": {
+                "appName": "found",
+                "appPublicName": "found",
+                "volumeName": "vol",
+                "columns": {}
+            }
+        }
+    ]
 }
 
 
 SECRETS:
 {
-    "metadata": {
-        "name": "found.secret",
-        "creationTimestamp": null
-    }
+    "items": [
+        {
+            "metadata": {
+                "name": "found.secret",
+                "creationTimestamp": null
+            }
+        }
+    ]
 }
 

--- a/pkg/cli/testdata/all/all_test_yaml.txt
+++ b/pkg/cli/testdata/all/all_test_yaml.txt
@@ -1,57 +1,64 @@
 
 APPS:
 ---
-metadata:
-  creationTimestamp: null
-  name: found
-spec:
-  secrets:
-  - secret: found.secret
-    target: found
-status:
-  appImage:
-    imageData: {}
-    vcs: {}
-  appSpec: {}
-  appStatus: {}
-  columns: {}
-  defaults: {}
+items:
+- metadata:
+    creationTimestamp: null
+    name: found
+  spec:
+    secrets:
+    - secret: found.secret
+      target: found
+  status:
+    appImage:
+      imageData: {}
+      vcs: {}
+    appSpec: {}
+    appStatus: {}
+    columns: {}
+    defaults: {}
 
 
 CONTAINERS:
 ---
-metadata:
-  creationTimestamp: null
-  name: found.container
-spec:
-  appName: found
-  probes: null
-status:
-  columns: {}
-  image: ""
-  imageID: ""
-  lastState: {}
-  ready: false
-  restartCount: 0
-  state: {}
+items:
+- metadata:
+    creationTimestamp: null
+    name: found.container
+  spec:
+    appName: found
+    probes: null
+  status:
+    columns: {}
+    image: ""
+    imageID: ""
+    lastState: {}
+    ready: false
+    restartCount: 0
+    state: {}
 
 
 VOLUMES:
 ---
-metadata:
-  creationTimestamp: null
-  name: found.vol
-spec: {}
-status:
-  appName: found
-  appPublicName: found
-  columns: {}
-  volumeName: vol
+items:
+- metadata:
+    creationTimestamp: null
+    labels:
+      acorn.io/app-name: found
+      acorn.io/volume-name: vol
+    name: found.vol
+  spec: {}
+  status:
+    appName: found
+    appPublicName: found
+    columns: {}
+    volumeName: vol
 
 
 SECRETS:
 ---
-metadata:
-  creationTimestamp: null
-  name: found.secret
+items:
+- metadata:
+    creationTimestamp: null
+    name: found.secret
 

--- a/pkg/cli/volume_classes.go
+++ b/pkg/cli/volume_classes.go
@@ -52,10 +52,10 @@ func (a *Storage) Run(cmd *cobra.Command, args []string) error {
 	for _, storage := range storages {
 		if len(args) > 0 {
 			if slices.Contains(args, storage.Name) {
-				out.Write(storage)
+				out.Write(&storage)
 			}
 		} else {
-			out.Write(storage)
+			out.Write(&storage)
 		}
 	}
 

--- a/pkg/cli/volumes.go
+++ b/pkg/cli/volumes.go
@@ -53,10 +53,10 @@ func (a *Volume) Run(cmd *cobra.Command, args []string) error {
 	for _, volume := range volumes {
 		if len(args) > 0 {
 			if slices.Contains(args, volume.Name) {
-				out.Write(volume)
+				out.Write(&volume)
 			}
 		} else {
-			out.Write(volume)
+			out.Write(&volume)
 		}
 	}
 

--- a/pkg/cli/volumes_test.go
+++ b/pkg/cli/volumes_test.go
@@ -113,7 +113,7 @@ func TestVolume(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "{\n    \"metadata\": {\n        \"name\": \"found.vol\",\n        \"creationTimestamp\": null\n    },\n    \"spec\": {},\n    \"status\": {\n        \"appName\": \"found\",\n        \"appPublicName\": \"found\",\n        \"volumeName\": \"vol\",\n        \"columns\": {}\n    }\n}\n\n",
+			wantOut: "{\n    \"items\": [\n        {\n            \"metadata\": {\n                \"name\": \"found.vol\",\n                \"creationTimestamp\": null,\n                \"labels\": {\n                    \"acorn.io/app-name\": \"found\",\n                    \"acorn.io/volume-name\": \"vol\"\n                }\n            },\n            \"spec\": {},\n            \"status\": {\n                \"appName\": \"found\",\n                \"appPublicName\": \"found\",\n                \"volumeName\": \"vol\",\n                \"columns\": {}\n            }\n        }\n    ]\n}\n\n",
 		},
 		{
 			name: "acorn volume -o yaml", fields: fields{
@@ -126,7 +126,7 @@ func TestVolume(t *testing.T) {
 				client: &testdata.MockClient{},
 			},
 			wantErr: false,
-			wantOut: "---\nmetadata:\n  creationTimestamp: null\n  name: found.vol\nspec: {}\nstatus:\n  appName: found\n  appPublicName: found\n  columns: {}\n  volumeName: vol\n\n",
+			wantOut: "---\nitems:\n- metadata:\n    creationTimestamp: null\n    labels:\n      acorn.io/app-name: found\n      acorn.io/volume-name: vol\n    name: found.vol\n  spec: {}\n  status:\n    appName: found\n    appPublicName: found\n    columns: {}\n    volumeName: vol\n\n",
 		},
 		{
 			name: "acorn volume found.vol", fields: fields{

--- a/pkg/openapi/generated/openapi_generated.go
+++ b/pkg/openapi/generated/openapi_generated.go
@@ -2599,6 +2599,12 @@ func schema_pkg_apis_apiacornio_v1_Credential(ref common.ReferenceCallback) comm
 							Format: "",
 						},
 					},
+					"localStorage": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/rulerequest/handle.go
+++ b/pkg/rulerequest/handle.go
@@ -97,7 +97,7 @@ application. If you are unsure say no.`)
 
 	writer := table.NewWriter(tables.RuleRequests, false, "")
 	for _, request := range requests {
-		writer.Write(request)
+		writer.WriteFormatted(request, nil)
 	}
 
 	if err := writer.Close(); err != nil {


### PR DESCRIPTION
All resource output should support json/jsoncompact/yaml/aml. If the
output format is one of the data formats then the source API resources
will be printed, not the intermediate struct used for formatting the
disable data.

Signed-off-by: Darren Shepherd <darren@acorn.io>
