### PR TITLE
Draft: Allow the implicit use of Docker Hub for auto-upgrade image references

### DIFF
--- a/pkg/autoupgrade/daemon.go
+++ b/pkg/autoupgrade/daemon.go
@@ -178,7 +178,7 @@ func (d *daemon) determineAppsToRefresh(apps map[kclient.ObjectKey]v1.AppInstanc
 // which will trigger the appInstance handlers to pick up the change and deploy the new version of the app
 func (d *daemon) refreshImages(ctx context.Context, apps map[kclient.ObjectKey]v1.AppInstance, imagesToRefresh map[imageAndNamespaceKey][]kclient.ObjectKey, updateTime time.Time) {
 	for imageKey, appsForImage := range imagesToRefresh {
-		current, err := imagename.ParseReference(imageKey.image, imagename.WithDefaultRegistry(defaultNoReg), imagename.WithDefaultTag(""))
+		current, err := imagename.ParseReference(imageKey.image, imagename.WithDefaultTag(""))
 		if err != nil {
 			logrus.Errorf("Problem parsing image referece %v: %v", imageKey.image, err)
 			continue


### PR DESCRIPTION
### Checklist
- [ ] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [ ] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [ ] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [ ] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [ ] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [ ] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

