### PR TITLE
Raise builder limit even further

### DIFF
--- a/pkg/system/resources.go
+++ b/pkg/system/resources.go
@@ -19,7 +19,7 @@ var (
 	registryCPURequest    = *resource.NewMilliQuantity(200, resource.DecimalSI) // REGISTRY_CPU_REQUEST
 
 	buildkitdMemoryRequest = *resource.NewQuantity(256*mi, resource.BinarySI)    // BUILDKITD_MEMORY_REQUEST
-	buildkitdMemoryLimit   = *resource.NewQuantity(1*gi, resource.BinarySI)      // BUILDKITD_MEMORY_LIMIT
+	buildkitdMemoryLimit   = *resource.NewQuantity(10*gi, resource.BinarySI)     // BUILDKITD_MEMORY_LIMIT
 	buildkitdCPURequest    = *resource.NewMilliQuantity(800, resource.DecimalSI) // BUILDKITD_CPU_REQUEST
 
 	buildkitdServiceMemoryRequest = *resource.NewQuantity(128*mi, resource.BinarySI)    // BUILDKITD_SERVICE_MEMORY_REQUEST


### PR DESCRIPTION
Upping the limit even further as we were seeing some OOM's when the builder was under heavy load.

### Checklist
- [X] The title of this PR would make a good line in Acorn's Release Note's Changelog
- [X] The title of this PR ends with a link to the main issue being address in parentheses, like: `This is a title (#1216)`. [Here's an example](https://github.com/acorn-io/acorn/pull/1199)
- [X] All relevant issues are referenced in the PR description. *NOTE: don't use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) that auto-close issues*
- [X] Commits follow [contributing guidance](https://github.com/acorn-io/acorn/blob/main/CONTRIBUTING.md#commits)
- [X] Automated tests added to cover the changes. If tests couldn't be added, an explanation is provided in the Verification and Testing section
- [X] Changes to user-facing functionality, API, CLI, and upgrade impacts are clearly called out in PR description
- [ ] PR has at least two approvals before merging (or a reasonable exception, like it's just a docs change)

