### PR TITLE
Fix image interpolation for IDs that already contain the digest

### DIFF
--- a/pkg/secrets/interpolation.go
+++ b/pkg/secrets/interpolation.go
@@ -194,7 +194,7 @@ func (i *Interpolator) resolveApp(keyName string) (string, bool, error) {
 	case "namespace":
 		return i.app.Status.Namespace, true, nil
 	case "image":
-		if tags.IsLocalReference(i.app.Status.AppImage.ID) {
+		if tags.IsLocalReference(i.app.Status.AppImage.ID) || strings.Contains(i.app.Status.AppImage.ID, "sha256:") {
 			return i.app.Status.AppImage.ID, true, nil
 		} else if i.app.Status.AppImage.ID != "" && i.app.Status.AppImage.Digest != "" {
 			tag, err := name.NewTag(i.app.Status.AppImage.ID)


### PR DESCRIPTION
The image interpolation logic here was assuming that, if the AppImage ID is not a local reference, then it is a tag that needs to have its digest resolved. However, it is possible for the AppImage ID field to already have the full digest in it, in which case we do not need to resolve it. When this was the case, the call to `name.NewTag` would result in an error, and the app would not be able to run at all.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

