### PR TITLE
Don't renew certs if no domain is set

### DIFF
--- a/pkg/controller/tls/certs.go
+++ b/pkg/controller/tls/certs.go
@@ -68,6 +68,10 @@ func RenewCert(req router.Request, resp router.Response) error {
 
 	domain := sec.Annotations[labels.AcornDomain]
 
+	if domain == "" {
+		return nil
+	}
+
 	go func() {
 		// Do not start a new challenge if we already have one in progress
 		if !lockDomain(domain) {


### PR DESCRIPTION
When no acorn domain is set, we shouldn't renew the certs. This means that the certificate is managed from outside, not the one managed by acorn LE integration.

fixing https://acorn-io.slack.com/archives/C03FU91U4SX/p1687221325484799

### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

