### PR TITLE
Fix issue with TestJobDelete

### DIFF
--- a/integration/run/testdata/jobfinalize/scripts/run.sh
+++ b/integration/run/testdata/jobfinalize/scripts/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -x -e
-[ "$ACORN_EVENT" = "onDelete" ]
+[ "$ACORN_EVENT" = "delete" ]


### PR DESCRIPTION
The TestJobDelete test was running for around 250 seconds where other tests took about 10 seconds. This was because the Job was continually failing delete due to `onDelete` notation still being used.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

