### PR TITLE
Use AppInstance instead of App for app subresouces that update (#1753)

### DIFF
--- a/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
+++ b/pkg/server/registry/apigroups/acorn/apps/confirmupgrade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	"github.com/acorn-io/mink/pkg/stores"
 	"github.com/acorn-io/mink/pkg/types"
@@ -30,7 +31,9 @@ func (s *ConfirmUpgradeStrategy) Create(ctx context.Context, obj types.Object) (
 		return obj, nil
 	}
 
-	app := &apiv1.App{}
+	// Use app instance here because in Hub this request is forwarded to the workload cluster.
+	// The app validation logic should not run there.
+	app := &v1.AppInstance{}
 	err := s.client.Get(ctx, kclient.ObjectKey{Namespace: ri.Namespace, Name: ri.Name}, app)
 	if err != nil {
 		return nil, err

--- a/pkg/server/registry/apigroups/acorn/apps/ignorecleanup.go
+++ b/pkg/server/registry/apigroups/acorn/apps/ignorecleanup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	apiv1 "github.com/acorn-io/acorn/pkg/apis/api.acorn.io/v1"
+	v1 "github.com/acorn-io/acorn/pkg/apis/internal.acorn.io/v1"
 	"github.com/acorn-io/acorn/pkg/controller/jobs"
 	kclient "github.com/acorn-io/acorn/pkg/k8sclient"
 	"github.com/acorn-io/mink/pkg/stores"
@@ -33,7 +34,9 @@ func (s *ignoreCleanupStrategy) Create(ctx context.Context, obj types.Object) (t
 		return obj, nil
 	}
 
-	app := &apiv1.App{}
+	// Use app instance here because in Hub this request is forwarded to the workload cluster.
+	// The app validation logic should not run there.
+	app := &v1.AppInstance{}
 	err := s.client.Get(ctx, kclient.ObjectKey{Namespace: ri.Namespace, Name: ri.Name}, app)
 	if err != nil {
 		return nil, err

--- a/pkg/server/registry/apigroups/acorn/apps/pull.go
+++ b/pkg/server/registry/apigroups/acorn/apps/pull.go
@@ -36,6 +36,8 @@ func (s *PullAppImageStrategy) Create(ctx context.Context, obj types.Object) (ty
 	p := obj.(*apiv1.AppPullImage)
 	ri, _ := request.RequestInfoFrom(ctx)
 
+	// Use app instance here because in Hub this request is forwarded to the workload cluster.
+	// The app validation logic should not run there.
 	app := &v1.AppInstance{}
 	err := s.client.Get(ctx, kclient.ObjectKey{Namespace: ri.Namespace, Name: ri.Name}, app)
 	if err != nil {


### PR DESCRIPTION
The subresource calls for Apps in Hub get forwarded to the workload cluster. Updating the App (instead of the AppInstance) in the workload cluster will cause the App to go through validation. We don't want this to happen in the workload cluster because some objects, like compute classes, are slightly modified when they are synced up. Validating at the account-api-server level works, but not in the workload cluster.

This change will use the AppInstance for these subresources to avoid this error.

### Checklist
- [x] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [x] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [x] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [x] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [x] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [x] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

Related issue: https://github.com/acorn-io/acorn/issues/1753