### PR TITLE
Add CPU/Memory request/limits and PriorityClasses for system components

### DIFF
--- a/pkg/imagesystem/buildertemplate.go
+++ b/pkg/imagesystem/buildertemplate.go
@@ -42,6 +42,7 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 					Labels: labels.ManagedByApp(namespace, name, "app", name),
 				},
 				Spec: corev1.PodSpec{
+					PriorityClassName:  system.AcornPriorityClass,
 					ServiceAccountName: "acorn-builder",
 					EnableServiceLinks: new(bool),
 					Containers: []corev1.Container{
@@ -54,6 +55,7 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 								"--addr",
 								"unix:///run/buildkit/buildkitd.sock",
 							},
+							Resources: system.BuildkitdResources(),
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
@@ -138,6 +140,7 @@ func BuilderObjects(name, namespace, forNamespace, buildKitImage, pub, privKey, 
 							Args: []string{
 								"build-server",
 							},
+							Resources: system.BuildkitdServiceResources(),
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/imagesystem/registrytemplate.go
+++ b/pkg/imagesystem/registrytemplate.go
@@ -58,6 +58,7 @@ func registryDeployment(namespace, registryImage string) []client.Object {
 					},
 				},
 				Spec: corev1.PodSpec{
+					PriorityClassName:  system.AcornPriorityClass,
 					EnableServiceLinks: new(bool),
 					Containers: []corev1.Container{
 						{
@@ -68,8 +69,9 @@ func registryDeployment(namespace, registryImage string) []client.Object {
 									Value: "true",
 								},
 							},
-							Image:   registryImage,
-							Command: []string{"/usr/local/bin/registry", "serve", "/etc/docker/registry/config.yml"},
+							Resources: system.RegistryResources(),
+							Image:     registryImage,
+							Command:   []string{"/usr/local/bin/registry", "serve", "/etc/docker/registry/config.yml"},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									TCPSocket: &corev1.TCPSocketAction{

--- a/pkg/install/apiserver.yaml
+++ b/pkg/install/apiserver.yaml
@@ -66,6 +66,11 @@ spec:
             - containerPort: 7443
           securityContext:
             runAsUser: 1000
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+      priorityClassName: system-cluster-critical
       serviceAccountName: acorn-system
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/pkg/install/controller.yaml
+++ b/pkg/install/controller.yaml
@@ -31,6 +31,11 @@ spec:
             httpGet:
               path: /healthz
               port: 8888
+          resources:
+            requests:
+              cpu: 150m
+              memory: 200Mi
+      priorityClassName: system-cluster-critical
       serviceAccountName: acorn-system
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/pkg/system/constants.go
+++ b/pkg/system/constants.go
@@ -13,6 +13,8 @@ const (
 	CustomCABundleSecretVolumeName
 	CustomCABundleDir      = "/etc/ssl/certs"
 	CustomCABundleCertName = "ca-certificates.crt"
+
+	AcornPriorityClass = "system-cluster-critical"
 )
 
 var (

--- a/pkg/system/resources.go
+++ b/pkg/system/resources.go
@@ -1,0 +1,75 @@
+package system
+
+import (
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Values will likely need to be tweaked as we get more usage data. They are currently based
+// on metrics we have collected from internal use. You can override these values by setting
+// the corresponding environment variable.
+var (
+	mi = int64(1_048_576) // 1 MiB in bytes
+
+	registryMemoryRequest = *resource.NewQuantity(40*mi, resource.BinarySI)    // REGISTRY_MEMORY_REQUEST
+	registryMemoryLimit   = *resource.NewQuantity(80*mi, resource.BinarySI)    // REGISTRY_MEMORY_LIMIT
+	registryCPURequest    = *resource.NewMilliQuantity(50, resource.DecimalSI) // REGISTRY_CPU_REQUEST
+
+	buildkitdMemoryRequest = *resource.NewQuantity(100*mi, resource.BinarySI)   // BUILDKITD_MEMORY_REQUEST
+	buildkitdMemoryLimit   = *resource.NewQuantity(200*mi, resource.BinarySI)   // BUILDKITD_MEMORY_LIMIT
+	buildkitdCPURequest    = *resource.NewMilliQuantity(50, resource.DecimalSI) // BUILDKITD_CPU_REQUEST
+
+	buildkitdServiceMemoryRequest = *resource.NewQuantity(70*mi, resource.BinarySI)    // BUILDKITD_SERVICE_MEMORY_REQUEST
+	buildkitdServiceMemoryLimit   = *resource.NewQuantity(140*mi, resource.BinarySI)   // BUILDKITD_SERVICE_MEMORY_LIMIT
+	buildkitdServiceCPURequest    = *resource.NewMilliQuantity(50, resource.DecimalSI) // BUILDKITD_SERVICE_CPU_REQUEST
+)
+
+func RegistryResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: envOrDefault("REGISTRY_MEMORY_REQUEST", registryMemoryRequest),
+			corev1.ResourceCPU:    envOrDefault("REGISTRY_CPU_REQUEST", registryCPURequest),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: envOrDefault("REGISTRY_MEMORY_LIMIT", registryMemoryLimit),
+		},
+	}
+}
+
+func BuildkitdResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: envOrDefault("BUILDKITD_MEMORY_REQUEST", buildkitdMemoryRequest),
+			corev1.ResourceCPU:    envOrDefault("BUILDKITD_CPU_REQUEST", buildkitdCPURequest),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: envOrDefault("BUILDKITD_MEMORY_LIMIT", buildkitdMemoryLimit),
+		},
+	}
+}
+
+func BuildkitdServiceResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: envOrDefault("BUILDKITD_SERVICE_MEMORY_REQUEST", buildkitdServiceMemoryRequest),
+			corev1.ResourceCPU:    envOrDefault("BUILDKITD_SERVICE_CPU_REQUEST", buildkitdServiceCPURequest),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: envOrDefault("BUILDKITD_SERVICE_MEMORY_LIMIT", buildkitdServiceMemoryLimit),
+		},
+	}
+}
+
+func envOrDefault(env string, def resource.Quantity) resource.Quantity {
+	if env = os.Getenv(env); env == "" {
+		return def
+	}
+
+	quantity, err := resource.ParseQuantity(env)
+	if err == nil {
+		return quantity
+	}
+	return def
+}


### PR DESCRIPTION
This PR ensures that the critical Acorn workloads have the same priority class as critical Kubernetes workloads. In addition, it uses internal usage metrics to determine logical values for their request/limit of memory and CPU. 

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

