### PR TITLE
Fix EKS test to actually run tests

### DIFF
--- a/.github/workflows/aws-eks-test.yml
+++ b/.github/workflows/aws-eks-test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: run acorn integration tests
         run: |
-          TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile test-summary.xml -- -timeout=7m" make test
+          TEST_ACORN_CONTROLLER=external TEST_FLAGS="--junitfile test-summary.xml" GO_TEST_FLAGS="-timeout=7m" make integration
         env:
           KUBECONFIG: "/home/runner/.kube/config"
 


### PR DESCRIPTION
For the last few days the nightly EKS test run has not been running any tests. After doing some testing locally, I believe this should fix the problem.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

